### PR TITLE
Update bugs url in package.json files to point to correct repository

### DIFF
--- a/packages/permissions-kernel-snap/package.json
+++ b/packages/permissions-kernel-snap/package.json
@@ -4,7 +4,7 @@
   "description": "Manage onchain 7715 permissions",
   "homepage": "https://github.com/MetaMask/snap-7715-permissions/tree/main/packages/permissions-kernel-snap#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/core/issues"
+    "url": "https://github.com/MetaMask/snap-7715-permissions/issues"
   },
   "repository": {
     "type": "git",

--- a/packages/permissions-provider-snap/package.json
+++ b/packages/permissions-provider-snap/package.json
@@ -4,7 +4,7 @@
   "description": "Grants 7715 permissions from a DeleGator smart account",
   "homepage": "https://github.com/MetaMask/snap-7715-permissions/tree/main/packages/permissions-kernel-snap#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/core/issues"
+    "url": "https://github.com/MetaMask/snap-7715-permissions/issues"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Copy+pasted package.json snippet contains "bugs" pointing to metamask/core repo, for both snaps.

This PR updates the bugs url in package.json for both snaps to point to this repo.