### PR TITLE
Fix number formatting for rules to not truncate decimal places

### DIFF
--- a/packages/permissions-provider-snap/snap.manifest.json
+++ b/packages/permissions-provider-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "9hNOAzC2gi8ja71RDj3Fn31HLVEZAVS7fSgWF3J1e5w=",
+    "shasum": "LKB2WdGsesRmG2YEnsDtsZCmIouHbpmEcUzD7DVkGvw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/permissions-provider-snap/src/utils/balance.ts
+++ b/packages/permissions-provider-snap/src/utils/balance.ts
@@ -4,18 +4,15 @@ import { formatUnits, maxUint256, parseUnits, toHex } from 'viem';
 /**
  * Formats a token balance to a human-readable string.
  * @param wei - The token balance in wei as a string, number, or Hex.
- * @param decimalPlaces - The number of decimal places to display in the formatted balance.
  * @param tokenDecimal - The number of decimal places the token uses.
  * @returns The formatted human-readable token balance.
  */
 export const formatTokenBalance = (
   wei: string | number | Hex,
-  decimalPlaces = 2,
   tokenDecimal = 18,
 ): string => {
-  const ethBalance = formatUnits(BigInt(wei), tokenDecimal);
-  const ethBalanceNum = parseFloat(ethBalance);
-  return ethBalanceNum.toFixed(decimalPlaces);
+  const formattedBalance = formatUnits(BigInt(wei), tokenDecimal);
+  return formattedBalance;
 };
 
 /**


### PR DESCRIPTION
When formatting a token amount to add to a rule, we were truncating at 2 dp. This caused values less than 0.005 eth to be lost in the UI, coalescing to zero. This was not problematic for values in whole ether, but more realistic numbers will be significantly less.

With this PR we no longer truncate the formatted value, and simply return the output from `formatUnits`. Arguable the helper function isn't overly necessary, but I've left it in for now.