### PR TITLE
[DRAFT] feat: Add MetaMask Promised Outcomes

### DIFF
--- a/packages/gator-permissions-snap/docs/promisedOutcomes.md
+++ b/packages/gator-permissions-snap/docs/promisedOutcomes.md
@@ -1,0 +1,25 @@
+# Promised Outcomes
+
+## Overview
+
+This document will provide an overview of the `MetaMask Promised Outcomes` feature. We can extend an ERC-7715 permission response to enforce promises made by the dapp regarding the outcomes of the granted permissions without relying solely on the dapp's honesty.
+
+## Providing Promised outcomes
+
+When constructing a permission request for the wallet, the dApp can attach `promisedOutcomes`. The `promisedOutcomes` field is an array of objects, each representing a promised outcome. The type field specifies the kind of outcome being promised, and the data field contains type-specific details.
+
+Some potential types of promised outcomes:
+
+- `exact-transfer`: Promises an exact transfer of a specific asset amount to a recipient.
+- `event-emission`: Promises that a specific event will be emitted with certain parameters.
+- `custom`: Allows for open-ended custom promises with wallet-interpreted logic.
+
+## Wallet Responsibilities
+
+Upon receiving a `PermissionsRequest` with `promisedOutcomes`, the wallet should:
+
+1. Interpret the `promisedOutcomes` and generate corresponding enforcement caveats.
+2. Present the assured outcomes to the user for approval and the requested permissions.
+3. If approved, include the enforcement caveats in the `PermissionsContext` returned to the dapp.
+
+The wallet should strive to enforce the promised outcomes as closely as possible, with a caveat enforcer with an `afterHook`. Additionally, that wallet may run a runtime simulation to guarantee the promised outcomes further.

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "Hk/x+7Ye+UtnhlThDWmoaxIeVMj56IpIRGDOK/XGi60=",
+    "shasum": "UHHW6qivFzaHx3NwDrWc9uU/HuiSD1w9TaL+nLSiijc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
@@ -11,19 +11,22 @@ import {
   Form,
   Field,
 } from '@metamask/snaps-sdk/jsx';
-import { AccountDetails } from '../../ui/components/AccountDetails';
-import { RequestHeader } from '../../ui/components/RequestHeader';
-import { NativeTokenStreamContext, NativeTokenStreamMetadata } from './types';
-import { InputField } from '../../ui/components/InputField';
-import { DropdownField } from '../../ui/components/DropdownField';
-import { TimePeriod } from '../../core/types';
-import { IconUrls } from '../../ui/iconConstant';
-import {
-  ItemDetails,
-  RequestDetails,
-} from '../../ui/components/RequestDetails';
+
 import { getChainName } from '../../../../shared/src/utils/common';
+import { TimePeriod } from '../../core/types';
+import { AccountDetails } from '../../ui/components/AccountDetails';
+import { DropdownField } from '../../ui/components/DropdownField';
+import { InputField } from '../../ui/components/InputField';
+import { PromisedOutcomes } from '../../ui/components/PromisedOutcomes';
+import type { ItemDetails } from '../../ui/components/RequestDetails';
+import { RequestDetails } from '../../ui/components/RequestDetails';
+import { RequestHeader } from '../../ui/components/RequestHeader';
 import { TooltipIcon } from '../../ui/components/TooltipIcon';
+import { IconUrls } from '../../ui/iconConstant';
+import type {
+  NativeTokenStreamContext,
+  NativeTokenStreamMetadata,
+} from './types';
 
 export const INITIAL_AMOUNT_ELEMENT = 'initial-amount';
 export const REMOVE_INITIAL_AMOUNT_BUTTON = 'remove-initial-amount';
@@ -216,6 +219,13 @@ export const createConfirmationContent = ({
             errorMessage={validationErrors.expiryError}
           />
         </Section>
+
+        <PromisedOutcomes
+          origin={origin}
+          tokenSymbol="GATOR"
+          value={'10.00'}
+          allowance={`${amountPerSecond} ETH/sec`}
+        />
         {rulesToAddButton}
       </Box>
     </Box>

--- a/packages/gator-permissions-snap/src/ui/components/PromisedOutcomes.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/PromisedOutcomes.tsx
@@ -1,0 +1,60 @@
+import type { SnapComponent } from '@metamask/snaps-sdk/jsx';
+import {
+  Box,
+  Section,
+  Input,
+  Text,
+  Field,
+  Form,
+  Radio,
+  RadioGroup,
+} from '@metamask/snaps-sdk/jsx';
+
+export type PromisedOutcomesProps = {
+  value: string;
+  origin: string;
+  tokenSymbol: string;
+  allowance: string;
+};
+
+const extractDomainFromOrigin = (origin: string) => {
+  const url = new URL(origin);
+  return url.hostname;
+};
+
+export const PromisedOutcomes: SnapComponent<PromisedOutcomesProps> = ({
+  value,
+  origin,
+  allowance,
+  tokenSymbol,
+}) => {
+  return (
+    <Section>
+      <Box>
+        <Box direction="horizontal" alignment="space-between">
+          <Text>Add guarantee</Text>
+          <Form name="add-guarantee-form">
+            <Field>
+              <RadioGroup name="add-guarantee-radio-group" disabled={true}>
+                <Radio value="option-1" children={''}></Radio>
+              </RadioGroup>
+            </Field>
+          </Form>
+        </Box>
+
+        <Text>
+          This ensures that {extractDomainFromOrigin(origin)} will withdraw{' '}
+          {allowance} from your account only if you receive their {tokenSymbol}{' '}
+          token in return.
+        </Text>
+
+        <Input
+          name="PromisedOutcomes"
+          type="text"
+          value={value}
+          disabled={true}
+        />
+      </Box>
+    </Section>
+  );
+};

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "Dfoudp3CqlmRrbTu8sKW/Iq2n5W/oIaH4n14oyqnGF0=",
+    "shasum": "Nkqv8KoPYMTGplSE/MXIjYsDpirNYrVLMl928apKdGk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/shared/src/types/7715-permissions-types.ts
+++ b/packages/shared/src/types/7715-permissions-types.ts
@@ -1,5 +1,6 @@
 import { any, z } from 'zod';
 
+import { zPromisedOutcomes } from './7715-promised-outcomes';
 import { zAddress, zHexStr } from './common';
 
 // Rather than only define permissions by name,
@@ -22,6 +23,11 @@ export const zPermission = z.object({
   data: z.record(any()),
 
   rules: z.record(any()).optional(),
+
+  /**
+   * The promised outcomes of the permission made by the dApp.
+   */
+  promisedOutcomes: z.array(zPromisedOutcomes).optional(),
 });
 
 export const zMetaMaskPermissionData = z.object({

--- a/packages/shared/src/types/7715-promised-outcomes.ts
+++ b/packages/shared/src/types/7715-promised-outcomes.ts
@@ -1,0 +1,42 @@
+import { any, z } from 'zod';
+
+import { zAddress, zHexStr } from './common';
+
+export const zPromisedOutcomesTypeDescriptor = z.union([
+  z.literal('exact-transfer'),
+  z.literal('event-emission'),
+  z.literal('custom'),
+]);
+
+export type PromisedOutcomesTypeDescriptor = z.infer<
+  typeof zPromisedOutcomesTypeDescriptor
+>;
+
+export const zPromisedOutcomes = z.object({
+  type: zPromisedOutcomesTypeDescriptor,
+
+  /**
+   * Data structure varies by promised outcome type.
+   */
+  data: z.record(any()),
+});
+
+export const zExactTransferOutcome = zPromisedOutcomes.extend({
+  type: z.literal('exact-transfer'),
+  data: z.object({
+    address: zAddress,
+    amount: zHexStr,
+    recipient: zAddress,
+    tokenSymbol: z.string(),
+  }),
+});
+
+export type ExactTransferOutcome = z.infer<typeof zExactTransferOutcome>;
+
+export const zEventEmissionOutcome = zPromisedOutcomes.extend({
+  type: z.literal('event-emission'),
+  data: z.object({
+    eventName: z.string(),
+    eventArgs: z.record(any()),
+  }),
+});


### PR DESCRIPTION
# Promised Outcomes

## Overview

This document will provide an overview of the `MetaMask Promised Outcomes` feature. We can extend an ERC-7715 permission response to enforce promises made by the dapp regarding the outcomes of the granted permissions without relying solely on the dapp's honesty.

## Providing Promised outcomes

When constructing a permission request for the wallet, the dApp can attach `promisedOutcomes`. The `promisedOutcomes` field is an array of objects, each representing a promised outcome. The type field specifies the kind of outcome being promised, and the data field contains type-specific details.

Some potential types of promised outcomes:

- `exact-transfer`: Promises an exact transfer of a specific asset amount to a recipient.
- `event-emission`: Promises that a specific event will be emitted with certain parameters.
- `custom`: Allows for open-ended custom promises with wallet-interpreted logic.

## Wallet Responsibilities

Upon receiving a `PermissionsRequest` with `promisedOutcomes`, the wallet should:

1. Interpret the `promisedOutcomes` and generate corresponding enforcement caveats.
2. Present the assured outcomes to the user for approval and the requested permissions.
3. If approved, include the enforcement caveats in the `PermissionsContext` returned to the dapp.

The wallet should strive to enforce the promised outcomes as closely as possible, with a caveat enforcer with an `afterHook`. Additionally, that wallet may run a runtime simulation to guarantee the promised outcomes further.

## POC e2e

For POC e2e, we will use the `exact-transfer` type to enforce a promise that the dApp will transfer a specific asset(ie, mock GATOR token) amount to a recipient(ie, the account the user chooses that is granting the permission).

Anytime the dApp redeems the permission, they are required to transfer X amount of GATOR tokens. This keeps the POC simple as we expand on the feature to make it more flexible.

## Changes
- [x] Add docs for `MetaMask Promised Outcomes` feature.
- [x] Render the `PromisedOutcomes` on the permission request confirmation 
- [x] Define the `PromisedOutcomes` type interface exposed to dApps attached to the permission request. This new field is optional. 
- [ ] Parse the `promisedOutcomes[]`  field to the correct promised outcomes types and throw an error if the type is not supported. For the POC, we will only allow the `exact-transfer` type.
- [ ] Build `exact-transfer` caveats and attach them to the delegation that will be signed.
- [ ] Create the mock ERC20 GATOR token and deploy to testnet.
- [ ] Redeem the grant permission and show that the user account has increased by X GATOR tokens.

## UI

![outcomes](https://github.com/user-attachments/assets/49396028-f4b1-437a-8890-bc0028c0048c)

## Mental models

**EVM UserOp State transition(UserOp submitted by dApp on behalf of the user `delegator` account)**

![infra-1](https://github.com/user-attachments/assets/eb9cefbf-6fe4-4b1f-9bab-a140f46307ce)

![infra-2](https://github.com/user-attachments/assets/c3afd851-73c4-4408-a7af-db4cf680068c)


**Native token stream permission with not `PromisedOutcomes`**

![native-token-stream-permission-no-outcomes](https://github.com/user-attachments/assets/876eabab-1a97-4979-8113-c667411d12aa)