### PR TITLE
Add `erc20-token-stream` permission

### DIFF
--- a/docs/addingNewPermissionTypes.md
+++ b/docs/addingNewPermissionTypes.md
@@ -5,6 +5,7 @@ This guide explains how to add a new permission type to the MetaMask Permissions
 ## Overview
 
 A permission type consists of several components:
+
 1. Permission definition and registration
 2. Type definitions
 3. Validation logic
@@ -17,6 +18,7 @@ A permission type consists of several components:
 ### 1. Create Permission Directory
 
 Create a new directory under `packages/gator-permissions-snap/src/permissions/` for your permission type. For example:
+
 ```
 packages/gator-permissions-snap/src/permissions/yourPermissionType/
 ```
@@ -27,7 +29,11 @@ Create a `types.ts` file in your permission directory with the following structu
 
 ```typescript
 import { z } from 'zod';
-import { zHexStr, zPermission, zMetaMaskPermissionData } from '@metamask/7715-permissions-shared/types';
+import {
+  zHexStr,
+  zPermission,
+  zMetaMaskPermissionData,
+} from '@metamask/7715-permissions-shared/types';
 
 // Define your permission metadata type
 // Metadata is anything derived from the context that is not editable, such as validtion errors
@@ -177,6 +183,7 @@ export const yourPermissionDefinition: PermissionDefinition<
 ### 8. Register the Permission
 
 1. Add your permission type to the permission handler factory:
+
 ```typescript
 case 'your-permission-type':
   handler = createPermissionHandler(yourPermissionDefinition);
@@ -184,6 +191,7 @@ case 'your-permission-type':
 ```
 
 2. Add your permission to the default offers in `snap-permission-registry.ts`:
+
 ```typescript
 export const DEFAULT_OFFERS: GatorPermission[] = [
   // ... existing permissions
@@ -258,11 +266,13 @@ export const YourPermissionForm = ({
 Then, add your form to the permission type selector in `packages/site/src/pages/index.tsx`:
 
 1. Import your form component:
+
 ```typescript
 import { YourPermissionForm } from '../components/permissions';
 ```
 
 2. Add your permission type to the select options:
+
 ```typescript
 <select
   id="permissionType"
@@ -276,6 +286,7 @@ import { YourPermissionForm } from '../components/permissions';
 ```
 
 3. Add the form component to the conditional rendering:
+
 ```typescript
 {permissionType === 'your-permission-type' && (
   <YourPermissionForm
@@ -287,6 +298,7 @@ import { YourPermissionForm } from '../components/permissions';
 ```
 
 Key points for implementing permission forms:
+
 1. Use the `StyledForm` component for consistent styling
 2. Implement proper type safety with TypeScript
 3. Use controlled form components with React state

--- a/docs/addingNewPermissionTypes.md
+++ b/docs/addingNewPermissionTypes.md
@@ -1,20 +1,202 @@
-# Adding new permission types
+# Adding New Permission Types
 
-Follow the following steps to add new permission types to the `gator-permissions-snap`:
+This guide explains how to add a new permission type to the MetaMask Permissions system. The process involves several key steps and file additions.
 
-1. Create new permission type definition with `permission.data` to `./packages/shared/src/types/7715-permissions-types.ts` file.
-2. Create a new orchestrator file in `./packages/gator-permissions-snap/src/orchestrators/orchestrator/<NewPermissionTypeOrchestrator.tsx>` directory.
-3. Create a new TS declaration in your orchestrator file to extend `PermissionTypeMapping` with your new permission type. This will allow TS to automatically revolve the new orchestrator everywhere:
+## Overview
 
-```ts
-declare module './types' {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface PermissionTypeMapping {
-    'new-permission-type': JsonObject & NewPermissionTypeDefinition; // JsonObject & NewPermissionTypeDefinition to be compatible with the Snap JSON object type
-  }
+A permission type consists of several components:
+1. Permission definition and registration
+2. Type definitions
+3. Validation logic
+4. Context management
+5. UI components
+6. Caveat handling
+
+## Step-by-Step Guide
+
+### 1. Create Permission Directory
+
+Create a new directory under `packages/gator-permissions-snap/src/permissions/` for your permission type. For example:
+```
+packages/gator-permissions-snap/src/permissions/yourPermissionType/
+```
+
+### 2. Define Types
+
+Create a `types.ts` file in your permission directory with the following structure:
+
+```typescript
+import { z } from 'zod';
+import { zHexStr, zPermission, zMetaMaskPermissionData } from '@metamask/7715-permissions-shared/types';
+
+// Define your permission metadata type
+export type YourPermissionMetadata = {
+  // Add metadata fields
+  validationErrors: {
+    // Add validation error fields
+  };
+  rulesToAdd: string[];
+};
+
+// Define your permission context type
+export type YourPermissionContext = BaseContext & {
+  // Add context fields
+};
+
+// Define your permission schema
+export const zYourPermission = zPermission.extend({
+  type: z.literal('your-permission-type'),
+  data: z.intersection(
+    zMetaMaskPermissionData,
+    z.object({
+      // Add your permission data fields
+    }),
+  ),
+});
+
+// Export types
+export type YourPermission = z.infer<typeof zYourPermission>;
+export type YourPermissionRequest = TypedPermissionRequest<YourPermission>;
+export type PopulatedYourPermission = DeepRequired<YourPermission>;
+```
+
+### 3. Implement Validation
+
+Create a `validation.ts` file to handle permission validation:
+
+```typescript
+import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+
+export function parseAndValidatePermission(
+  permissionRequest: PermissionRequest,
+): YourPermissionRequest {
+  // Implement validation logic
+  // Return validated permission request
 }
 ```
 
-4. Add your orchestrator to `orchestratorModules` value in `./packages/gator-permissions-snap/src/orchestrators/orchestrator/lookup-table.ts` file.
+### 4. Create Context Management
 
-You are now all set to implement your orchestrators' interface.
+Create a `context.ts` file to handle permission context:
+
+```typescript
+export async function buildContext({
+  permissionRequest,
+  // Add required services
+}: {
+  permissionRequest: YourPermissionRequest;
+  // Add service types
+}): Promise<YourPermissionContext> {
+  // Implement context building logic
+}
+
+export async function deriveMetadata({
+  context,
+}: {
+  context: YourPermissionContext;
+}): Promise<YourPermissionMetadata> {
+  // Implement metadata derivation
+}
+
+export async function applyContext({
+  context,
+  originalRequest,
+}: {
+  context: YourPermissionContext;
+  originalRequest: YourPermissionRequest;
+}): Promise<YourPermissionRequest> {
+  // Implement context application
+}
+```
+
+### 5. Implement UI Components
+
+Create a `content.tsx` file for the permission UI:
+
+```typescript
+export async function createConfirmationContent({
+  context,
+  metadata,
+  isJustificationCollapsed,
+  origin,
+  chainId,
+}: {
+  context: YourPermissionContext;
+  metadata: YourPermissionMetadata;
+  isJustificationCollapsed: boolean;
+  origin: string;
+  chainId: number;
+}): Promise<GenericSnapElement> {
+  // Implement UI components
+}
+```
+
+### 6. Add Caveat Handling
+
+Create a `caveats.ts` file to handle permission caveats:
+
+```typescript
+export async function appendCaveats({
+  permission,
+  caveatBuilder,
+}: {
+  permission: PopulatedYourPermission;
+  caveatBuilder: CoreCaveatBuilder;
+}): Promise<CoreCaveatBuilder> {
+  // Implement caveat handling
+}
+```
+
+### 7. Create Permission Definition
+
+Create an `index.ts` file to export your permission definition:
+
+```typescript
+export const yourPermissionDefinition: PermissionDefinition<
+  YourPermissionRequest,
+  YourPermissionContext,
+  YourPermissionMetadata,
+  YourPermission,
+  PopulatedYourPermission
+> = {
+  rules: allRules,
+  title: 'Your Permission Title',
+  dependencies: {
+    parseAndValidatePermission,
+    buildContext,
+    deriveMetadata,
+    createConfirmationContent,
+    applyContext,
+    populatePermission,
+    appendCaveats,
+  },
+};
+```
+
+### 8. Register the Permission
+
+1. Add your permission type to the permission handler factory:
+```typescript
+case 'your-permission-type':
+  handler = createPermissionHandler(yourPermissionDefinition);
+  break;
+```
+
+2. Add your permission to the default offers in `snap-permission-registry.ts`:
+```typescript
+export const DEFAULT_OFFERS: GatorPermission[] = [
+  // ... existing permissions
+  {
+    type: 'your-permission-type',
+    proposedName: 'Your Permission Name',
+  },
+];
+```
+
+## Best Practices
+
+1. **Type Safety**: Use TypeScript and Zod for robust type checking and validation.
+2. **Error Handling**: Implement comprehensive validation with clear error messages.
+3. **UI Consistency**: Follow existing UI patterns and components.
+4. **Documentation**: Add JSDoc comments for all public functions and types.
+5. **Testing**: Write unit tests for validation and business logic.

--- a/docs/addingNewPermissionTypes.md
+++ b/docs/addingNewPermissionTypes.md
@@ -202,9 +202,7 @@ export const DEFAULT_OFFERS: GatorPermission[] = [
 ];
 ```
 
-### 9. Add the Permission to the demo dapp
-
-### 10. Implement Permission Form Component
+### 9. Implement Permission Form Component
 
 Create a new form component in `packages/site/src/components/permissions/` for your permission type. For example, `YourPermissionForm.tsx`:
 

--- a/docs/addingNewPermissionTypes.md
+++ b/docs/addingNewPermissionTypes.md
@@ -30,12 +30,12 @@ import { z } from 'zod';
 import { zHexStr, zPermission, zMetaMaskPermissionData } from '@metamask/7715-permissions-shared/types';
 
 // Define your permission metadata type
+// Metadata is anything derived from the context that is not editable, such as validtion errors
 export type YourPermissionMetadata = {
   // Add metadata fields
   validationErrors: {
     // Add validation error fields
   };
-  rulesToAdd: string[];
 };
 
 // Define your permission context type
@@ -71,6 +71,7 @@ export function parseAndValidatePermission(
   permissionRequest: PermissionRequest,
 ): YourPermissionRequest {
   // Implement validation logic
+  // Validation failures should throw meaningful errors.
   // Return validated permission request
 }
 ```

--- a/docs/addingNewPermissionTypes.md
+++ b/docs/addingNewPermissionTypes.md
@@ -194,6 +194,108 @@ export const DEFAULT_OFFERS: GatorPermission[] = [
 ];
 ```
 
+### 9. Add the Permission to the demo dapp
+
+### 10. Implement Permission Form Component
+
+Create a new form component in `packages/site/src/components/permissions/` for your permission type. For example, `YourPermissionForm.tsx`:
+
+```typescript
+import { useCallback, useEffect, useState } from 'react';
+import { StyledForm } from './styles';
+import type { YourPermissionRequest } from './types';
+
+type YourPermissionFormProps = {
+  onChange: (request: YourPermissionRequest) => void;
+}
+
+export const YourPermissionForm = ({
+  onChange,
+}: YourPermissionFormProps) => {
+  // 1. Define state for each form field
+  const [field1, setField1] = useState(initialValue1);
+  const [field2, setField2] = useState(initialValue2);
+  // ... add more state as needed
+
+  // 2. Implement change handlers for each field
+  const handleField1Change = useCallback(
+    ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+      setField1(value);
+    },
+    [],
+  );
+
+  // 3. Use useEffect to emit changes to parent
+  useEffect(() => {
+    onChange({
+      type: 'your-permission-type',
+      field1,
+      field2,
+      // ... include all fields
+    });
+  }, [onChange, field1, field2 /* ... */]);
+
+  // 4. Render form fields
+  return (
+    <StyledForm>
+      <div>
+        <label htmlFor="field1">Field 1:</label>
+        <input
+          type="text"
+          id="field1"
+          name="field1"
+          value={field1}
+          onChange={handleField1Change}
+          placeholder="Enter field 1"
+        />
+      </div>
+      {/* Add more form fields */}
+    </StyledForm>
+  );
+};
+```
+
+Then, add your form to the permission type selector in `packages/site/src/pages/index.tsx`:
+
+1. Import your form component:
+```typescript
+import { YourPermissionForm } from '../components/permissions';
+```
+
+2. Add your permission type to the select options:
+```typescript
+<select
+  id="permissionType"
+  name="permissionType"
+  value={permissionType}
+  onChange={handlePermissionTypeChange}
+>
+  {/* ... existing options ... */}
+  <option value="your-permission-type">Your Permission Type</option>
+</select>
+```
+
+3. Add the form component to the conditional rendering:
+```typescript
+{permissionType === 'your-permission-type' && (
+  <YourPermissionForm
+    onChange={(request: YourPermissionRequest) => {
+      setPermissionRequest(request);
+    }}
+  />
+)}
+```
+
+Key points for implementing permission forms:
+1. Use the `StyledForm` component for consistent styling
+2. Implement proper type safety with TypeScript
+3. Use controlled form components with React state
+4. Emit changes to parent component using the `onChange` prop
+5. Include all required fields from your permission type definition
+6. Add appropriate validation and error handling
+7. Follow the existing pattern of using `useCallback` for event handlers
+8. Use `useEffect` to emit form changes to the parent
+
 ## Best Practices
 
 1. **Type Safety**: Use TypeScript and Zod for robust type checking and validation.

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "daaQiXVVVvJGgI2PHBl9UFJmPMxoie2tGD1TOxPIQmE=",
+    "shasum": "TbuA49LvPqzXBMLlkNlIRXaaElgbw3V8QKmxs5Rlo9E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "/p0aPugcJzMS6wNekI/ZtyJUQ/5EsupvbPDiT4cPebg=",
+    "shasum": "ZA6QEmzn+1LTSlIH7hGCFhIyeu9eO8g2xw312S4bdSE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "Ft70Omb1nOK49mRy2oPSAEBuwiDJsl0Ooig/6O85dCc=",
+    "shasum": "0TP5ydRCXNvDxWxjTs7Rp1v5C85Ld3tPabxulFWKWHo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "OuArP0RAiIuuilf8/74gv9GSFwhcUnQqC1xbLAvXpLk=",
+    "shasum": "PoFMZl7wTNzoiX+wVkMk8Gwmhxd4el+wY1HHBX0XjGs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "PoFMZl7wTNzoiX+wVkMk8Gwmhxd4el+wY1HHBX0XjGs=",
+    "shasum": "rNRclGmH8r9z7JF1tMzA9Hfqu1ZO5ZghIAw2Es9bg1U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "rNRclGmH8r9z7JF1tMzA9Hfqu1ZO5ZghIAw2Es9bg1U=",
+    "shasum": "lfJ1LUj3jXFYfyT1jw1tIzBxKyC8HButKqdCVUp2RQ4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "ZA6QEmzn+1LTSlIH7hGCFhIyeu9eO8g2xw312S4bdSE=",
+    "shasum": "OuArP0RAiIuuilf8/74gv9GSFwhcUnQqC1xbLAvXpLk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "0TP5ydRCXNvDxWxjTs7Rp1v5C85Ld3tPabxulFWKWHo=",
+    "shasum": "/p0aPugcJzMS6wNekI/ZtyJUQ/5EsupvbPDiT4cPebg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "TbuA49LvPqzXBMLlkNlIRXaaElgbw3V8QKmxs5Rlo9E=",
+    "shasum": "Ft70Omb1nOK49mRy2oPSAEBuwiDJsl0Ooig/6O85dCc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/clients/blockchainMetadataClient.ts
+++ b/packages/gator-permissions-snap/src/clients/blockchainMetadataClient.ts
@@ -201,28 +201,35 @@ export class BlockchainTokenMetadataClient implements TokenMetadataClient {
       return decoded;
     };
 
-    const symbol = decodeOutput<string>({
-      output: SYMBOL_ABI.outputs,
-      encoded: symbolEncoded,
-      name: 'symbol',
-    });
+    try {
+      const symbol = decodeOutput<string>({
+        output: SYMBOL_ABI.outputs,
+        encoded: symbolEncoded,
+        name: 'symbol',
+      });
 
-    const decimals = decodeOutput<number>({
-      output: DECIMALS_ABI.outputs,
-      encoded: decimalsEncoded,
-      name: 'decimals',
-    });
+      const decimals = decodeOutput<number>({
+        output: DECIMALS_ABI.outputs,
+        encoded: decimalsEncoded,
+        name: 'decimals',
+      });
 
-    const balance = decodeOutput<bigint>({
-      output: BALANCEOF_ABI.outputs,
-      encoded: balanceEncoded,
-      name: 'balance',
-    });
+      const balance = decodeOutput<bigint>({
+        output: BALANCEOF_ABI.outputs,
+        encoded: balanceEncoded,
+        name: 'balance',
+      });
 
-    return {
-      balance,
-      decimals,
-      symbol,
-    };
+      return {
+        balance,
+        decimals,
+        symbol,
+      };
+    } catch (error) {
+      const message = `Failed to fetch token balance and metadata: ${error}.`;
+
+      console.error(message);
+      throw new Error(message);
+    }
   }
 }

--- a/packages/gator-permissions-snap/src/clients/blockchainMetadataClient.ts
+++ b/packages/gator-permissions-snap/src/clients/blockchainMetadataClient.ts
@@ -226,7 +226,7 @@ export class BlockchainTokenMetadataClient implements TokenMetadataClient {
         symbol,
       };
     } catch (error) {
-      console.error(
+      logger.error(
         `Failed to fetch token balance and metadata: ${(error as Error).message}.`,
       );
 

--- a/packages/gator-permissions-snap/src/clients/blockchainMetadataClient.ts
+++ b/packages/gator-permissions-snap/src/clients/blockchainMetadataClient.ts
@@ -226,10 +226,11 @@ export class BlockchainTokenMetadataClient implements TokenMetadataClient {
         symbol,
       };
     } catch (error) {
-      const message = `Failed to fetch token balance and metadata: ${error}.`;
+      console.error(
+        `Failed to fetch token balance and metadata: ${(error as Error).message}.`,
+      );
 
-      console.error(message);
-      throw new Error(message);
+      throw error;
     }
   }
 }

--- a/packages/gator-permissions-snap/src/clients/types.ts
+++ b/packages/gator-permissions-snap/src/clients/types.ts
@@ -1,5 +1,5 @@
 import type { CaipAssetType } from '@metamask/utils';
-import type { Address, Hex } from 'viem';
+import type { Address } from 'viem';
 
 /**
  * The params for the price API client to fetch spot prices.

--- a/packages/gator-permissions-snap/src/clients/types.ts
+++ b/packages/gator-permissions-snap/src/clients/types.ts
@@ -1,5 +1,5 @@
 import type { CaipAssetType } from '@metamask/utils';
-import type { Address } from 'viem';
+import type { Address, Hex } from 'viem';
 
 /**
  * The params for the price API client to fetch spot prices.

--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -4,6 +4,7 @@ import { extractPermissionName } from '@metamask/7715-permissions-shared/utils';
 import type { AccountController } from '../accountController';
 import { nativeTokenPeriodicPermissionDefinition } from '../permissions/nativeTokenPeriodic';
 import { nativeTokenStreamPermissionDefinition } from '../permissions/nativeTokenStream';
+import { erc20TokenStreamPermissionDefinition } from '../permissions/erc20TokenStream';
 import type { TokenMetadataService } from '../services/tokenMetadataService';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { UserEventDispatcher } from '../userEventDispatcher';
@@ -99,6 +100,9 @@ export class PermissionHandlerFactory {
         handler = createPermissionHandler(
           nativeTokenPeriodicPermissionDefinition,
         );
+        break;
+      case 'erc20-token-stream':
+        handler = createPermissionHandler(erc20TokenStreamPermissionDefinition);
         break;
       default:
         throw new Error(`Unsupported permission type: ${type}`);

--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -2,9 +2,9 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractPermissionName } from '@metamask/7715-permissions-shared/utils';
 
 import type { AccountController } from '../accountController';
+import { erc20TokenStreamPermissionDefinition } from '../permissions/erc20TokenStream';
 import { nativeTokenPeriodicPermissionDefinition } from '../permissions/nativeTokenPeriodic';
 import { nativeTokenStreamPermissionDefinition } from '../permissions/nativeTokenStream';
-import { erc20TokenStreamPermissionDefinition } from '../permissions/erc20TokenStream';
 import type { TokenMetadataService } from '../services/tokenMetadataService';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { UserEventDispatcher } from '../userEventDispatcher';

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -234,6 +234,7 @@ export class PermissionRequestLifecycleOrchestrator {
       validBefore,
     );
 
+    // eslint-disable-next-line no-restricted-globals
     const saltBytes = crypto.getRandomValues(new Uint8Array(32));
     const salt = bytesToHex(saltBytes);
 

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -234,11 +234,7 @@ export class PermissionRequestLifecycleOrchestrator {
       validBefore,
     );
 
-    // use a random salt to ensure unique delegation
-    const saltBytes = new Uint8Array(32);
-    for (let i = 0; i < 32; i++) {
-      saltBytes[i] = Math.floor(Math.random() * 256);
-    }
+    const saltBytes = crypto.getRandomValues(new Uint8Array(32));
     const salt = bytesToHex(saltBytes);
 
     const delegation = {

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -12,6 +12,7 @@ import type { TokenMetadataService } from '../services/tokenMetadataService';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { UserEventDispatcher } from '../userEventDispatcher';
 import type { PermissionRequestLifecycleOrchestrator } from './permissionRequestLifecycleOrchestrator';
+import { Hex } from 'viem';
 
 /**
  * Represents the result of a permission request.
@@ -39,6 +40,22 @@ export type BaseContext = {
   expiry: string;
   isAdjustmentAllowed: boolean;
   justification: string;
+};
+
+/**
+ * Base context for all token permissions.
+ * This includes the account details and token metadata.
+ */
+export type BaseTokenPermissionContext = BaseContext & {
+  accountDetails: {
+    address: Hex;
+    balanceFormattedAsCurrency: string;
+    balance: Hex; // it would be nice if this was Hex, but must be Json serializable for Snaps JSX
+  };
+  tokenMetadata: {
+    decimals: number;
+    symbol: string;
+  };
 };
 
 /**

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -6,13 +6,13 @@ import type {
 import type { CoreCaveatBuilder } from '@metamask/delegation-toolkit';
 import type { SnapsProvider } from '@metamask/snaps-sdk';
 import type { GenericSnapElement } from '@metamask/snaps-sdk/jsx';
+import type { Hex } from 'viem';
 
 import type { AccountController } from '../accountController';
 import type { TokenMetadataService } from '../services/tokenMetadataService';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { UserEventDispatcher } from '../userEventDispatcher';
 import type { PermissionRequestLifecycleOrchestrator } from './permissionRequestLifecycleOrchestrator';
-import { Hex } from 'viem';
 
 /**
  * Represents the result of a permission request.

--- a/packages/gator-permissions-snap/src/permissions/contextValidation.ts
+++ b/packages/gator-permissions-snap/src/permissions/contextValidation.ts
@@ -1,0 +1,145 @@
+import { parseUnits, formatUnits } from 'viem';
+import {
+  convertReadableDateToTimestamp,
+  getStartOfTodayUTC,
+  TIME_PERIOD_TO_SECONDS,
+} from '../utils/time';
+import { TimePeriod } from '../core/types';
+
+export interface ValidationErrors {
+  [key: string]: string;
+}
+
+/**
+ * Validates and parses a token amount string to BigInt
+ * @param amount - The amount string to validate
+ * @param decimals - Token decimals
+ * @param fieldName - Name of the field for error messages
+ * @param allowZero - Whether zero values are allowed (default: false)
+ * @returns Object containing the parsed amount and any validation error
+ */
+export function validateAndParseAmount(
+  amount: string | undefined,
+  decimals: number,
+  fieldName: string,
+  allowZero = false,
+): { amount: bigint | undefined; error: string | undefined } {
+  if (!amount) {
+    return { amount: undefined, error: undefined };
+  }
+
+  try {
+    const parsedAmount = parseUnits(amount, decimals);
+    if (!allowZero && parsedAmount <= 0n) {
+      return {
+        amount: undefined,
+        error: `${fieldName} must be greater than 0`,
+      };
+    }
+    if (allowZero && parsedAmount < 0n) {
+      return {
+        amount: undefined,
+        error: `${fieldName} must be greater than or equal to 0`,
+      };
+    }
+    return { amount: parsedAmount, error: undefined };
+  } catch (error) {
+    return { amount: undefined, error: `Invalid ${fieldName.toLowerCase()}` };
+  }
+}
+
+/**
+ * Validates a start time to ensure it's today or later
+ * @param startTime - The start time string to validate
+ * @returns Validation error message or undefined if valid
+ */
+export function validateStartTime(startTime: string): string | undefined {
+  try {
+    const startTimeDate = convertReadableDateToTimestamp(startTime);
+    if (startTimeDate < getStartOfTodayUTC()) {
+      return 'Start time must be today or later';
+    }
+    return undefined;
+  } catch (error) {
+    return 'Invalid start time';
+  }
+}
+
+/**
+ * Validates an expiry time to ensure it's in the future
+ * @param expiry - The expiry time string to validate
+ * @returns Validation error message or undefined if valid
+ */
+export function validateExpiry(expiry: string): string | undefined {
+  try {
+    const expiryDate = convertReadableDateToTimestamp(expiry);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (expiryDate < nowSeconds) {
+      return 'Expiry must be in the future';
+    }
+    return undefined;
+  } catch (error) {
+    return 'Invalid expiry';
+  }
+}
+
+/**
+ * Validates that max amount is greater than initial amount
+ * @param maxAmount - The maximum amount as BigInt
+ * @param initialAmount - The initial amount as BigInt
+ * @returns Validation error message or undefined if valid
+ */
+export function validateMaxAmountVsInitialAmount(
+  maxAmount: bigint | undefined,
+  initialAmount: bigint | undefined,
+): string | undefined {
+  if (
+    maxAmount !== undefined &&
+    initialAmount !== undefined &&
+    maxAmount < initialAmount
+  ) {
+    return 'Max amount must be greater than initial amount';
+  }
+  return undefined;
+}
+
+/**
+ * Calculates amount per second from amount per period
+ * @param amountPerPeriod - The amount per period as BigInt
+ * @param timePeriod - The time period
+ * @param decimals - Token decimals
+ * @returns Formatted amount per second string
+ */
+export function calculateAmountPerSecond(
+  amountPerPeriod: bigint,
+  timePeriod: TimePeriod,
+  decimals: number,
+): string {
+  return formatUnits(
+    amountPerPeriod / TIME_PERIOD_TO_SECONDS[timePeriod],
+    decimals,
+  );
+}
+
+/**
+ * Validates a period duration (for periodic permissions)
+ * @param periodDuration - The period duration string to validate
+ * @returns Object containing parsed duration and any validation error
+ */
+export function validatePeriodDuration(periodDuration: string): {
+  duration: number | undefined;
+  error: string | undefined;
+} {
+  try {
+    const duration = parseInt(periodDuration, 10);
+    if (isNaN(duration) || duration <= 0) {
+      return {
+        duration: undefined,
+        error: 'Period duration must be greater than 0',
+      };
+    }
+    return { duration, error: undefined };
+  } catch (error) {
+    return { duration: undefined, error: 'Invalid period duration' };
+  }
+}

--- a/packages/gator-permissions-snap/src/permissions/contextValidation.ts
+++ b/packages/gator-permissions-snap/src/permissions/contextValidation.ts
@@ -1,22 +1,23 @@
 import { parseUnits, formatUnits } from 'viem';
+
+import type { TimePeriod } from '../core/types';
 import {
   convertReadableDateToTimestamp,
   getStartOfTodayUTC,
   TIME_PERIOD_TO_SECONDS,
 } from '../utils/time';
-import { TimePeriod } from '../core/types';
 
-export interface ValidationErrors {
+export type ValidationErrors = {
   [key: string]: string;
-}
+};
 
 /**
- * Validates and parses a token amount string to BigInt
- * @param amount - The amount string to validate
- * @param decimals - Token decimals
- * @param fieldName - Name of the field for error messages
- * @param allowZero - Whether zero values are allowed (default: false)
- * @returns Object containing the parsed amount and any validation error
+ * Validates and parses a token amount string to BigInt.
+ * @param amount - The amount string to validate.
+ * @param decimals - Token decimals.
+ * @param fieldName - Name of the field for error messages.
+ * @param allowZero - Whether zero values are allowed (default: false).
+ * @returns Object containing the parsed amount and any validation error.
  */
 export function validateAndParseAmount(
   amount: string | undefined,
@@ -49,9 +50,9 @@ export function validateAndParseAmount(
 }
 
 /**
- * Validates a start time to ensure it's today or later
- * @param startTime - The start time string to validate
- * @returns Validation error message or undefined if valid
+ * Validates a start time to ensure it's today or later.
+ * @param startTime - The start time string to validate.
+ * @returns Validation error message or undefined if valid.
  */
 export function validateStartTime(startTime: string): string | undefined {
   try {
@@ -66,9 +67,9 @@ export function validateStartTime(startTime: string): string | undefined {
 }
 
 /**
- * Validates an expiry time to ensure it's in the future
- * @param expiry - The expiry time string to validate
- * @returns Validation error message or undefined if valid
+ * Validates an expiry time to ensure it's in the future.
+ * @param expiry - The expiry time string to validate.
+ * @returns Validation error message or undefined if valid.
  */
 export function validateExpiry(expiry: string): string | undefined {
   try {
@@ -84,10 +85,10 @@ export function validateExpiry(expiry: string): string | undefined {
 }
 
 /**
- * Validates that max amount is greater than initial amount
- * @param maxAmount - The maximum amount as BigInt
- * @param initialAmount - The initial amount as BigInt
- * @returns Validation error message or undefined if valid
+ * Validates that max amount is greater than initial amount.
+ * @param maxAmount - The maximum amount as BigInt.
+ * @param initialAmount - The initial amount as BigInt.
+ * @returns Validation error message or undefined if valid.
  */
 export function validateMaxAmountVsInitialAmount(
   maxAmount: bigint | undefined,
@@ -104,11 +105,11 @@ export function validateMaxAmountVsInitialAmount(
 }
 
 /**
- * Calculates amount per second from amount per period
- * @param amountPerPeriod - The amount per period as BigInt
- * @param timePeriod - The time period
- * @param decimals - Token decimals
- * @returns Formatted amount per second string
+ * Calculates amount per second from amount per period.
+ * @param amountPerPeriod - The amount per period as BigInt.
+ * @param timePeriod - The time period.
+ * @param decimals - Token decimals.
+ * @returns Formatted amount per second string.
  */
 export function calculateAmountPerSecond(
   amountPerPeriod: bigint,
@@ -122,9 +123,9 @@ export function calculateAmountPerSecond(
 }
 
 /**
- * Validates a period duration (for periodic permissions)
- * @param periodDuration - The period duration string to validate
- * @returns Object containing parsed duration and any validation error
+ * Validates a period duration (for periodic permissions).
+ * @param periodDuration - The period duration string to validate.
+ * @returns Object containing parsed duration and any validation error.
  */
 export function validatePeriodDuration(periodDuration: string): {
   duration: number | undefined;

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/caveats.ts
@@ -1,0 +1,32 @@
+import type { CoreCaveatBuilder } from '@metamask/delegation-toolkit';
+
+import type { PopulatedErc20TokenStreamPermission } from './types';
+
+/**
+ * Appends permission-specific caveats to the caveat builder.
+ * @param options0 - The options object containing the permission and caveat builder.
+ * @param options0.permission - The complete ERC20 token stream permission containing stream parameters.
+ * @param options0.caveatBuilder - The core caveat builder to append caveats to.
+ * @returns The modified caveat builder with appended ERC20 token stream caveats.
+ */
+export async function appendCaveats({
+  permission,
+  caveatBuilder,
+}: {
+  permission: PopulatedErc20TokenStreamPermission;
+  caveatBuilder: CoreCaveatBuilder;
+}): Promise<CoreCaveatBuilder> {
+  const { initialAmount, maxAmount, amountPerSecond, startTime } =
+    permission.data;
+
+  caveatBuilder.addCaveat(
+    'erc20Streaming',
+    permission.data.tokenAddress,
+    BigInt(initialAmount),
+    BigInt(maxAmount),
+    BigInt(amountPerSecond),
+    startTime,
+  );
+
+  return caveatBuilder;
+}

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
@@ -62,7 +62,7 @@ export async function createConfirmationContent({
     },
     {
       label: 'Token',
-      text: context.accountDetails.symbol,
+      text: context.tokenMetadata.symbol,
     },
   ];
 
@@ -76,6 +76,7 @@ export async function createConfirmationContent({
       />
       <AccountDetails
         account={context.accountDetails}
+        tokenMetadata={context.tokenMetadata}
         title="Stream from"
         tooltip="The account that the token stream comes from."
       />
@@ -97,7 +98,7 @@ export async function createConfirmationContent({
             <Input
               name="stream-rate"
               type="text"
-              value={`${amountPerSecond} ${context.accountDetails.symbol}/sec`}
+              value={`${amountPerSecond} ${context.tokenMetadata.symbol}/sec`}
               disabled={true}
             />
           </Field>

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
@@ -1,0 +1,116 @@
+import type { GenericSnapElement } from '@metamask/snaps-sdk/jsx';
+import { Box, Field, Input, Section, Text } from '@metamask/snaps-sdk/jsx';
+
+import { getChainName } from '../../../../shared/src/utils/common';
+import { JUSTIFICATION_SHOW_MORE_BUTTON_NAME } from '../../core/permissionHandler';
+import { renderRules } from '../../core/rules';
+import { AccountDetails } from '../../ui/components/AccountDetails';
+import type { ItemDetails } from '../../ui/components/RequestDetails';
+import { RequestDetails } from '../../ui/components/RequestDetails';
+import { TooltipIcon } from '../../ui/components/TooltipIcon';
+import {
+  initialAmountRule,
+  maxAmountRule,
+  startTimeRule,
+  expiryRule,
+  streamAmountPerPeriodRule,
+  streamPeriodRule,
+} from './rules';
+import type {
+  Erc20TokenStreamContext,
+  Erc20TokenStreamMetadata,
+} from './types';
+
+/**
+ * Creates the confirmation content for an ERC20 token stream permission request.
+ *
+ * @param options - The options for creating the confirmation content.
+ * @param options.context - The context containing stream details and account information.
+ * @param options.metadata - The metadata containing stream configuration.
+ * @param options.isJustificationCollapsed - Whether the justification section is collapsed.
+ * @param options.origin - The origin of the permission request.
+ * @param options.chainId - The chain ID for the network.
+ * @returns A promise that resolves to a GenericSnapElement containing the confirmation UI.
+ */
+export async function createConfirmationContent({
+  context,
+  metadata,
+  isJustificationCollapsed,
+  origin,
+  chainId,
+}: {
+  context: Erc20TokenStreamContext;
+  metadata: Erc20TokenStreamMetadata;
+  isJustificationCollapsed: boolean;
+  origin: string;
+  chainId: number;
+}): Promise<GenericSnapElement> {
+  const { amountPerSecond } = metadata;
+
+  const networkName = getChainName(chainId);
+
+  const itemDetails: ItemDetails[] = [
+    {
+      label: 'Recipient',
+      text: origin,
+      tooltipText: 'The site requesting the permission',
+    },
+    {
+      label: 'Network',
+      text: networkName,
+      tooltipText: 'The network on which the permission is being requested',
+    },
+    {
+      label: 'Token',
+      text: context.accountDetails.symbol,
+    },
+  ];
+
+  return (
+    <Box>
+      <RequestDetails
+        itemDetails={itemDetails}
+        justification={context.justification}
+        isJustificationShowMoreCollapsed={isJustificationCollapsed}
+        justificationShowMoreElementName={JUSTIFICATION_SHOW_MORE_BUTTON_NAME}
+      />
+      <AccountDetails
+        account={context.accountDetails}
+        title="Stream from"
+        tooltip="The account that the token stream comes from."
+      />
+      <Section>
+        {renderRules({
+          rules: [streamAmountPerPeriodRule, streamPeriodRule],
+          context,
+          metadata,
+        })}
+
+        <Box direction="vertical">
+          <Box direction="horizontal" alignment="space-between">
+            <Box direction="horizontal">
+              <Text>Stream rate</Text>
+              <TooltipIcon tooltip="The amount of tokens to stream per second." />
+            </Box>
+          </Box>
+          <Field>
+            <Input
+              name="stream-rate"
+              type="text"
+              value={`${amountPerSecond} ${context.accountDetails.symbol}/sec`}
+              disabled={true}
+            />
+          </Field>
+        </Box>
+      </Section>
+
+      <Section>
+        {renderRules({
+          rules: [initialAmountRule, maxAmountRule, startTimeRule, expiryRule],
+          context,
+          metadata,
+        })}
+      </Section>
+    </Box>
+  );
+}

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -107,7 +107,7 @@ export async function buildContext({
   accountController: AccountController;
 }): Promise<Erc20TokenStreamContext> {
   const chainId = Number(permissionRequest.chainId);
-  const tokenAddress = permissionRequest.permission.data.tokenAddress;
+  const { tokenAddress } = permissionRequest.permission.data;
 
   const address = await accountController.getAccountAddress({
     chainId,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -142,8 +142,6 @@ export async function buildContext({
     decimals,
   );
 
-  const balance = toHex(rawBalance);
-
   const expiry = convertTimestampToReadableDate(permissionRequest.expiry);
 
   const initialAmount = formatUnitsFromString({
@@ -175,11 +173,12 @@ export async function buildContext({
     permissionRequest.permission.data.startTime,
   );
 
+  const balance = toHex(rawBalance);
+
   return {
     expiry,
     justification: permissionRequest.permission.data.justification,
     isAdjustmentAllowed: permissionRequest.isAdjustmentAllowed ?? true,
-    // todo: we should consider removing the accountDetails from the context object, and into it's own object
     accountDetails: {
       address,
       balance,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -39,7 +39,7 @@ export async function applyContext({
 }): Promise<Erc20TokenStreamPermissionRequest> {
   const {
     permissionDetails,
-    accountDetails: { decimals },
+    tokenMetadata: { decimals },
   } = context;
   const expiry = convertReadableDateToTimestamp(context.expiry);
 
@@ -136,7 +136,6 @@ export async function buildContext({
     decimals,
   );
 
-  // todo: this should just be BigInt
   const balance = toHex(rawBalance);
 
   const expiry = convertTimestampToReadableDate(permissionRequest.expiry);
@@ -179,6 +178,8 @@ export async function buildContext({
       address,
       balance,
       balanceFormattedAsCurrency: balanceFormatted,
+    },
+    tokenMetadata: {
       symbol,
       decimals,
     },
@@ -206,7 +207,7 @@ export async function deriveMetadata({
   const {
     permissionDetails,
     expiry,
-    accountDetails: { decimals },
+    tokenMetadata: { decimals },
   } = context;
 
   const validationErrors: Erc20TokenStreamMetadata['validationErrors'] = {};

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -197,7 +197,6 @@ export async function deriveMetadata({
   const { permissionDetails, expiry } = context;
 
   const validationErrors: Erc20TokenStreamMetadata['validationErrors'] = {};
-  const rulesToAdd: string[] = [];
 
   let maxAmountBigInt: bigint | undefined;
   let initialAmountBigInt: bigint | undefined;
@@ -213,8 +212,6 @@ export async function deriveMetadata({
     } catch (error) {
       validationErrors.maxAmountError = 'Invalid max amount';
     }
-  } else {
-    rulesToAdd.push('Max amount');
   }
 
   if (permissionDetails.initialAmount) {
@@ -228,8 +225,6 @@ export async function deriveMetadata({
     } catch (error) {
       validationErrors.initialAmountError = 'Invalid initial amount';
     }
-  } else {
-    rulesToAdd.push('Initial amount');
   }
 
   try {
@@ -283,6 +278,5 @@ export async function deriveMetadata({
   return {
     amountPerSecond,
     validationErrors,
-    rulesToAdd,
   };
 }

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -1,7 +1,8 @@
-import { formatEther, maxUint256, parseEther, toHex } from 'viem';
+import { formatUnits, maxUint256, parseUnits, toHex } from 'viem';
 
 import type { AccountController } from '../../accountController';
 import { TimePeriod } from '../../core/types';
+import type { TokenMetadataService } from '../../services/tokenMetadataService';
 import type { TokenPricesService } from '../../services/tokenPricesService';
 import { formatUnitsFromString } from '../../utils/balance';
 import {
@@ -36,18 +37,21 @@ export async function applyContext({
   context: Erc20TokenStreamContext;
   originalRequest: Erc20TokenStreamPermissionRequest;
 }): Promise<Erc20TokenStreamPermissionRequest> {
-  const { permissionDetails } = context;
+  const {
+    permissionDetails,
+    accountDetails: { decimals },
+  } = context;
   const expiry = convertReadableDateToTimestamp(context.expiry);
 
   const permissionData = {
     maxAmount: permissionDetails.maxAmount
-      ? toHex(parseEther(permissionDetails.maxAmount))
+      ? toHex(parseUnits(permissionDetails.maxAmount, decimals))
       : undefined,
     initialAmount: permissionDetails.initialAmount
-      ? toHex(parseEther(permissionDetails.initialAmount))
+      ? toHex(parseUnits(permissionDetails.initialAmount, decimals))
       : undefined,
     amountPerSecond: toHex(
-      parseEther(permissionDetails.amountPerPeriod) /
+      parseUnits(permissionDetails.amountPerPeriod, decimals) /
         TIME_PERIOD_TO_SECONDS[permissionDetails.timePeriod],
     ),
     startTime: convertReadableDateToTimestamp(permissionDetails.startTime),
@@ -95,16 +99,19 @@ export async function populatePermission({
  * @param options0.permissionRequest - The Erc20 token stream permission request to convert.
  * @param options0.tokenPricesService - Service for fetching token price information.
  * @param options0.accountController - Controller for managing account operations.
+ * @param options0.tokenMetadataService - Service for fetching token metadata.
  * @returns A context object containing the formatted permission details and account information.
  */
 export async function buildContext({
   permissionRequest,
   tokenPricesService,
   accountController,
+  tokenMetadataService,
 }: {
   permissionRequest: Erc20TokenStreamPermissionRequest;
   tokenPricesService: TokenPricesService;
   accountController: AccountController;
+  tokenMetadataService: TokenMetadataService;
 }): Promise<Erc20TokenStreamContext> {
   const chainId = Number(permissionRequest.chainId);
   const { tokenAddress } = permissionRequest.permission.data;
@@ -117,8 +124,9 @@ export async function buildContext({
     balance: rawBalance,
     decimals,
     symbol,
-  } = await accountController.getTokenBalanceAndMetadata({
+  } = await tokenMetadataService.getTokenBalanceAndMetadata({
     chainId,
+    account: address,
     assetAddress: tokenAddress,
   });
 
@@ -153,8 +161,9 @@ export async function buildContext({
 
   // It may seem strange to convert the amount per second to amount per period, format, and then convert back to amount per second.
   // The user is inputting amount per period, and we derive amount per second, so it makes sense for the context to contain the amount per period.
-  const amountPerPeriod = formatEther(
+  const amountPerPeriod = formatUnits(
     amountPerSecond * TIME_PERIOD_TO_SECONDS[timePeriod],
+    decimals,
   );
 
   const startTime = convertTimestampToReadableDate(
@@ -194,7 +203,11 @@ export async function deriveMetadata({
 }: {
   context: Erc20TokenStreamContext;
 }): Promise<Erc20TokenStreamMetadata> {
-  const { permissionDetails, expiry } = context;
+  const {
+    permissionDetails,
+    expiry,
+    accountDetails: { decimals },
+  } = context;
 
   const validationErrors: Erc20TokenStreamMetadata['validationErrors'] = {};
 
@@ -204,7 +217,7 @@ export async function deriveMetadata({
   let amountPerSecond = 'Unknown';
   if (permissionDetails.maxAmount) {
     try {
-      maxAmountBigInt = parseEther(permissionDetails.maxAmount);
+      maxAmountBigInt = parseUnits(permissionDetails.maxAmount, decimals);
       if (maxAmountBigInt < 0n) {
         validationErrors.maxAmountError = 'Max amount must be greater than 0';
         maxAmountBigInt = undefined;
@@ -216,7 +229,10 @@ export async function deriveMetadata({
 
   if (permissionDetails.initialAmount) {
     try {
-      initialAmountBigInt = parseEther(permissionDetails.initialAmount);
+      initialAmountBigInt = parseUnits(
+        permissionDetails.initialAmount,
+        decimals,
+      );
       if (initialAmountBigInt < 0n) {
         validationErrors.initialAmountError =
           'Initial amount must be greater than 0';
@@ -228,15 +244,19 @@ export async function deriveMetadata({
   }
 
   try {
-    amountPerSecondBigInt = parseEther(permissionDetails.amountPerPeriod);
+    amountPerSecondBigInt = parseUnits(
+      permissionDetails.amountPerPeriod,
+      decimals,
+    );
     if (amountPerSecondBigInt <= 0n) {
       validationErrors.amountPerPeriodError =
         'Amount per period must be greater than 0';
       amountPerSecondBigInt = undefined;
     } else {
-      amountPerSecond = formatEther(
+      amountPerSecond = formatUnits(
         amountPerSecondBigInt /
           TIME_PERIOD_TO_SECONDS[permissionDetails.timePeriod],
+        decimals,
       );
     }
   } catch (error) {

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -1,0 +1,288 @@
+import { formatEther, maxUint256, parseEther, toHex } from 'viem';
+
+import type { AccountController } from '../../accountController';
+import { TimePeriod } from '../../core/types';
+import type { TokenPricesService } from '../../services/tokenPricesService';
+import { formatUnitsFromString } from '../../utils/balance';
+import {
+  convertReadableDateToTimestamp,
+  convertTimestampToReadableDate,
+  getStartOfTodayUTC,
+  TIME_PERIOD_TO_SECONDS,
+} from '../../utils/time';
+import type {
+  Erc20TokenStreamContext,
+  Erc20TokenStreamPermissionRequest,
+  Erc20TokenStreamMetadata,
+  PopulatedErc20TokenStreamPermission,
+  Erc20TokenStreamPermission,
+} from './types';
+
+const DEFAULT_MAX_AMOUNT = toHex(maxUint256);
+const DEFAULT_INITIAL_AMOUNT = '0x0';
+
+/**
+ * Construct an amended Erc20TokenStreamPermissionRequest, based on the specified request,
+ * with the changes made by the specified context.
+ * @param options0 - The options object containing the context and original request.
+ * @param options0.context - The Erc20 token stream context containing the updated permission details.
+ * @param options0.originalRequest - The original permission request to be amended.
+ * @returns A new permission request with the context changes applied.
+ */
+export async function applyContext({
+  context,
+  originalRequest,
+}: {
+  context: Erc20TokenStreamContext;
+  originalRequest: Erc20TokenStreamPermissionRequest;
+}): Promise<Erc20TokenStreamPermissionRequest> {
+  const { permissionDetails } = context;
+  const expiry = convertReadableDateToTimestamp(context.expiry);
+
+  const permissionData = {
+    maxAmount: permissionDetails.maxAmount
+      ? toHex(parseEther(permissionDetails.maxAmount))
+      : undefined,
+    initialAmount: permissionDetails.initialAmount
+      ? toHex(parseEther(permissionDetails.initialAmount))
+      : undefined,
+    amountPerSecond: toHex(
+      parseEther(permissionDetails.amountPerPeriod) /
+        TIME_PERIOD_TO_SECONDS[permissionDetails.timePeriod],
+    ),
+    startTime: convertReadableDateToTimestamp(permissionDetails.startTime),
+    justification: originalRequest.permission.data.justification,
+    tokenAddress: originalRequest.permission.data.tokenAddress,
+  };
+
+  return {
+    ...originalRequest,
+    expiry,
+    permission: {
+      type: 'erc20-token-stream',
+      data: permissionData,
+      rules: originalRequest.permission.rules ?? {},
+    },
+  };
+}
+
+/**
+ * Populate an Erc20 token stream permission by filling in default values for optional fields.
+ * @param options0 - The options object containing the permission to populate.
+ * @param options0.permission - The Erc20 token stream permission to populate with default values.
+ * @returns A populated Erc20 token stream permission with all required fields populated.
+ */
+export async function populatePermission({
+  permission,
+}: {
+  permission: Erc20TokenStreamPermission;
+}): Promise<PopulatedErc20TokenStreamPermission> {
+  return {
+    ...permission,
+    data: {
+      ...permission.data,
+      initialAmount: permission.data.initialAmount ?? DEFAULT_INITIAL_AMOUNT,
+      maxAmount: permission.data.maxAmount ?? DEFAULT_MAX_AMOUNT,
+    },
+    rules: permission.rules ?? {},
+  };
+}
+
+/**
+ * Converts a permission request into a context object that can be used to render the UI
+ * and manage the permission state.
+ * @param options0 - The options object containing the request and required services.
+ * @param options0.permissionRequest - The Erc20 token stream permission request to convert.
+ * @param options0.tokenPricesService - Service for fetching token price information.
+ * @param options0.accountController - Controller for managing account operations.
+ * @returns A context object containing the formatted permission details and account information.
+ */
+export async function buildContext({
+  permissionRequest,
+  tokenPricesService,
+  accountController,
+}: {
+  permissionRequest: Erc20TokenStreamPermissionRequest;
+  tokenPricesService: TokenPricesService;
+  accountController: AccountController;
+}): Promise<Erc20TokenStreamContext> {
+  const chainId = Number(permissionRequest.chainId);
+  const tokenAddress = permissionRequest.permission.data.tokenAddress;
+
+  const address = await accountController.getAccountAddress({
+    chainId,
+  });
+
+  const {
+    balance: rawBalance,
+    decimals,
+    symbol,
+  } = await accountController.getTokenBalanceAndMetadata({
+    chainId,
+    assetAddress: tokenAddress,
+  });
+
+  const balanceFormatted = await tokenPricesService.getCryptoToFiatConversion(
+    `eip155:${chainId}/erc20:${tokenAddress}`,
+    toHex(rawBalance),
+    decimals,
+  );
+
+  // todo: this should just be BigInt
+  const balance = toHex(rawBalance);
+
+  const expiry = convertTimestampToReadableDate(permissionRequest.expiry);
+
+  const initialAmount = formatUnitsFromString({
+    value: permissionRequest.permission.data.initialAmount,
+    allowUndefined: true,
+    decimals,
+  });
+
+  const timePeriod = TimePeriod.WEEKLY;
+
+  const maxAmount = formatUnitsFromString({
+    value: permissionRequest.permission.data.maxAmount,
+    allowUndefined: true,
+    decimals,
+  });
+
+  const amountPerSecond = BigInt(
+    permissionRequest.permission.data.amountPerSecond,
+  );
+
+  // It may seem strange to convert the amount per second to amount per period, format, and then convert back to amount per second.
+  // The user is inputting amount per period, and we derive amount per second, so it makes sense for the context to contain the amount per period.
+  const amountPerPeriod = formatEther(
+    amountPerSecond * TIME_PERIOD_TO_SECONDS[timePeriod],
+  );
+
+  const startTime = convertTimestampToReadableDate(
+    permissionRequest.permission.data.startTime,
+  );
+
+  return {
+    expiry,
+    justification: permissionRequest.permission.data.justification,
+    isAdjustmentAllowed: permissionRequest.isAdjustmentAllowed ?? true,
+    // todo: we should consider removing the accountDetails from the context object, and into it's own object
+    accountDetails: {
+      address,
+      balance,
+      balanceFormattedAsCurrency: balanceFormatted,
+      symbol,
+      decimals,
+    },
+    permissionDetails: {
+      initialAmount,
+      maxAmount,
+      timePeriod,
+      startTime,
+      amountPerPeriod,
+    },
+  };
+}
+
+/**
+ * Creates metadata for the Erc20 token stream context, including validation of amounts and timestamps.
+ * @param options0 - The options object containing the context to create metadata for.
+ * @param options0.context - The Erc20 token stream context to validate and create metadata from.
+ * @returns Metadata object containing derived values and validation errors.
+ */
+export async function deriveMetadata({
+  context,
+}: {
+  context: Erc20TokenStreamContext;
+}): Promise<Erc20TokenStreamMetadata> {
+  const { permissionDetails, expiry } = context;
+
+  const validationErrors: Erc20TokenStreamMetadata['validationErrors'] = {};
+  const rulesToAdd: string[] = [];
+
+  let maxAmountBigInt: bigint | undefined;
+  let initialAmountBigInt: bigint | undefined;
+  let amountPerSecondBigInt: bigint | undefined;
+  let amountPerSecond = 'Unknown';
+  if (permissionDetails.maxAmount) {
+    try {
+      maxAmountBigInt = parseEther(permissionDetails.maxAmount);
+      if (maxAmountBigInt < 0n) {
+        validationErrors.maxAmountError = 'Max amount must be greater than 0';
+        maxAmountBigInt = undefined;
+      }
+    } catch (error) {
+      validationErrors.maxAmountError = 'Invalid max amount';
+    }
+  } else {
+    rulesToAdd.push('Max amount');
+  }
+
+  if (permissionDetails.initialAmount) {
+    try {
+      initialAmountBigInt = parseEther(permissionDetails.initialAmount);
+      if (initialAmountBigInt < 0n) {
+        validationErrors.initialAmountError =
+          'Initial amount must be greater than 0';
+        initialAmountBigInt = undefined;
+      }
+    } catch (error) {
+      validationErrors.initialAmountError = 'Invalid initial amount';
+    }
+  } else {
+    rulesToAdd.push('Initial amount');
+  }
+
+  try {
+    amountPerSecondBigInt = parseEther(permissionDetails.amountPerPeriod);
+    if (amountPerSecondBigInt <= 0n) {
+      validationErrors.amountPerPeriodError =
+        'Amount per period must be greater than 0';
+      amountPerSecondBigInt = undefined;
+    } else {
+      amountPerSecond = formatEther(
+        amountPerSecondBigInt /
+          TIME_PERIOD_TO_SECONDS[permissionDetails.timePeriod],
+      );
+    }
+  } catch (error) {
+    validationErrors.amountPerPeriodError = 'Invalid amount per period';
+  }
+
+  try {
+    const startTimeDate = convertReadableDateToTimestamp(
+      permissionDetails.startTime,
+    );
+
+    if (startTimeDate < getStartOfTodayUTC()) {
+      validationErrors.startTimeError = 'Start time must be today or later';
+    }
+  } catch (error) {
+    validationErrors.startTimeError = 'Invalid start time';
+  }
+
+  try {
+    const expiryDate = convertReadableDateToTimestamp(expiry);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    if (expiryDate < nowSeconds) {
+      validationErrors.expiryError = 'Expiry must be in the future';
+    }
+  } catch (error) {
+    validationErrors.expiryError = 'Invalid expiry';
+  }
+
+  if (
+    maxAmountBigInt !== undefined &&
+    initialAmountBigInt !== undefined &&
+    maxAmountBigInt < initialAmountBigInt
+  ) {
+    validationErrors.maxAmountError =
+      'Max amount must be greater than initial amount';
+  }
+
+  return {
+    amountPerSecond,
+    validationErrors,
+    rulesToAdd,
+  };
+}

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/index.ts
@@ -1,0 +1,38 @@
+import type { PermissionDefinition } from '../../core/types';
+import { appendCaveats } from './caveats';
+import { createConfirmationContent } from './content';
+import {
+  applyContext,
+  buildContext,
+  deriveMetadata,
+  populatePermission,
+} from './context';
+import { allRules } from './rules';
+import type {
+  Erc20TokenStreamContext,
+  Erc20TokenStreamMetadata,
+  Erc20TokenStreamPermission,
+  Erc20TokenStreamPermissionRequest,
+  PopulatedErc20TokenStreamPermission,
+} from './types';
+import { parseAndValidatePermission } from './validation';
+
+export const erc20TokenStreamPermissionDefinition: PermissionDefinition<
+  Erc20TokenStreamPermissionRequest,
+  Erc20TokenStreamContext,
+  Erc20TokenStreamMetadata,
+  Erc20TokenStreamPermission,
+  PopulatedErc20TokenStreamPermission
+> = {
+  rules: allRules,
+  title: 'ERC20 token stream',
+  dependencies: {
+    parseAndValidatePermission,
+    buildContext,
+    deriveMetadata,
+    createConfirmationContent,
+    applyContext,
+    populatePermission,
+    appendCaveats,
+  },
+};

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/rules.ts
@@ -1,0 +1,138 @@
+import type { RuleDefinition } from '../../core/types';
+import { TimePeriod } from '../../core/types';
+import type {
+  Erc20TokenStreamContext,
+  Erc20TokenStreamMetadata,
+} from './types';
+
+export const INITIAL_AMOUNT_ELEMENT = 'erc20-token-stream-initial-amount';
+export const MAX_AMOUNT_ELEMENT = 'erc20-token-stream-max-amount';
+export const START_TIME_ELEMENT = 'erc20-token-stream-start-time';
+export const AMOUNT_PER_PERIOD_ELEMENT = 'erc20-token-stream-amount-per-period';
+export const TIME_PERIOD_ELEMENT = 'erc20-token-stream-time-period';
+export const EXPIRY_ELEMENT = 'erc20-token-stream-expiry';
+
+type Erc20TokenStreamRuleDefinition = RuleDefinition<
+  Erc20TokenStreamContext,
+  Erc20TokenStreamMetadata
+>;
+
+export const initialAmountRule: Erc20TokenStreamRuleDefinition = {
+  label: 'Initial Amount',
+  name: INITIAL_AMOUNT_ELEMENT,
+  type: 'number',
+  isOptional: true,
+  tooltip: 'The initial amount of tokens that can be streamed.',
+  value: (context: Erc20TokenStreamContext) =>
+    context.permissionDetails.initialAmount,
+  error: (metadata: Erc20TokenStreamMetadata) =>
+    metadata.validationErrors.initialAmountError,
+  updateContext: (
+    context: Erc20TokenStreamContext,
+    value: string | undefined,
+  ) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      initialAmount: value,
+    },
+  }),
+};
+
+export const maxAmountRule: Erc20TokenStreamRuleDefinition = {
+  label: 'Max Amount',
+  name: MAX_AMOUNT_ELEMENT,
+  tooltip: 'The maximum amount of tokens that can be streamed.',
+  type: 'number',
+  isOptional: true,
+  value: (context: Erc20TokenStreamContext) =>
+    context.permissionDetails.maxAmount,
+  error: (metadata: Erc20TokenStreamMetadata) =>
+    metadata.validationErrors.maxAmountError,
+  updateContext: (
+    context: Erc20TokenStreamContext,
+    value: string | undefined,
+  ) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      maxAmount: value,
+    },
+  }),
+};
+
+export const startTimeRule: Erc20TokenStreamRuleDefinition = {
+  label: 'Start Time',
+  name: START_TIME_ELEMENT,
+  type: 'text',
+  tooltip: 'The start time of the stream.',
+  value: (context: Erc20TokenStreamContext) =>
+    context.permissionDetails.startTime,
+  error: (metadata: Erc20TokenStreamMetadata) =>
+    metadata.validationErrors.startTimeError,
+  updateContext: (context: Erc20TokenStreamContext, value: string) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      startTime: value,
+    },
+  }),
+};
+
+export const streamAmountPerPeriodRule: Erc20TokenStreamRuleDefinition = {
+  label: 'Stream Amount',
+  name: AMOUNT_PER_PERIOD_ELEMENT,
+  type: 'number',
+  tooltip: 'The amount of tokens that can be streamed per period.',
+  value: (context: Erc20TokenStreamContext) =>
+    context.permissionDetails.amountPerPeriod,
+  error: (metadata: Erc20TokenStreamMetadata) =>
+    metadata.validationErrors.amountPerPeriodError,
+  updateContext: (context: Erc20TokenStreamContext, value: string) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      amountPerPeriod: value,
+    },
+  }),
+};
+
+export const streamPeriodRule: Erc20TokenStreamRuleDefinition = {
+  label: 'Stream Period',
+  name: TIME_PERIOD_ELEMENT,
+  type: 'dropdown',
+  tooltip: 'The period of the stream.',
+  options: Object.values(TimePeriod),
+  value: (context: Erc20TokenStreamContext) =>
+    context.permissionDetails.timePeriod,
+  updateContext: (context: Erc20TokenStreamContext, value: TimePeriod) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      timePeriod: value,
+    },
+  }),
+};
+
+export const expiryRule: Erc20TokenStreamRuleDefinition = {
+  label: 'Expiry',
+  name: EXPIRY_ELEMENT,
+  type: 'text',
+  tooltip: 'The expiry date of the permission.',
+  value: (context: Erc20TokenStreamContext) => context.expiry,
+  error: (metadata: Erc20TokenStreamMetadata) =>
+    metadata.validationErrors.expiryError,
+  updateContext: (context: Erc20TokenStreamContext, value: string) => ({
+    ...context,
+    expiry: value,
+  }),
+};
+
+export const allRules = [
+  initialAmountRule,
+  maxAmountRule,
+  startTimeRule,
+  expiryRule,
+  streamAmountPerPeriodRule,
+  streamPeriodRule,
+];

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
@@ -1,0 +1,68 @@
+import {
+  zHexStr,
+  zPermission,
+  zMetaMaskPermissionData,
+} from '@metamask/7715-permissions-shared/types';
+import type { Hex } from 'viem';
+import { z } from 'zod';
+
+import type {
+  DeepRequired,
+  TimePeriod,
+  TypedPermissionRequest,
+  BaseContext,
+} from '../../core/types';
+
+export type Erc20TokenStreamMetadata = {
+  amountPerSecond: string;
+  validationErrors: {
+    initialAmountError?: string;
+    maxAmountError?: string;
+    amountPerPeriodError?: string;
+    startTimeError?: string;
+    expiryError?: string;
+  };
+  rulesToAdd: string[];
+};
+
+// todo: move accountDetails to the base context so that accountDetails formatting is shared between permissions
+export type Erc20TokenStreamContext = BaseContext & {
+  accountDetails: {
+    address: Hex;
+    balanceFormattedAsCurrency: string;
+    balance: Hex;
+    decimals: number;
+    symbol: string;
+  };
+  permissionDetails: {
+    initialAmount: string | undefined;
+    maxAmount: string | undefined;
+    timePeriod: TimePeriod;
+    startTime: string;
+    amountPerPeriod: string;
+  };
+};
+
+export const zErc20TokenStreamPermission = zPermission.extend({
+  type: z.literal('erc20-token-stream'),
+  data: z.intersection(
+    zMetaMaskPermissionData,
+    z.object({
+      initialAmount: zHexStr.optional(),
+      maxAmount: zHexStr.optional(),
+      amountPerSecond: zHexStr,
+      startTime: z.number(),
+      tokenAddress: zHexStr,
+    }),
+  ),
+});
+
+export type Erc20TokenStreamPermission = z.infer<
+  typeof zErc20TokenStreamPermission
+>;
+
+export type Erc20TokenStreamPermissionRequest =
+  TypedPermissionRequest<Erc20TokenStreamPermission>;
+
+export type PopulatedErc20TokenStreamPermission =
+  DeepRequired<Erc20TokenStreamPermission>;

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
@@ -22,7 +22,6 @@ export type Erc20TokenStreamMetadata = {
     startTimeError?: string;
     expiryError?: string;
   };
-  rulesToAdd: string[];
 };
 
 // todo: move accountDetails to the base context so that accountDetails formatting is shared between permissions

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
@@ -24,12 +24,13 @@ export type Erc20TokenStreamMetadata = {
   };
 };
 
-// todo: move accountDetails to the base context so that accountDetails formatting is shared between permissions
 export type Erc20TokenStreamContext = BaseContext & {
   accountDetails: {
     address: Hex;
     balanceFormattedAsCurrency: string;
     balance: Hex;
+  };
+  tokenMetadata: {
     decimals: number;
     symbol: string;
   };

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
@@ -3,14 +3,13 @@ import {
   zPermission,
   zMetaMaskPermissionData,
 } from '@metamask/7715-permissions-shared/types';
-import type { Hex } from 'viem';
 import { z } from 'zod';
 
 import type {
   DeepRequired,
   TimePeriod,
   TypedPermissionRequest,
-  BaseContext,
+  BaseTokenPermissionContext,
 } from '../../core/types';
 
 export type Erc20TokenStreamMetadata = {
@@ -24,16 +23,7 @@ export type Erc20TokenStreamMetadata = {
   };
 };
 
-export type Erc20TokenStreamContext = BaseContext & {
-  accountDetails: {
-    address: Hex;
-    balanceFormattedAsCurrency: string;
-    balance: Hex;
-  };
-  tokenMetadata: {
-    decimals: number;
-    symbol: string;
-  };
+export type Erc20TokenStreamContext = BaseTokenPermissionContext & {
   permissionDetails: {
     initialAmount: string | undefined;
     maxAmount: string | undefined;

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
@@ -1,7 +1,7 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
-import { validateHexInteger } from '../validation';
 
+import { validateHexInteger } from '../validation';
 import type {
   Erc20TokenStreamPermission,
   Erc20TokenStreamPermissionRequest,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
@@ -1,0 +1,95 @@
+import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
+import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+
+import type {
+  Erc20TokenStreamPermission,
+  Erc20TokenStreamPermissionRequest,
+} from './types';
+import { zErc20TokenStreamPermission } from './types';
+
+/**
+ * Validates a permission object data specific to the permission type.
+ * @param permission - The ERC20 token stream permission object to validate.
+ * @returns True if the permission data is valid, throws an error otherwise.
+ * @throws {Error} If any validation check fails.
+ */
+function validatePermissionData(permission: Erc20TokenStreamPermission): true {
+  const { initialAmount, maxAmount, amountPerSecond, startTime, tokenAddress } =
+    permission.data;
+  const bigIntAmountPerSecond = BigInt(amountPerSecond);
+
+  if (maxAmount) {
+    if (BigInt(maxAmount) === 0n) {
+      throw new Error('Invalid maxAmount: must be a positive number');
+    }
+  }
+
+  if (initialAmount) {
+    const bigIntInitialAmount = BigInt(initialAmount);
+    if (bigIntInitialAmount === 0n) {
+      throw new Error('Invalid initialAmount: must be greater than zero');
+    }
+    if (maxAmount) {
+      if (BigInt(maxAmount) < bigIntInitialAmount) {
+        throw new Error(
+          'Invalid maxAmount: must be greater than initialAmount',
+        );
+      }
+    }
+  }
+
+  if (bigIntAmountPerSecond === 0n) {
+    throw new Error('Invalid amountPerSecond: must be a positive number');
+  }
+
+  if (startTime <= 0) {
+    throw new Error('Invalid startTime: must be a positive number');
+  }
+
+  if (startTime !== Math.floor(startTime)) {
+    throw new Error('Invalid startTime: must be an integer');
+  }
+
+  if (!tokenAddress || tokenAddress === '0x') {
+    throw new Error(
+      'Invalid tokenAddress: must be a valid ERC20 token address',
+    );
+  }
+
+  return true;
+}
+
+/**
+ * Parses and validates a permission request for ERC20 token streaming.
+ * @param permissionRequest - The permission request object to validate.
+ * @returns A validated permission request object.
+ * @throws {Error} If the permission request is invalid.
+ */
+export function parseAndValidatePermission(
+  permissionRequest: PermissionRequest,
+): Erc20TokenStreamPermissionRequest {
+  const {
+    data: validationResult,
+    error: validationError,
+    success,
+  } = zErc20TokenStreamPermission.safeParse(permissionRequest.permission);
+
+  if (!success) {
+    throw new Error(extractZodError(validationError.errors));
+  }
+
+  validatePermissionData(validationResult);
+
+  return {
+    ...permissionRequest,
+    isAdjustmentAllowed: permissionRequest.isAdjustmentAllowed ?? true,
+    permission: {
+      ...validationResult,
+      data: {
+        ...validationResult.data,
+        initialAmount: validationResult.data.initialAmount,
+        maxAmount: validationResult.data.maxAmount,
+      },
+    },
+  };
+}

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
@@ -1,5 +1,6 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+import { validateHexInteger } from '../validation';
 
 import type {
   Erc20TokenStreamPermission,
@@ -16,30 +17,30 @@ import { zErc20TokenStreamPermission } from './types';
 function validatePermissionData(permission: Erc20TokenStreamPermission): true {
   const { initialAmount, maxAmount, amountPerSecond, startTime, tokenAddress } =
     permission.data;
-  const bigIntAmountPerSecond = BigInt(amountPerSecond);
 
-  if (maxAmount) {
-    if (BigInt(maxAmount) === 0n) {
-      throw new Error('Invalid maxAmount: must be a positive number');
-    }
-  }
+  validateHexInteger({
+    name: 'maxAmount',
+    value: maxAmount,
+    required: false,
+    allowZero: false,
+  });
 
-  if (initialAmount) {
-    const bigIntInitialAmount = BigInt(initialAmount);
-    if (bigIntInitialAmount === 0n) {
-      throw new Error('Invalid initialAmount: must be greater than zero');
-    }
-    if (maxAmount) {
-      if (BigInt(maxAmount) < bigIntInitialAmount) {
-        throw new Error(
-          'Invalid maxAmount: must be greater than initialAmount',
-        );
-      }
-    }
-  }
+  validateHexInteger({
+    name: 'initialAmount',
+    value: initialAmount,
+    required: false,
+    allowZero: false,
+  });
 
-  if (bigIntAmountPerSecond === 0n) {
-    throw new Error('Invalid amountPerSecond: must be a positive number');
+  validateHexInteger({
+    name: 'amountPerSecond',
+    value: amountPerSecond,
+    required: true,
+    allowZero: false,
+  });
+
+  if (initialAmount && maxAmount && BigInt(maxAmount) < BigInt(initialAmount)) {
+    throw new Error('Invalid maxAmount: must be greater than initialAmount');
   }
 
   if (startTime <= 0) {

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/content.tsx
@@ -75,6 +75,7 @@ export async function createConfirmationContent({
         />
         <AccountDetails
           account={context.accountDetails}
+          tokenMetadata={context.tokenMetadata}
           title="Transfer from"
           tooltip="The account that the token transfers come from."
         />

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -36,7 +36,7 @@ export async function applyContext({
 }): Promise<NativeTokenPeriodicPermissionRequest> {
   const {
     permissionDetails,
-    accountDetails: { decimals },
+    tokenMetadata: { decimals },
   } = context;
   const expiry = convertReadableDateToTimestamp(context.expiry);
 
@@ -155,6 +155,8 @@ export async function buildContext({
       address,
       balance,
       balanceFormattedAsCurrency: balanceFormatted,
+    },
+    tokenMetadata: {
       symbol,
       decimals,
     },
@@ -181,7 +183,7 @@ export async function deriveMetadata({
   const {
     permissionDetails,
     expiry,
-    accountDetails: { decimals },
+    tokenMetadata: { decimals },
   } = context;
 
   const validationErrors: NativeTokenPeriodicMetadata['validationErrors'] = {};

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -111,6 +111,7 @@ export async function buildContext({
   const balanceFormatted = await tokenPricesService.getCryptoToFiatConversion(
     `eip155:1/slip44:60`,
     toHex(rawBalance),
+    decimals,
   );
 
   // todo: this should just be BigInt
@@ -152,6 +153,7 @@ export async function buildContext({
       balance,
       balanceFormattedAsCurrency: balanceFormatted,
       symbol,
+      decimals,
     },
     permissionDetails: {
       periodAmount,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -122,9 +122,6 @@ export async function buildContext({
     decimals,
   );
 
-  // todo: this should just be BigInt
-  const balance = toHex(rawBalance);
-
   const expiry = convertTimestampToReadableDate(permissionRequest.expiry);
 
   const periodAmount = formatUnitsFromString({
@@ -151,6 +148,8 @@ export async function buildContext({
   const startTime = convertTimestampToReadableDate(
     permissionRequest.permission.data.startTime,
   );
+
+  const balance = toHex(rawBalance);
 
   return {
     expiry,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -1,4 +1,4 @@
-import { parseEther, toHex } from 'viem';
+import { parseUnits, toHex } from 'viem';
 
 import type { AccountController } from '../../accountController';
 import { TimePeriod } from '../../core/types';
@@ -34,11 +34,14 @@ export async function applyContext({
   context: NativeTokenPeriodicContext;
   originalRequest: NativeTokenPeriodicPermissionRequest;
 }): Promise<NativeTokenPeriodicPermissionRequest> {
-  const { permissionDetails } = context;
+  const {
+    permissionDetails,
+    accountDetails: { decimals },
+  } = context;
   const expiry = convertReadableDateToTimestamp(context.expiry);
 
   const permissionData = {
-    periodAmount: toHex(parseEther(permissionDetails.periodAmount)),
+    periodAmount: toHex(parseUnits(permissionDetails.periodAmount, decimals)),
     periodDuration: parseInt(permissionDetails.periodDuration, 10),
     startTime: convertReadableDateToTimestamp(permissionDetails.startTime),
     justification: originalRequest.permission.data.justification,
@@ -175,12 +178,19 @@ export async function deriveMetadata({
 }: {
   context: NativeTokenPeriodicContext;
 }): Promise<NativeTokenPeriodicMetadata> {
-  const { permissionDetails, expiry } = context;
+  const {
+    permissionDetails,
+    expiry,
+    accountDetails: { decimals },
+  } = context;
 
   const validationErrors: NativeTokenPeriodicMetadata['validationErrors'] = {};
 
   try {
-    const periodAmountBigInt = parseEther(permissionDetails.periodAmount);
+    const periodAmountBigInt = parseUnits(
+      permissionDetails.periodAmount,
+      decimals,
+    );
     if (periodAmountBigInt <= 0n) {
       validationErrors.periodAmountError =
         'Period amount must be greater than 0';

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
@@ -3,13 +3,12 @@ import {
   zPermission,
   zMetaMaskPermissionData,
 } from '@metamask/7715-permissions-shared/types';
-import type { Hex } from 'viem';
 import { z } from 'zod';
 
 import type {
   DeepRequired,
   TypedPermissionRequest,
-  BaseContext,
+  BaseTokenPermissionContext,
   TimePeriod,
 } from '../../core/types';
 
@@ -23,16 +22,7 @@ export type NativeTokenPeriodicMetadata = {
   };
 };
 
-export type NativeTokenPeriodicContext = BaseContext & {
-  accountDetails: {
-    address: Hex;
-    balanceFormattedAsCurrency: string;
-    balance: Hex;
-  };
-  tokenMetadata: {
-    decimals: number;
-    symbol: string;
-  };
+export type NativeTokenPeriodicContext = BaseTokenPermissionContext & {
   permissionDetails: {
     periodAmount: string;
     periodType: TimePeriod | 'Other';

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
@@ -28,6 +28,8 @@ export type NativeTokenPeriodicContext = BaseContext & {
     address: Hex;
     balanceFormattedAsCurrency: string;
     balance: Hex;
+  };
+  tokenMetadata: {
     decimals: number;
     symbol: string;
   };

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
@@ -27,7 +27,8 @@ export type NativeTokenPeriodicContext = BaseContext & {
   accountDetails: {
     address: Hex;
     balanceFormattedAsCurrency: string;
-    balance: string;
+    balance: Hex;
+    decimals: number;
     symbol: string;
   };
   permissionDetails: {

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/validation.ts
@@ -1,5 +1,6 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+import { validateHexInteger } from '../validation';
 
 import type {
   NativeTokenPeriodicPermission,
@@ -17,11 +18,13 @@ function validatePermissionData(
   permission: NativeTokenPeriodicPermission,
 ): true {
   const { periodAmount, periodDuration, startTime } = permission.data;
-  const bigIntPeriodAmount = BigInt(periodAmount);
 
-  if (bigIntPeriodAmount === 0n) {
-    throw new Error('Invalid periodAmount: must be a positive number');
-  }
+  validateHexInteger({
+    name: 'periodAmount',
+    value: periodAmount,
+    required: true,
+    allowZero: false,
+  });
 
   if (periodDuration <= 0) {
     throw new Error('Invalid periodDuration: must be a positive number');

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/validation.ts
@@ -1,7 +1,7 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
-import { validateHexInteger } from '../validation';
 
+import { validateHexInteger } from '../validation';
 import type {
   NativeTokenPeriodicPermission,
   NativeTokenPeriodicPermissionRequest,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
@@ -70,7 +70,7 @@ export async function createConfirmationContent({
     },
     {
       label: 'Token',
-      text: context.accountDetails.symbol,
+      text: context.tokenMetadata.symbol,
       iconUrl: IconUrls.ethereum.token,
     },
   ];
@@ -85,6 +85,7 @@ export async function createConfirmationContent({
       />
       <AccountDetails
         account={context.accountDetails}
+        tokenMetadata={context.tokenMetadata}
         title="Stream from"
         tooltip="The account that the token stream comes from."
       />
@@ -106,7 +107,7 @@ export async function createConfirmationContent({
             <Box>
               <Image
                 src={IconUrls.ethereum.token}
-                alt={`${context.accountDetails.symbol} token icon`}
+                alt={`${context.tokenMetadata.symbol} token icon`}
               />
             </Box>
             <Input

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -127,6 +127,7 @@ export async function buildContext({
   const balanceFormatted = await tokenPricesService.getCryptoToFiatConversion(
     `eip155:1/slip44:60`,
     toHex(rawBalance),
+    decimals,
   );
 
   // todo: this should just be BigInt
@@ -172,6 +173,7 @@ export async function buildContext({
       balance,
       balanceFormattedAsCurrency: balanceFormatted,
       symbol,
+      decimals,
     },
     permissionDetails: {
       initialAmount,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -8,9 +8,15 @@ import { formatUnitsFromString } from '../../utils/balance';
 import {
   convertReadableDateToTimestamp,
   convertTimestampToReadableDate,
-  getStartOfTodayUTC,
   TIME_PERIOD_TO_SECONDS,
 } from '../../utils/time';
+import {
+  validateAndParseAmount,
+  validateStartTime,
+  validateExpiry,
+  validateMaxAmountVsInitialAmount,
+  calculateAmountPerSecond,
+} from '../contextValidation';
 import type {
   NativeTokenStreamContext,
   NativeTokenStreamPermissionRequest,
@@ -209,88 +215,64 @@ export async function deriveMetadata({
 
   const validationErrors: NativeTokenStreamMetadata['validationErrors'] = {};
 
-  let maxAmountBigInt: bigint | undefined;
-  let initialAmountBigInt: bigint | undefined;
-  let amountPerSecondBigInt: bigint | undefined;
+  // Validate max amount
+  const maxAmountResult = validateAndParseAmount(
+    permissionDetails.maxAmount,
+    decimals,
+    'Max amount',
+    false, // Disallow zero for max amount
+  );
+  if (maxAmountResult.error) {
+    validationErrors.maxAmountError = maxAmountResult.error;
+  }
+
+  // Validate initial amount
+  const initialAmountResult = validateAndParseAmount(
+    permissionDetails.initialAmount,
+    decimals,
+    'Initial amount',
+    true, // Allow zero for initial amount
+  );
+  if (initialAmountResult.error) {
+    validationErrors.initialAmountError = initialAmountResult.error;
+  }
+
+  // Validate amount per period
+  const amountPerPeriodResult = validateAndParseAmount(
+    permissionDetails.amountPerPeriod,
+    decimals,
+    'Amount per period',
+  );
   let amountPerSecond = 'Unknown';
-  if (permissionDetails.maxAmount) {
-    try {
-      maxAmountBigInt = parseUnits(permissionDetails.maxAmount, decimals);
-      if (maxAmountBigInt < 0n) {
-        validationErrors.maxAmountError = 'Max amount must be greater than 0';
-        maxAmountBigInt = undefined;
-      }
-    } catch (error) {
-      validationErrors.maxAmountError = 'Invalid max amount';
-    }
-  }
-
-  if (permissionDetails.initialAmount) {
-    try {
-      initialAmountBigInt = parseUnits(
-        permissionDetails.initialAmount,
-        decimals,
-      );
-      if (initialAmountBigInt < 0n) {
-        validationErrors.initialAmountError =
-          'Initial amount must be greater than 0';
-        initialAmountBigInt = undefined;
-      }
-    } catch (error) {
-      validationErrors.initialAmountError = 'Invalid initial amount';
-    }
-  }
-
-  try {
-    amountPerSecondBigInt = parseUnits(
-      permissionDetails.amountPerPeriod,
+  if (amountPerPeriodResult.error) {
+    validationErrors.amountPerPeriodError = amountPerPeriodResult.error;
+  } else if (amountPerPeriodResult.amount) {
+    amountPerSecond = calculateAmountPerSecond(
+      amountPerPeriodResult.amount,
+      permissionDetails.timePeriod,
       decimals,
     );
-    if (amountPerSecondBigInt <= 0n) {
-      validationErrors.amountPerPeriodError =
-        'Amount per period must be greater than 0';
-      amountPerSecondBigInt = undefined;
-    } else {
-      amountPerSecond = formatUnits(
-        amountPerSecondBigInt /
-          TIME_PERIOD_TO_SECONDS[permissionDetails.timePeriod],
-        decimals,
-      );
-    }
-  } catch (error) {
-    validationErrors.amountPerPeriodError = 'Invalid amount per period';
   }
 
-  try {
-    const startTimeDate = convertReadableDateToTimestamp(
-      permissionDetails.startTime,
-    );
-
-    if (startTimeDate < getStartOfTodayUTC()) {
-      validationErrors.startTimeError = 'Start time must be today or later';
-    }
-  } catch (error) {
-    validationErrors.startTimeError = 'Invalid start time';
+  // Validate start time
+  const startTimeError = validateStartTime(permissionDetails.startTime);
+  if (startTimeError) {
+    validationErrors.startTimeError = startTimeError;
   }
 
-  try {
-    const expiryDate = convertReadableDateToTimestamp(expiry);
-    const nowSeconds = Math.floor(Date.now() / 1000);
-
-    if (expiryDate < nowSeconds) {
-      validationErrors.expiryError = 'Expiry must be in the future';
-    }
-  } catch (error) {
-    validationErrors.expiryError = 'Invalid expiry';
+  // Validate expiry
+  const expiryError = validateExpiry(expiry);
+  if (expiryError) {
+    validationErrors.expiryError = expiryError;
   }
 
-  if (
-    maxAmountBigInt !== undefined &&
-    initialAmountBigInt !== undefined &&
-    maxAmountBigInt < initialAmountBigInt
-  ) {
-    validationErrors.maxAmountError =
-      'Max amount must be greater than initial amount';
+  // Validate max amount vs initial amount
+  const maxVsInitialError = validateMaxAmountVsInitialAmount(
+    maxAmountResult.amount,
+    initialAmountResult.amount,
+  );
+  if (maxVsInitialError) {
+    validationErrors.maxAmountError = maxVsInitialError;
   }
 
   return {

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -139,9 +139,6 @@ export async function buildContext({
     decimals,
   );
 
-  // todo: this should just be BigInt
-  const balance = toHex(rawBalance);
-
   const expiry = convertTimestampToReadableDate(permissionRequest.expiry);
 
   const initialAmount = formatUnitsFromString({
@@ -172,6 +169,8 @@ export async function buildContext({
   const startTime = convertTimestampToReadableDate(
     permissionRequest.permission.data.startTime,
   );
+
+  const balance = toHex(rawBalance);
 
   return {
     expiry,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -39,7 +39,7 @@ export async function applyContext({
 }): Promise<NativeTokenStreamPermissionRequest> {
   const {
     permissionDetails,
-    accountDetails: { decimals },
+    tokenMetadata: { decimals },
   } = context;
   const expiry = convertReadableDateToTimestamp(context.expiry);
 
@@ -171,11 +171,12 @@ export async function buildContext({
     expiry,
     justification: permissionRequest.permission.data.justification,
     isAdjustmentAllowed: permissionRequest.isAdjustmentAllowed ?? true,
-    // todo: we should consider removing the accountDetails from the context object, and into it's own object
     accountDetails: {
       address,
       balance,
       balanceFormattedAsCurrency: balanceFormatted,
+    },
+    tokenMetadata: {
       symbol,
       decimals,
     },
@@ -203,7 +204,7 @@ export async function deriveMetadata({
   const {
     permissionDetails,
     expiry,
-    accountDetails: { decimals },
+    tokenMetadata: { decimals },
   } = context;
 
   const validationErrors: NativeTokenStreamMetadata['validationErrors'] = {};

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -199,7 +199,6 @@ export async function deriveMetadata({
   const { permissionDetails, expiry } = context;
 
   const validationErrors: NativeTokenStreamMetadata['validationErrors'] = {};
-  const rulesToAdd: string[] = [];
 
   let maxAmountBigInt: bigint | undefined;
   let initialAmountBigInt: bigint | undefined;
@@ -215,8 +214,6 @@ export async function deriveMetadata({
     } catch (error) {
       validationErrors.maxAmountError = 'Invalid max amount';
     }
-  } else {
-    rulesToAdd.push('Max amount');
   }
 
   if (permissionDetails.initialAmount) {
@@ -230,8 +227,6 @@ export async function deriveMetadata({
     } catch (error) {
       validationErrors.initialAmountError = 'Invalid initial amount';
     }
-  } else {
-    rulesToAdd.push('Initial amount');
   }
 
   try {
@@ -285,6 +280,5 @@ export async function deriveMetadata({
   return {
     amountPerSecond,
     validationErrors,
-    rulesToAdd,
   };
 }

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
@@ -24,12 +24,13 @@ export type NativeTokenStreamMetadata = {
   };
 };
 
-// todo: move accountDetails to the base context so that accountDetails formatting is shared between permissions
 export type NativeTokenStreamContext = BaseContext & {
   accountDetails: {
     address: Hex;
     balanceFormattedAsCurrency: string;
     balance: Hex;
+  };
+  tokenMetadata: {
     decimals: number;
     symbol: string;
   };

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
@@ -3,14 +3,13 @@ import {
   zPermission,
   zMetaMaskPermissionData,
 } from '@metamask/7715-permissions-shared/types';
-import type { Hex } from 'viem';
 import { z } from 'zod';
 
 import type {
   DeepRequired,
   TimePeriod,
   TypedPermissionRequest,
-  BaseContext,
+  BaseTokenPermissionContext,
 } from '../../core/types';
 
 export type NativeTokenStreamMetadata = {
@@ -24,16 +23,7 @@ export type NativeTokenStreamMetadata = {
   };
 };
 
-export type NativeTokenStreamContext = BaseContext & {
-  accountDetails: {
-    address: Hex;
-    balanceFormattedAsCurrency: string;
-    balance: Hex;
-  };
-  tokenMetadata: {
-    decimals: number;
-    symbol: string;
-  };
+export type NativeTokenStreamContext = BaseTokenPermissionContext & {
   permissionDetails: {
     initialAmount: string | undefined;
     maxAmount: string | undefined;

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
@@ -22,7 +22,6 @@ export type NativeTokenStreamMetadata = {
     startTimeError?: string;
     expiryError?: string;
   };
-  rulesToAdd: string[];
 };
 
 // todo: move accountDetails to the base context so that accountDetails formatting is shared between permissions

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
@@ -30,7 +30,8 @@ export type NativeTokenStreamContext = BaseContext & {
   accountDetails: {
     address: Hex;
     balanceFormattedAsCurrency: string;
-    balance: string;
+    balance: Hex;
+    decimals: number;
     symbol: string;
   };
   permissionDetails: {

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/validation.ts
@@ -1,5 +1,6 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+import { validateHexInteger } from '../validation';
 
 import type {
   NativeTokenStreamPermission,
@@ -16,30 +17,30 @@ import { zNativeTokenStreamPermission } from './types';
 function validatePermissionData(permission: NativeTokenStreamPermission): true {
   const { initialAmount, maxAmount, amountPerSecond, startTime } =
     permission.data;
-  const bigIntAmountPerSecond = BigInt(amountPerSecond);
 
-  if (maxAmount) {
-    if (BigInt(maxAmount) === 0n) {
-      throw new Error('Invalid maxAmount: must be a positive number');
-    }
-  }
+  validateHexInteger({
+    name: 'maxAmount',
+    value: maxAmount,
+    required: false,
+    allowZero: false,
+  });
 
-  if (initialAmount) {
-    const bigIntInitialAmount = BigInt(initialAmount);
-    if (bigIntInitialAmount === 0n) {
-      throw new Error('Invalid initialAmount: must be greater than zero');
-    }
-    if (maxAmount) {
-      if (BigInt(maxAmount) < bigIntInitialAmount) {
-        throw new Error(
-          'Invalid maxAmount: must be greater than initialAmount',
-        );
-      }
-    }
-  }
+  validateHexInteger({
+    name: 'initialAmount',
+    value: initialAmount,
+    required: false,
+    allowZero: false,
+  });
 
-  if (bigIntAmountPerSecond === 0n) {
-    throw new Error('Invalid amountPerSecond: must be a positive number');
+  validateHexInteger({
+    name: 'amountPerSecond',
+    value: amountPerSecond,
+    required: true,
+    allowZero: false,
+  });
+
+  if (initialAmount && maxAmount && BigInt(maxAmount) < BigInt(initialAmount)) {
+    throw new Error('Invalid maxAmount: must be greater than initialAmount');
   }
 
   if (startTime <= 0) {

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/validation.ts
@@ -1,7 +1,7 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
-import { validateHexInteger } from '../validation';
 
+import { validateHexInteger } from '../validation';
 import type {
   NativeTokenStreamPermission,
   NativeTokenStreamPermissionRequest,

--- a/packages/gator-permissions-snap/src/permissions/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/validation.ts
@@ -1,4 +1,4 @@
-import { Hex } from 'viem';
+import type { Hex } from 'viem';
 
 /**
  * Validates a hex integer value with configurable constraints.
@@ -8,7 +8,7 @@ import { Hex } from 'viem';
  * @param params.value - The hex value to validate.
  * @param params.allowZero - Whether zero values are allowed.
  * @param params.required - Whether the value is required (must be defined).
- * @throws {Error} If the value fails validation.
+ * @throws {Error} If the value fails validation
  */
 export function validateHexInteger({
   name,
@@ -39,6 +39,4 @@ export function validateHexInteger({
   if (parsedValue === 0n && !allowZero) {
     throw new Error(`Invalid ${name}: must be greater than 0`);
   }
-
-  return parsedValue;
 }

--- a/packages/gator-permissions-snap/src/permissions/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/validation.ts
@@ -1,0 +1,44 @@
+import { Hex } from 'viem';
+
+/**
+ * Validates a hex integer value with configurable constraints.
+ *
+ * @param params - The validation parameters.
+ * @param params.name - The name of the value being validated, used in error messages.
+ * @param params.value - The hex value to validate.
+ * @param params.allowZero - Whether zero values are allowed.
+ * @param params.required - Whether the value is required (must be defined).
+ * @throws {Error} If the value fails validation.
+ */
+export function validateHexInteger({
+  name,
+  value,
+  allowZero,
+  required,
+}: {
+  name: string;
+  value: Hex | undefined;
+  allowZero: boolean;
+  required: boolean;
+}) {
+  if (value === undefined || value === null) {
+    if (!required) {
+      return;
+    }
+
+    throw new Error(`Invalid ${name}: must be defined`);
+  }
+  let parsedValue: bigint;
+
+  try {
+    parsedValue = BigInt(value);
+  } catch (error) {
+    throw new Error(`Invalid ${name}: must be a valid hex integer`);
+  }
+
+  if (parsedValue === 0n && !allowZero) {
+    throw new Error(`Invalid ${name}: must be greater than 0`);
+  }
+
+  return parsedValue;
+}

--- a/packages/gator-permissions-snap/src/services/tokenPricesService.ts
+++ b/packages/gator-permissions-snap/src/services/tokenPricesService.ts
@@ -74,6 +74,7 @@ export class TokenPricesService {
   async getCryptoToFiatConversion(
     tokenCaip19Type: CaipAssetType,
     balance: Hex,
+    decimals: number,
   ): Promise<string> {
     try {
       logger.debug('TokenPricesService:getCryptoToFiatConversion()');
@@ -84,7 +85,7 @@ export class TokenPricesService {
         tokenCaip19Type,
         this.#safeParsePreferences(preferences),
       );
-      const formattedBalance = Number(formatTokenBalance(balance));
+      const formattedBalance = Number(formatTokenBalance(balance, decimals));
       const valueInFiat = formattedBalance * tokenSpotPrice;
 
       const humanReadableValue = formatAsCurrency(preferences, valueInFiat);

--- a/packages/gator-permissions-snap/src/services/tokenPricesService.ts
+++ b/packages/gator-permissions-snap/src/services/tokenPricesService.ts
@@ -69,6 +69,7 @@ export class TokenPricesService {
    *
    * @param tokenCaip19Type - The token CAIP-19 asset type to fetch spot prices for.
    * @param balance - The token balance.
+   * @param decimals - The number of decimals the token uses.
    * @returns The value of the token balance in the user's preferred currency in human-readable format.
    */
   async getCryptoToFiatConversion(

--- a/packages/gator-permissions-snap/src/ui/components/AccountDetails.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/AccountDetails.tsx
@@ -1,15 +1,15 @@
 import type { SnapComponent } from '@metamask/snaps-sdk/jsx';
 import { Text, Box, Section, Avatar } from '@metamask/snaps-sdk/jsx';
-import { type Hex } from 'viem';
+import { formatUnits, type Hex } from 'viem';
 
-import { formatTokenBalance } from '../../utils/balance';
 import { TooltipIcon } from './TooltipIcon';
 
 export type AccountDetailsProps = {
   account: {
     address: Hex;
     balanceFormattedAsCurrency: string;
-    balance: string;
+    balance: Hex;
+    decimals: number;
   };
   title: string;
   tooltip: string;
@@ -20,7 +20,7 @@ export const AccountDetails: SnapComponent<AccountDetailsProps> = ({
   title,
   tooltip,
 }) => {
-  const { address, balance, balanceFormattedAsCurrency } = account;
+  const { address, balance, balanceFormattedAsCurrency, decimals } = account;
   return (
     <Section>
       <Box direction="vertical">
@@ -39,7 +39,7 @@ export const AccountDetails: SnapComponent<AccountDetailsProps> = ({
         <Box direction="horizontal" alignment="end">
           <Text color="muted">{balanceFormattedAsCurrency}</Text>
           <Text color="alternative">
-            {`${formatTokenBalance(balance)}`} available
+            {`${formatUnits(BigInt(balance), decimals)}`} available
           </Text>
         </Box>
       </Box>

--- a/packages/gator-permissions-snap/src/ui/components/AccountDetails.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/AccountDetails.tsx
@@ -9,7 +9,10 @@ export type AccountDetailsProps = {
     address: Hex;
     balanceFormattedAsCurrency: string;
     balance: Hex;
+  };
+  tokenMetadata: {
     decimals: number;
+    symbol: string;
   };
   title: string;
   tooltip: string;
@@ -17,10 +20,12 @@ export type AccountDetailsProps = {
 
 export const AccountDetails: SnapComponent<AccountDetailsProps> = ({
   account,
+  tokenMetadata,
   title,
   tooltip,
 }) => {
-  const { address, balance, balanceFormattedAsCurrency, decimals } = account;
+  const { address, balance, balanceFormattedAsCurrency } = account;
+  const { decimals } = tokenMetadata;
   return (
     <Section>
       <Box direction="vertical">

--- a/packages/gator-permissions-snap/src/utils/balance.ts
+++ b/packages/gator-permissions-snap/src/utils/balance.ts
@@ -1,5 +1,5 @@
 import type { Hex } from 'viem';
-import { formatUnits, maxUint256, parseUnits, toHex } from 'viem';
+import { formatUnits } from 'viem';
 
 /**
  * Formats a token balance to a human-readable string.
@@ -9,47 +9,10 @@ import { formatUnits, maxUint256, parseUnits, toHex } from 'viem';
  */
 export const formatTokenBalance = (
   wei: string | number | Hex,
-  tokenDecimal = 18,
+  tokenDecimal: number,
 ): string => {
   const formattedBalance = formatUnits(BigInt(wei), tokenDecimal);
   return formattedBalance;
-};
-
-/**
- * Converts a token balance to a hex string with the given decimal places.
- * @param value - The value to convert.
- * @param tokenDecimal - The number of decimal places the token uses.
- * @returns The hex string.
- */
-export const convertValueToHex = (
-  value: string | number,
-  tokenDecimal = 18,
-): Hex => {
-  return toHex(parseUnits(value.toString(), tokenDecimal));
-};
-
-/**
- * Parses a max allowance value.
- * @param value - The value to parse.
- * @returns The parsed value.
- */
-export const maxAllowanceParser = (value: string) => {
-  if (value === 'Unlimited') {
-    return toHex(maxUint256);
-  }
-  return convertValueToHex(value);
-};
-
-/**
- * Parses a zero default value.
- * @param value - The value to parse.
- * @returns The parsed value.
- */
-export const zeroDefaultParser = (value: string | null | undefined) => {
-  if (!value) {
-    return convertValueToHex('0');
-  }
-  return convertValueToHex(value);
 };
 
 /**

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -251,7 +251,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
         };
 
         expect(delegation).toStrictEqual(expectedDelegation);
-        expect(delegation.salt).not.toStrictEqual(0n);
+        expect(delegation.salt).not.toBe(0n);
       });
 
       it('should correctly setup the onConfirmationCreated hook to update the context', async () => {

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -246,11 +246,12 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
               terms: toHex(mockPermissionRequest.expiry, { size: 32 }),
             },
           ],
-          salt: 0n,
+          salt: expect.any(BigInt),
           signature: mockSignature,
         };
 
         expect(delegation).toStrictEqual(expectedDelegation);
+        expect(delegation.salt).not.toStrictEqual(0n);
       });
 
       it('should correctly setup the onConfirmationCreated hook to update the context', async () => {

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/caveats.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/caveats.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from '@jest/globals';
+import type { CoreCaveatBuilder } from '@metamask/delegation-toolkit';
+import { toHex, parseUnits } from 'viem/utils';
+
+import { appendCaveats } from '../../../src/permissions/erc20TokenStream/caveats';
+import type { PopulatedErc20TokenStreamPermission } from '../../../src/permissions/erc20TokenStream/types';
+import { convertReadableDateToTimestamp } from '../../../src/utils/time';
+
+describe('erc20TokenStream:caveats', () => {
+  describe('appendCaveats()', () => {
+    const tokenDecimals = 10;
+    const initialAmount = toHex(parseUnits('1', tokenDecimals));
+    const maxAmount = toHex(parseUnits('10', tokenDecimals));
+    const amountPerSecond = toHex(parseUnits('.5', tokenDecimals));
+    const startTime = convertReadableDateToTimestamp('10/26/2024');
+    const tokenAddress = '0x1234567890123456789012345678901234567890';
+
+    const mockPermission: PopulatedErc20TokenStreamPermission = {
+      type: 'erc20-token-stream',
+      data: {
+        initialAmount,
+        maxAmount,
+        amountPerSecond,
+        startTime,
+        tokenAddress,
+        justification: 'test',
+      },
+      rules: {},
+    };
+
+    it('should append erc20Streaming caveat', async () => {
+      const mockCaveatBuilder = {
+        addCaveat: jest.fn().mockReturnThis(),
+      } as unknown as jest.Mocked<CoreCaveatBuilder>;
+
+      await appendCaveats({
+        permission: mockPermission,
+        caveatBuilder: mockCaveatBuilder,
+      });
+
+      expect(mockCaveatBuilder.addCaveat).toHaveBeenCalledWith(
+        'erc20Streaming',
+        tokenAddress,
+        BigInt(initialAmount),
+        BigInt(maxAmount),
+        BigInt(amountPerSecond),
+        startTime,
+      );
+
+      expect(mockCaveatBuilder.addCaveat).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return the modified caveat builder', async () => {
+      const mockCaveatBuilder = {
+        addCaveat: jest.fn().mockReturnThis(),
+      } as unknown as jest.Mocked<CoreCaveatBuilder>;
+
+      const result = await appendCaveats({
+        permission: mockPermission,
+        caveatBuilder: mockCaveatBuilder,
+      });
+
+      expect(result).toBe(mockCaveatBuilder);
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
@@ -1,0 +1,2167 @@
+import { describe, expect, it } from '@jest/globals';
+import { toHex, parseUnits } from 'viem/utils';
+
+import { TimePeriod } from '../../../src/core/types';
+import { createConfirmationContent } from '../../../src/permissions/erc20TokenStream/content';
+import type {
+  Erc20TokenStreamContext,
+  Erc20TokenStreamMetadata,
+} from '../../../src/permissions/erc20TokenStream/types';
+
+const tokenDecimals = 10;
+
+const mockContext: Erc20TokenStreamContext = {
+  expiry: '05/01/2024',
+  isAdjustmentAllowed: true,
+  justification: 'Permission to stream ERC20 tokens',
+  accountDetails: {
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    balance: toHex(parseUnits('10', tokenDecimals)),
+    balanceFormattedAsCurrency: '$🐊10.00',
+    decimals: tokenDecimals,
+    symbol: 'USDC',
+  },
+  permissionDetails: {
+    initialAmount: '1',
+    maxAmount: '10',
+    timePeriod: TimePeriod.WEEKLY,
+    startTime: '10/26/1985',
+    amountPerPeriod: '302400',
+  },
+};
+
+const mockMetadata: Erc20TokenStreamMetadata = {
+  amountPerSecond: '0.5',
+  validationErrors: {},
+  rulesToAdd: [],
+};
+
+describe('erc20TokenStream:content', () => {
+  describe('createConfirmationContent()', () => {
+    it('should render content with all permission details', async () => {
+      const content = await createConfirmationContent({
+        context: mockContext,
+        metadata: mockMetadata,
+        isJustificationCollapsed: true,
+        origin: 'https://example.com',
+        chainId: 1,
+      });
+
+      expect(content).toMatchInlineSnapshot(`
+{
+  "key": null,
+  "props": {
+    "children": [
+      {
+        "key": null,
+        "props": {
+          "children": [
+            [
+              {
+                "key": null,
+                "props": {
+                  "alignment": "space-between",
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Recipient",
+                            },
+                            "type": "Text",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": {
+                                "key": null,
+                                "props": {
+                                  "color": "muted",
+                                  "name": "question",
+                                  "size": "inherit",
+                                },
+                                "type": "Icon",
+                              },
+                              "content": {
+                                "key": null,
+                                "props": {
+                                  "children": "The site requesting the permission",
+                                },
+                                "type": "Text",
+                              },
+                            },
+                            "type": "Tooltip",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "https://example.com",
+                            },
+                            "type": "Text",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                  ],
+                  "direction": "horizontal",
+                },
+                "type": "Box",
+              },
+              {
+                "key": null,
+                "props": {
+                  "alignment": "space-between",
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Network",
+                            },
+                            "type": "Text",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": {
+                                "key": null,
+                                "props": {
+                                  "color": "muted",
+                                  "name": "question",
+                                  "size": "inherit",
+                                },
+                                "type": "Icon",
+                              },
+                              "content": {
+                                "key": null,
+                                "props": {
+                                  "children": "The network on which the permission is being requested",
+                                },
+                                "type": "Text",
+                              },
+                            },
+                            "type": "Tooltip",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Ethereum",
+                            },
+                            "type": "Text",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                  ],
+                  "direction": "horizontal",
+                },
+                "type": "Box",
+              },
+              {
+                "key": null,
+                "props": {
+                  "alignment": "space-between",
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Token",
+                            },
+                            "type": "Text",
+                          },
+                          null,
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "USDC",
+                            },
+                            "type": "Text",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                  ],
+                  "direction": "horizontal",
+                },
+                "type": "Box",
+              },
+            ],
+            {
+              "key": null,
+              "props": {
+                "alignment": "space-between",
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": "Reason",
+                          },
+                          "type": "Text",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "color": "muted",
+                                "name": "question",
+                                "size": "inherit",
+                              },
+                              "type": "Icon",
+                            },
+                            "content": {
+                              "key": null,
+                              "props": {
+                                "children": "Reason given by the recipient for requesting this token stream allowance.",
+                              },
+                              "type": "Text",
+                            },
+                          },
+                          "type": "Tooltip",
+                        },
+                      ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Permission to str...",
+                                "color": "muted",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "end",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "Show",
+                                    "name": "show-more-justification",
+                                  },
+                                  "type": "Button",
+                                },
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                ],
+                "direction": "horizontal",
+              },
+              "type": "Box",
+            },
+          ],
+        },
+        "type": "Section",
+      },
+      {
+        "key": null,
+        "props": {
+          "children": {
+            "key": null,
+            "props": {
+              "children": [
+                {
+                  "key": null,
+                  "props": {
+                    "alignment": "space-between",
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Stream from",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The account that the token stream comes from.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "address": "eip155:1:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                                "size": "sm",
+                              },
+                              "type": "Avatar",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Gator Account",
+                                "color": "default",
+                              },
+                              "type": "Text",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                    ],
+                    "direction": "horizontal",
+                  },
+                  "type": "Box",
+                },
+                {
+                  "key": null,
+                  "props": {
+                    "alignment": "end",
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "$🐊10.00",
+                          "color": "muted",
+                        },
+                        "type": "Text",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            "10",
+                            " available",
+                          ],
+                          "color": "alternative",
+                        },
+                        "type": "Text",
+                      },
+                    ],
+                    "direction": "horizontal",
+                  },
+                  "type": "Box",
+                },
+              ],
+              "direction": "vertical",
+            },
+            "type": "Box",
+          },
+        },
+        "type": "Section",
+      },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            [
+              {
+                "key": null,
+                "props": {
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": {
+                          "key": null,
+                          "props": {
+                            "children": [
+                              {
+                                "key": null,
+                                "props": {
+                                  "children": "Stream Amount",
+                                },
+                                "type": "Text",
+                              },
+                              {
+                                "key": null,
+                                "props": {
+                                  "children": {
+                                    "key": null,
+                                    "props": {
+                                      "color": "muted",
+                                      "name": "question",
+                                      "size": "inherit",
+                                    },
+                                    "type": "Icon",
+                                  },
+                                  "content": {
+                                    "key": null,
+                                    "props": {
+                                      "children": "The amount of tokens that can be streamed per period.",
+                                    },
+                                    "type": "Text",
+                                  },
+                                },
+                                "type": "Tooltip",
+                              },
+                            ],
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": null,
+                            },
+                            "type": "Box",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "name": "erc20-token-stream-amount-per-period",
+                              "type": "number",
+                              "value": "302400",
+                            },
+                            "type": "Input",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": null,
+                            },
+                            "type": "Box",
+                          },
+                        ],
+                      },
+                      "type": "Field",
+                    },
+                  ],
+                  "direction": "vertical",
+                },
+                "type": "Box",
+              },
+              {
+                "key": null,
+                "props": {
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": {
+                          "key": null,
+                          "props": {
+                            "children": [
+                              {
+                                "key": null,
+                                "props": {
+                                  "children": "Stream Period",
+                                },
+                                "type": "Text",
+                              },
+                              {
+                                "key": null,
+                                "props": {
+                                  "children": {
+                                    "key": null,
+                                    "props": {
+                                      "color": "muted",
+                                      "name": "question",
+                                      "size": "inherit",
+                                    },
+                                    "type": "Icon",
+                                  },
+                                  "content": {
+                                    "key": null,
+                                    "props": {
+                                      "children": "The period of the stream.",
+                                    },
+                                    "type": "Text",
+                                  },
+                                },
+                                "type": "Tooltip",
+                              },
+                            ],
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": {
+                          "key": null,
+                          "props": {
+                            "children": [
+                              {
+                                "key": "Daily",
+                                "props": {
+                                  "children": "Daily",
+                                  "value": "Daily",
+                                },
+                                "type": "Option",
+                              },
+                              {
+                                "key": "Weekly",
+                                "props": {
+                                  "children": "Weekly",
+                                  "value": "Weekly",
+                                },
+                                "type": "Option",
+                              },
+                              {
+                                "key": "Monthly",
+                                "props": {
+                                  "children": "Monthly",
+                                  "value": "Monthly",
+                                },
+                                "type": "Option",
+                              },
+                            ],
+                            "name": "erc20-token-stream-time-period",
+                            "value": "Weekly",
+                          },
+                          "type": "Dropdown",
+                        },
+                      },
+                      "type": "Field",
+                    },
+                  ],
+                  "direction": "vertical",
+                },
+                "type": "Box",
+              },
+            ],
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Stream rate",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The amount of tokens to stream per second.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "disabled": true,
+                          "name": "stream-rate",
+                          "type": "text",
+                          "value": "0.5 USDC/sec",
+                        },
+                        "type": "Input",
+                      },
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+          ],
+        },
+        "type": "Section",
+      },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Initial Amount",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The initial amount of tokens that can be streamed.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "name": "erc20-token-stream-initial-amount",
+                            "type": "number",
+                            "value": "1",
+                          },
+                          "type": "Input",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "primary",
+                                    "name": "close",
+                                    "size": "md",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "name": "erc20-token-stream-initial-amount_removeButton",
+                                "type": "button",
+                              },
+                              "type": "Button",
+                            },
+                          },
+                          "type": "Box",
+                        },
+                      ],
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Max Amount",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The maximum amount of tokens that can be streamed.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "name": "erc20-token-stream-max-amount",
+                            "type": "number",
+                            "value": "10",
+                          },
+                          "type": "Input",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "primary",
+                                    "name": "close",
+                                    "size": "md",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "name": "erc20-token-stream-max-amount_removeButton",
+                                "type": "button",
+                              },
+                              "type": "Button",
+                            },
+                          },
+                          "type": "Box",
+                        },
+                      ],
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Start Time",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The start time of the stream.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "name": "erc20-token-stream-start-time",
+                            "type": "text",
+                            "value": "10/26/1985",
+                          },
+                          "type": "Input",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                      ],
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Expiry",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The expiry date of the permission.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "name": "erc20-token-stream-expiry",
+                            "type": "text",
+                            "value": "05/01/2024",
+                          },
+                          "type": "Input",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                      ],
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+          ],
+        },
+        "type": "Section",
+      },
+    ],
+  },
+  "type": "Box",
+}
+`);
+    });
+
+    it('should render content with validation errors', async () => {
+      const content = await createConfirmationContent({
+        context: mockContext,
+        metadata: {
+          ...mockMetadata,
+          validationErrors: {
+            initialAmountError: 'Invalid initial amount',
+            maxAmountError: 'Invalid max amount',
+            amountPerPeriodError: 'Invalid amount per period',
+            startTimeError: 'Invalid start time',
+            expiryError: 'Invalid expiry',
+          },
+        },
+        isJustificationCollapsed: true,
+        origin: 'https://example.com',
+        chainId: 1,
+      });
+
+      expect(content).toMatchInlineSnapshot(`
+{
+  "key": null,
+  "props": {
+    "children": [
+      {
+        "key": null,
+        "props": {
+          "children": [
+            [
+              {
+                "key": null,
+                "props": {
+                  "alignment": "space-between",
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Recipient",
+                            },
+                            "type": "Text",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": {
+                                "key": null,
+                                "props": {
+                                  "color": "muted",
+                                  "name": "question",
+                                  "size": "inherit",
+                                },
+                                "type": "Icon",
+                              },
+                              "content": {
+                                "key": null,
+                                "props": {
+                                  "children": "The site requesting the permission",
+                                },
+                                "type": "Text",
+                              },
+                            },
+                            "type": "Tooltip",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "https://example.com",
+                            },
+                            "type": "Text",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                  ],
+                  "direction": "horizontal",
+                },
+                "type": "Box",
+              },
+              {
+                "key": null,
+                "props": {
+                  "alignment": "space-between",
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Network",
+                            },
+                            "type": "Text",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": {
+                                "key": null,
+                                "props": {
+                                  "color": "muted",
+                                  "name": "question",
+                                  "size": "inherit",
+                                },
+                                "type": "Icon",
+                              },
+                              "content": {
+                                "key": null,
+                                "props": {
+                                  "children": "The network on which the permission is being requested",
+                                },
+                                "type": "Text",
+                              },
+                            },
+                            "type": "Tooltip",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Ethereum",
+                            },
+                            "type": "Text",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                  ],
+                  "direction": "horizontal",
+                },
+                "type": "Box",
+              },
+              {
+                "key": null,
+                "props": {
+                  "alignment": "space-between",
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Token",
+                            },
+                            "type": "Text",
+                          },
+                          null,
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "USDC",
+                            },
+                            "type": "Text",
+                          },
+                        ],
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                  ],
+                  "direction": "horizontal",
+                },
+                "type": "Box",
+              },
+            ],
+            {
+              "key": null,
+              "props": {
+                "alignment": "space-between",
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": "Reason",
+                          },
+                          "type": "Text",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "color": "muted",
+                                "name": "question",
+                                "size": "inherit",
+                              },
+                              "type": "Icon",
+                            },
+                            "content": {
+                              "key": null,
+                              "props": {
+                                "children": "Reason given by the recipient for requesting this token stream allowance.",
+                              },
+                              "type": "Text",
+                            },
+                          },
+                          "type": "Tooltip",
+                        },
+                      ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Permission to str...",
+                                "color": "muted",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "end",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "Show",
+                                    "name": "show-more-justification",
+                                  },
+                                  "type": "Button",
+                                },
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                ],
+                "direction": "horizontal",
+              },
+              "type": "Box",
+            },
+          ],
+        },
+        "type": "Section",
+      },
+      {
+        "key": null,
+        "props": {
+          "children": {
+            "key": null,
+            "props": {
+              "children": [
+                {
+                  "key": null,
+                  "props": {
+                    "alignment": "space-between",
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Stream from",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The account that the token stream comes from.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "address": "eip155:1:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                                "size": "sm",
+                              },
+                              "type": "Avatar",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Gator Account",
+                                "color": "default",
+                              },
+                              "type": "Text",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                    ],
+                    "direction": "horizontal",
+                  },
+                  "type": "Box",
+                },
+                {
+                  "key": null,
+                  "props": {
+                    "alignment": "end",
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "$🐊10.00",
+                          "color": "muted",
+                        },
+                        "type": "Text",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            "10",
+                            " available",
+                          ],
+                          "color": "alternative",
+                        },
+                        "type": "Text",
+                      },
+                    ],
+                    "direction": "horizontal",
+                  },
+                  "type": "Box",
+                },
+              ],
+              "direction": "vertical",
+            },
+            "type": "Box",
+          },
+        },
+        "type": "Section",
+      },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            [
+              {
+                "key": null,
+                "props": {
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": {
+                          "key": null,
+                          "props": {
+                            "children": [
+                              {
+                                "key": null,
+                                "props": {
+                                  "children": "Stream Amount",
+                                },
+                                "type": "Text",
+                              },
+                              {
+                                "key": null,
+                                "props": {
+                                  "children": {
+                                    "key": null,
+                                    "props": {
+                                      "color": "muted",
+                                      "name": "question",
+                                      "size": "inherit",
+                                    },
+                                    "type": "Icon",
+                                  },
+                                  "content": {
+                                    "key": null,
+                                    "props": {
+                                      "children": "The amount of tokens that can be streamed per period.",
+                                    },
+                                    "type": "Text",
+                                  },
+                                },
+                                "type": "Tooltip",
+                              },
+                            ],
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": null,
+                            },
+                            "type": "Box",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "name": "erc20-token-stream-amount-per-period",
+                              "type": "number",
+                              "value": "302400",
+                            },
+                            "type": "Input",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": null,
+                            },
+                            "type": "Box",
+                          },
+                        ],
+                        "error": "Invalid amount per period",
+                      },
+                      "type": "Field",
+                    },
+                  ],
+                  "direction": "vertical",
+                },
+                "type": "Box",
+              },
+              {
+                "key": null,
+                "props": {
+                  "children": [
+                    {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": {
+                          "key": null,
+                          "props": {
+                            "children": [
+                              {
+                                "key": null,
+                                "props": {
+                                  "children": "Stream Period",
+                                },
+                                "type": "Text",
+                              },
+                              {
+                                "key": null,
+                                "props": {
+                                  "children": {
+                                    "key": null,
+                                    "props": {
+                                      "color": "muted",
+                                      "name": "question",
+                                      "size": "inherit",
+                                    },
+                                    "type": "Icon",
+                                  },
+                                  "content": {
+                                    "key": null,
+                                    "props": {
+                                      "children": "The period of the stream.",
+                                    },
+                                    "type": "Text",
+                                  },
+                                },
+                                "type": "Tooltip",
+                              },
+                            ],
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
+                        "direction": "horizontal",
+                      },
+                      "type": "Box",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": {
+                          "key": null,
+                          "props": {
+                            "children": [
+                              {
+                                "key": "Daily",
+                                "props": {
+                                  "children": "Daily",
+                                  "value": "Daily",
+                                },
+                                "type": "Option",
+                              },
+                              {
+                                "key": "Weekly",
+                                "props": {
+                                  "children": "Weekly",
+                                  "value": "Weekly",
+                                },
+                                "type": "Option",
+                              },
+                              {
+                                "key": "Monthly",
+                                "props": {
+                                  "children": "Monthly",
+                                  "value": "Monthly",
+                                },
+                                "type": "Option",
+                              },
+                            ],
+                            "name": "erc20-token-stream-time-period",
+                            "value": "Weekly",
+                          },
+                          "type": "Dropdown",
+                        },
+                      },
+                      "type": "Field",
+                    },
+                  ],
+                  "direction": "vertical",
+                },
+                "type": "Box",
+              },
+            ],
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Stream rate",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The amount of tokens to stream per second.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "disabled": true,
+                          "name": "stream-rate",
+                          "type": "text",
+                          "value": "0.5 USDC/sec",
+                        },
+                        "type": "Input",
+                      },
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+          ],
+        },
+        "type": "Section",
+      },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Initial Amount",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The initial amount of tokens that can be streamed.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "name": "erc20-token-stream-initial-amount",
+                            "type": "number",
+                            "value": "1",
+                          },
+                          "type": "Input",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "primary",
+                                    "name": "close",
+                                    "size": "md",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "name": "erc20-token-stream-initial-amount_removeButton",
+                                "type": "button",
+                              },
+                              "type": "Button",
+                            },
+                          },
+                          "type": "Box",
+                        },
+                      ],
+                      "error": "Invalid initial amount",
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Max Amount",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The maximum amount of tokens that can be streamed.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "name": "erc20-token-stream-max-amount",
+                            "type": "number",
+                            "value": "10",
+                          },
+                          "type": "Input",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "primary",
+                                    "name": "close",
+                                    "size": "md",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "name": "erc20-token-stream-max-amount_removeButton",
+                                "type": "button",
+                              },
+                              "type": "Button",
+                            },
+                          },
+                          "type": "Box",
+                        },
+                      ],
+                      "error": "Invalid max amount",
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Start Time",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The start time of the stream.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "name": "erc20-token-stream-start-time",
+                            "type": "text",
+                            "value": "10/26/1985",
+                          },
+                          "type": "Input",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                      ],
+                      "error": "Invalid start time",
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": [
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "children": "Expiry",
+                              },
+                              "type": "Text",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "color": "muted",
+                                    "name": "question",
+                                    "size": "inherit",
+                                  },
+                                  "type": "Icon",
+                                },
+                                "content": {
+                                  "key": null,
+                                  "props": {
+                                    "children": "The expiry date of the permission.",
+                                  },
+                                  "type": "Text",
+                                },
+                              },
+                              "type": "Tooltip",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "name": "erc20-token-stream-expiry",
+                            "type": "text",
+                            "value": "05/01/2024",
+                          },
+                          "type": "Input",
+                        },
+                        {
+                          "key": null,
+                          "props": {
+                            "children": null,
+                          },
+                          "type": "Box",
+                        },
+                      ],
+                      "error": "Invalid expiry",
+                    },
+                    "type": "Field",
+                  },
+                ],
+                "direction": "vertical",
+              },
+              "type": "Box",
+            },
+          ],
+        },
+        "type": "Section",
+      },
+    ],
+  },
+  "type": "Box",
+}
+`);
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
@@ -18,6 +18,8 @@ const mockContext: Erc20TokenStreamContext = {
     address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     balance: toHex(parseUnits('10', tokenDecimals)),
     balanceFormattedAsCurrency: '$🐊10.00',
+  },
+  tokenMetadata: {
     decimals: tokenDecimals,
     symbol: 'USDC',
   },

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
@@ -33,7 +33,6 @@ const mockContext: Erc20TokenStreamContext = {
 const mockMetadata: Erc20TokenStreamMetadata = {
   amountPerSecond: '0.5',
   validationErrors: {},
-  rulesToAdd: [],
 };
 
 describe('erc20TokenStream:content', () => {

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/context.test.ts
@@ -246,7 +246,8 @@ describe('erc20TokenStream:context', () => {
         });
 
         expect(metadata.validationErrors).toStrictEqual({
-          initialAmountError: 'Initial amount must be greater than 0',
+          initialAmountError:
+            'Initial amount must be greater than or equal to 0',
         });
       });
     });

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/context.test.ts
@@ -67,6 +67,8 @@ const alreadyPopulatedContext: Erc20TokenStreamContext = {
     address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     balance: toHex(100_000_000), // 100 USDC (6 decimals)
     balanceFormattedAsCurrency: '$🐊100.00',
+  },
+  tokenMetadata: {
     symbol: 'USDC',
     decimals: USDC_DECIMALS,
   },
@@ -149,7 +151,7 @@ describe('erc20TokenStream:context', () => {
       mockTokenMetadataService = {
         getTokenBalanceAndMetadata: jest.fn(() => ({
           balance: BigInt(alreadyPopulatedContext.accountDetails.balance),
-          symbol: alreadyPopulatedContext.accountDetails.symbol,
+          symbol: alreadyPopulatedContext.tokenMetadata.symbol,
           decimals: USDC_DECIMALS,
         })),
       } as unknown as jest.Mocked<TokenMetadataService>;

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/context.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, beforeEach, it } from '@jest/globals';
-import { toHex, parseUnits } from 'viem/utils';
+import { maxUint256 } from 'viem';
+import { toHex } from 'viem/utils';
 
 import type { AccountController } from '../../../src/accountController';
 import { TimePeriod } from '../../../src/core/types';
@@ -8,71 +9,77 @@ import {
   buildContext,
   deriveMetadata,
   applyContext,
-} from '../../../src/permissions/nativeTokenPeriodic/context';
+} from '../../../src/permissions/erc20TokenStream/context';
 import type {
-  NativeTokenPeriodicContext,
-  NativeTokenPeriodicPermission,
-  NativeTokenPeriodicPermissionRequest,
-} from '../../../src/permissions/nativeTokenPeriodic/types';
+  Erc20TokenStreamContext,
+  Erc20TokenStreamPermission,
+  Erc20TokenStreamPermissionRequest,
+} from '../../../src/permissions/erc20TokenStream/types';
 import type { TokenMetadataService } from '../../../src/services/tokenMetadataService';
 import type { TokenPricesService } from '../../../src/services/tokenPricesService';
 import {
   convertTimestampToReadableDate,
   convertReadableDateToTimestamp,
-  TIME_PERIOD_TO_SECONDS,
 } from '../../../src/utils/time';
 
-const permissionWithoutOptionals: NativeTokenPeriodicPermission = {
-  type: 'native-token-periodic',
+const USDC_ADDRESS = '0xA0b86a33E6417efb4e0Ba2b1e4E6FE87bbEf2B0F';
+const USDC_DECIMALS = 6;
+
+const permissionWithoutOptionals: Erc20TokenStreamPermission = {
+  type: 'erc20-token-stream',
   data: {
-    periodAmount: toHex(parseUnits('1', 18)), // 1 ETH per period
-    periodDuration: Number(TIME_PERIOD_TO_SECONDS[TimePeriod.DAILY]), // 1 day in seconds
-    startTime: convertReadableDateToTimestamp('10/26/1985'),
+    tokenAddress: USDC_ADDRESS,
+    amountPerSecond: toHex(500_000), // 0.5 USDC per second (6 decimals)
+    startTime: 499132800, // 10/26/1985,
     justification: 'Permission to do something important',
   },
 };
 
-const alreadyPopulatedPermission: NativeTokenPeriodicPermission = {
+const alreadyPopulatedPermission: Erc20TokenStreamPermission = {
   ...permissionWithoutOptionals,
   data: {
     ...permissionWithoutOptionals.data,
+    // 1 USDC
+    initialAmount: toHex(1_000_000),
+    // 10 USDC
+    maxAmount: toHex(10_000_000),
   },
   rules: {},
 };
 
-const alreadyPopulatedPermissionRequest: NativeTokenPeriodicPermissionRequest =
-  {
-    chainId: '0x1',
-    expiry: convertReadableDateToTimestamp('05/01/2024'),
-    signer: {
-      type: 'account',
-      data: {
-        address: '0x1',
-      },
+const alreadyPopulatedPermissionRequest: Erc20TokenStreamPermissionRequest = {
+  chainId: '0x1',
+  expiry: convertReadableDateToTimestamp('05/01/2024'),
+  signer: {
+    type: 'account',
+    data: {
+      address: '0x1',
     },
-    permission: alreadyPopulatedPermission,
-  };
+  },
+  permission: alreadyPopulatedPermission,
+};
 
-const alreadyPopulatedContext: NativeTokenPeriodicContext = {
+const alreadyPopulatedContext: Erc20TokenStreamContext = {
   expiry: '05/01/2024',
   isAdjustmentAllowed: true,
   justification: 'Permission to do something important',
   accountDetails: {
     address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-    balance: toHex(parseUnits('10', 18)),
-    balanceFormattedAsCurrency: '$🐊10.00',
-    symbol: 'ETH',
-    decimals: 18,
+    balance: toHex(100_000_000), // 100 USDC (6 decimals)
+    balanceFormattedAsCurrency: '$🐊100.00',
+    symbol: 'USDC',
+    decimals: USDC_DECIMALS,
   },
   permissionDetails: {
-    periodAmount: '1',
-    periodType: TimePeriod.DAILY,
-    periodDuration: Number(TIME_PERIOD_TO_SECONDS[TimePeriod.DAILY]).toString(),
+    initialAmount: '1',
+    maxAmount: '10',
+    timePeriod: TimePeriod.WEEKLY,
     startTime: '10/26/1985',
+    amountPerPeriod: '302400',
   },
 } as const;
 
-describe('nativeTokenPeriodic:context', () => {
+describe('erc20TokenStream:context', () => {
   describe('populatePermission()', () => {
     it('should return the permission unchanged if it is already populated', async () => {
       const populatedPermission = await populatePermission({
@@ -82,14 +89,32 @@ describe('nativeTokenPeriodic:context', () => {
       expect(populatedPermission).toStrictEqual(alreadyPopulatedPermission);
     });
 
-    it('should not override existing rules', async () => {
-      const permission: NativeTokenPeriodicPermission = {
-        type: 'native-token-periodic',
+    it('should add defaults to a permission', async () => {
+      const populatedPermission = await populatePermission({
+        permission: permissionWithoutOptionals,
+      });
+
+      expect(populatedPermission).toStrictEqual({
+        ...permissionWithoutOptionals,
         data: {
-          periodAmount: '0x1000000000000000000000000000000000000000',
-          periodDuration: 86400,
+          ...permissionWithoutOptionals.data,
+          initialAmount: '0x0',
+          maxAmount: toHex(maxUint256),
+        },
+        rules: {},
+      });
+    });
+
+    it('should not override existing rules', async () => {
+      const permission: Erc20TokenStreamPermission = {
+        type: 'erc20-token-stream',
+        data: {
+          initialAmount: '0x1000000000000000000000000000000000000000',
+          maxAmount: '0x1000000000000000000000000000000000000000',
+          amountPerSecond: '0x1000000000000000000000000000000000000000',
           startTime: 1714531200,
           justification: 'Permission to do something important',
+          tokenAddress: USDC_ADDRESS,
         },
         rules: {
           some: 'rule',
@@ -102,7 +127,7 @@ describe('nativeTokenPeriodic:context', () => {
     });
   });
 
-  describe('permissionRequestToContext()', () => {
+  describe('buildContext()', () => {
     let mockTokenPricesService: jest.Mocked<TokenPricesService>;
     let mockAccountController: jest.Mocked<AccountController>;
     let mockTokenMetadataService: jest.Mocked<TokenMetadataService>;
@@ -116,16 +141,16 @@ describe('nativeTokenPeriodic:context', () => {
       } as unknown as jest.Mocked<TokenPricesService>;
 
       mockAccountController = {
-        getAccountAddress: jest
-          .fn()
-          .mockResolvedValue(alreadyPopulatedContext.accountDetails.address),
+        getAccountAddress: jest.fn(
+          () => alreadyPopulatedContext.accountDetails.address,
+        ),
       } as unknown as jest.Mocked<AccountController>;
 
       mockTokenMetadataService = {
         getTokenBalanceAndMetadata: jest.fn(() => ({
           balance: BigInt(alreadyPopulatedContext.accountDetails.balance),
           symbol: alreadyPopulatedContext.accountDetails.symbol,
-          decimals: 18,
+          decimals: USDC_DECIMALS,
         })),
       } as unknown as jest.Mocked<TokenMetadataService>;
     });
@@ -149,14 +174,15 @@ describe('nativeTokenPeriodic:context', () => {
       ).toHaveBeenCalledWith({
         chainId: Number(alreadyPopulatedPermissionRequest.chainId),
         account: alreadyPopulatedContext.accountDetails.address,
+        assetAddress: USDC_ADDRESS,
       });
 
       expect(
         mockTokenPricesService.getCryptoToFiatConversion,
       ).toHaveBeenCalledWith(
-        `eip155:1/slip44:60`,
+        `eip155:1/erc20:${USDC_ADDRESS}`,
         alreadyPopulatedContext.accountDetails.balance,
-        18,
+        USDC_DECIMALS,
       );
     });
   });
@@ -177,124 +203,191 @@ describe('nativeTokenPeriodic:context', () => {
       });
 
       expect(metadata).toStrictEqual({
+        amountPerSecond: '0.5',
         validationErrors: {},
       });
     });
 
-    describe('periodAmount validation', () => {
+    describe('initialAmount validation', () => {
       it.each([['0x1234'], ['Steve']])(
-        'should return a validation error for invalid period amount %s',
-        async (periodAmount) => {
-          const contextWithInvalidPeriodAmount = {
+        'should return a validation error for invalid initial amount %s',
+        async (initialAmount) => {
+          const contextWithInvalidInitialAmount = {
             ...context,
             permissionDetails: {
               ...context.permissionDetails,
-              periodAmount,
+              initialAmount,
             },
           };
 
           const metadata = await deriveMetadata({
-            context: contextWithInvalidPeriodAmount,
+            context: contextWithInvalidInitialAmount,
           });
 
           expect(metadata.validationErrors).toStrictEqual({
-            periodAmountError: 'Invalid period amount',
+            initialAmountError: 'Invalid initial amount',
           });
         },
       );
 
-      it('should return a validation error for negative period amount', async () => {
-        const contextWithNegativePeriodAmount = {
+      it('should return a validation error for negative initial amount', async () => {
+        const contextWithNegativeInitialAmount = {
           ...context,
           permissionDetails: {
             ...context.permissionDetails,
-            periodAmount: '-1',
+            initialAmount: '-1',
           },
         };
 
         const metadata = await deriveMetadata({
-          context: contextWithNegativePeriodAmount,
+          context: contextWithNegativeInitialAmount,
         });
 
         expect(metadata.validationErrors).toStrictEqual({
-          periodAmountError: 'Period amount must be greater than 0',
+          initialAmountError: 'Initial amount must be greater than 0',
         });
       });
     });
 
-    describe('periodDuration validation', () => {
-      it('should return a validation error for invalid period duration', async () => {
-        const contextWithInvalidPeriodDuration = {
+    describe('maxAmount validation', () => {
+      it('should return a validation error for initial amount greater than max amount', async () => {
+        const contextWithInitialAmountGreaterThanMaxAmount = {
           ...context,
           permissionDetails: {
             ...context.permissionDetails,
-            periodDuration: 'invalid',
+            initialAmount: '10',
+            maxAmount: '1',
           },
         };
 
         const metadata = await deriveMetadata({
-          context: contextWithInvalidPeriodDuration,
+          context: contextWithInitialAmountGreaterThanMaxAmount,
         });
 
         expect(metadata.validationErrors).toStrictEqual({
-          periodDurationError: 'Period duration must be greater than 0',
+          maxAmountError: 'Max amount must be greater than initial amount',
         });
       });
 
-      it('should return a validation error for negative period duration', async () => {
-        const contextWithNegativePeriodDuration = {
+      it.each([['0x1234'], ['Steve']])(
+        'should return a validation error for invalid max amount %s',
+        async (maxAmount) => {
+          const contextWithInvalidMaxAmount = {
+            ...context,
+            permissionDetails: {
+              ...context.permissionDetails,
+              maxAmount,
+            },
+          };
+
+          const metadata = await deriveMetadata({
+            context: contextWithInvalidMaxAmount,
+          });
+
+          expect(metadata.validationErrors).toStrictEqual({
+            maxAmountError: 'Invalid max amount',
+          });
+        },
+      );
+
+      it('should return a validation error for negative max amount', async () => {
+        const contextWithNegativeMaxAmount = {
           ...context,
           permissionDetails: {
             ...context.permissionDetails,
-            periodDuration: '-1',
+            maxAmount: '-1',
           },
         };
 
         const metadata = await deriveMetadata({
-          context: contextWithNegativePeriodDuration,
+          context: contextWithNegativeMaxAmount,
         });
 
         expect(metadata.validationErrors).toStrictEqual({
-          periodDurationError: 'Period duration must be greater than 0',
+          maxAmountError: 'Max amount must be greater than 0',
         });
       });
     });
 
-    describe('startTime validation', () => {
-      it('should return a validation error for invalid start time', async () => {
-        const contextWithInvalidStartTime = {
+    describe('amountPerPeriod validation', () => {
+      it.each([['0x1234'], ['Steve']])(
+        'should return a validation error for invalid amount per period %s',
+        async (amountPerPeriod) => {
+          const contextWithInvalidAmountPerPeriod = {
+            ...context,
+            permissionDetails: {
+              ...context.permissionDetails,
+              amountPerPeriod,
+            },
+          };
+
+          const metadata = await deriveMetadata({
+            context: contextWithInvalidAmountPerPeriod,
+          });
+
+          expect(metadata.validationErrors).toStrictEqual({
+            amountPerPeriodError: 'Invalid amount per period',
+          });
+        },
+      );
+
+      it('should return a validation error for negative amount per period', async () => {
+        const contextWithNegativeAmountPerPeriod = {
           ...context,
           permissionDetails: {
             ...context.permissionDetails,
-            startTime: 'invalid',
+            amountPerPeriod: '-1',
           },
         };
 
         const metadata = await deriveMetadata({
-          context: contextWithInvalidStartTime,
+          context: contextWithNegativeAmountPerPeriod,
         });
 
         expect(metadata.validationErrors).toStrictEqual({
-          startTimeError: 'Invalid start time',
+          amountPerPeriodError: 'Amount per period must be greater than 0',
         });
       });
 
-      it('should return a validation error for start time in the past', async () => {
-        const contextWithPastStartTime = {
-          ...context,
-          permissionDetails: {
-            ...context.permissionDetails,
-            startTime: '01/01/2020',
+      describe('startTime validation', () => {
+        it('should return a validation error for startTime in the past', async () => {
+          const contextWithStartTimeInThePast = {
+            ...context,
+            permissionDetails: {
+              ...context.permissionDetails,
+              startTime: '10/26/1985',
+            },
+          };
+
+          const metadata = await deriveMetadata({
+            context: contextWithStartTimeInThePast,
+          });
+
+          expect(metadata.validationErrors).toStrictEqual({
+            startTimeError: 'Start time must be today or later',
+          });
+        });
+
+        it.each([['12345678'], ['0x1234'], ['Steve']])(
+          'should return a validation error for invalid startTime %s',
+          async (startTime) => {
+            const contextWithInvalidStartTime = {
+              ...context,
+              permissionDetails: {
+                ...context.permissionDetails,
+                startTime,
+              },
+            };
+
+            const metadata = await deriveMetadata({
+              context: contextWithInvalidStartTime,
+            });
+
+            expect(metadata.validationErrors).toStrictEqual({
+              startTimeError: 'Invalid start time',
+            });
           },
-        };
-
-        const metadata = await deriveMetadata({
-          context: contextWithPastStartTime,
-        });
-
-        expect(metadata.validationErrors).toStrictEqual({
-          startTimeError: 'Start time must be today or later',
-        });
+        );
       });
     });
 

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/validation.test.ts
@@ -72,7 +72,7 @@ describe('erc20TokenStream:validation', () => {
         };
 
         expect(() => parseAndValidatePermission(zeroMaxAmountRequest)).toThrow(
-          'Invalid maxAmount: must be a positive number',
+          'Invalid maxAmount: must be greater than 0',
         );
       });
 
@@ -110,7 +110,7 @@ describe('erc20TokenStream:validation', () => {
 
         expect(() =>
           parseAndValidatePermission(zeroInitialAmountRequest),
-        ).toThrow('Invalid initialAmount: must be greater than zero');
+        ).toThrow('Invalid initialAmount: must be greater than 0');
       });
 
       it('should allow missing initialAmount', () => {
@@ -146,7 +146,7 @@ describe('erc20TokenStream:validation', () => {
 
         expect(() =>
           parseAndValidatePermission(zeroAmountPerSecondRequest),
-        ).toThrow('Invalid amountPerSecond: must be a positive number');
+        ).toThrow('Invalid amountPerSecond: must be greater than 0');
       });
     });
 

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/validation.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from '@jest/globals';
+import { toHex, parseUnits } from 'viem/utils';
+
+import type { Erc20TokenStreamPermissionRequest } from '../../../src/permissions/erc20TokenStream/types';
+import { parseAndValidatePermission } from '../../../src/permissions/erc20TokenStream/validation';
+import { convertReadableDateToTimestamp } from '../../../src/utils/time';
+
+const tokenDecimals = 10;
+
+const validPermissionRequest: Erc20TokenStreamPermissionRequest = {
+  chainId: '0x1',
+  expiry: convertReadableDateToTimestamp('05/01/2024'),
+  isAdjustmentAllowed: true,
+  signer: {
+    type: 'account',
+    data: {
+      address: '0x1',
+    },
+  },
+  permission: {
+    type: 'erc20-token-stream',
+    data: {
+      initialAmount: toHex(parseUnits('1', tokenDecimals)), // 1 token
+      maxAmount: toHex(parseUnits('10', tokenDecimals)), // 10 tokens
+      amountPerSecond: toHex(parseUnits('.5', tokenDecimals)), // 0.5 tokens per second
+      startTime: convertReadableDateToTimestamp('10/26/2024'),
+      tokenAddress: '0x1234567890123456789012345678901234567890',
+      justification: 'test',
+    },
+    rules: {},
+  },
+};
+
+describe('erc20TokenStream:validation', () => {
+  describe('parseAndValidatePermission()', () => {
+    it('should validate a valid permission request', () => {
+      expect(() =>
+        parseAndValidatePermission(validPermissionRequest),
+      ).not.toThrow();
+
+      const result = parseAndValidatePermission(validPermissionRequest);
+      expect(result).toStrictEqual(validPermissionRequest);
+    });
+
+    it('should throw for invalid permission type', () => {
+      const invalidTypeRequest = {
+        ...validPermissionRequest,
+        permission: {
+          ...validPermissionRequest.permission,
+          type: 'invalid-type',
+        },
+      };
+
+      expect(() =>
+        parseAndValidatePermission(invalidTypeRequest as any),
+      ).toThrow(
+        'Failed type validation: type: Invalid literal value, expected "erc20-token-stream"',
+      );
+    });
+
+    describe('maxAmount validation', () => {
+      it('should throw for zero maxAmount', () => {
+        const zeroMaxAmountRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+              maxAmount: '0x0' as `0x${string}`,
+            },
+          },
+        };
+
+        expect(() => parseAndValidatePermission(zeroMaxAmountRequest)).toThrow(
+          'Invalid maxAmount: must be a positive number',
+        );
+      });
+
+      it('should throw when maxAmount is less than initialAmount', () => {
+        const invalidMaxAmountRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+              maxAmount: toHex(parseUnits('0.5', tokenDecimals)), // 0.5 tokens
+              initialAmount: toHex(parseUnits('1', tokenDecimals)), // 1 token
+            },
+          },
+        };
+
+        expect(() =>
+          parseAndValidatePermission(invalidMaxAmountRequest),
+        ).toThrow('Invalid maxAmount: must be greater than initialAmount');
+      });
+    });
+
+    describe('initialAmount validation', () => {
+      it('should throw for zero initialAmount', () => {
+        const zeroInitialAmountRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+              initialAmount: '0x0' as `0x${string}`,
+            },
+          },
+        };
+
+        expect(() =>
+          parseAndValidatePermission(zeroInitialAmountRequest),
+        ).toThrow('Invalid initialAmount: must be greater than zero');
+      });
+
+      it('should allow missing initialAmount', () => {
+        const noInitialAmountRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+            },
+          },
+        };
+        delete noInitialAmountRequest.permission.data.initialAmount;
+
+        expect(() =>
+          parseAndValidatePermission(noInitialAmountRequest),
+        ).not.toThrow();
+      });
+    });
+
+    describe('amountPerSecond validation', () => {
+      it('should throw for zero amountPerSecond', () => {
+        const zeroAmountPerSecondRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+              amountPerSecond: '0x0' as `0x${string}`,
+            },
+          },
+        };
+
+        expect(() =>
+          parseAndValidatePermission(zeroAmountPerSecondRequest),
+        ).toThrow('Invalid amountPerSecond: must be a positive number');
+      });
+    });
+
+    describe('startTime validation', () => {
+      it('should throw for negative startTime', () => {
+        const negativeStartTimeRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+              startTime: -1,
+            },
+          },
+        };
+
+        expect(() =>
+          parseAndValidatePermission(negativeStartTimeRequest),
+        ).toThrow('Invalid startTime: must be a positive number');
+      });
+
+      it('should throw for zero startTime', () => {
+        const zeroStartTimeRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+              startTime: 0,
+            },
+          },
+        };
+
+        expect(() => parseAndValidatePermission(zeroStartTimeRequest)).toThrow(
+          'Invalid startTime: must be a positive number',
+        );
+      });
+
+      it('should throw for non-integer startTime', () => {
+        const floatStartTimeRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+              startTime: 1.5,
+            },
+          },
+        };
+
+        expect(() => parseAndValidatePermission(floatStartTimeRequest)).toThrow(
+          'Invalid startTime: must be an integer',
+        );
+      });
+    });
+
+    describe('tokenAddress validation', () => {
+      it('should throw for invalid token address', () => {
+        const invalidTokenAddressRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+              tokenAddress: '0xinvalid',
+            },
+          },
+        };
+
+        expect(() =>
+          parseAndValidatePermission(invalidTokenAddressRequest),
+        ).toThrow(
+          'Failed type validation: data.tokenAddress: Invalid hex value',
+        );
+      });
+
+      it('should throw for missing token address', () => {
+        const missingTokenAddressRequest = {
+          ...validPermissionRequest,
+          permission: {
+            ...validPermissionRequest.permission,
+            data: {
+              ...validPermissionRequest.permission.data,
+            },
+          },
+        };
+        delete (missingTokenAddressRequest.permission.data as any).tokenAddress;
+
+        expect(() =>
+          parseAndValidatePermission(missingTokenAddressRequest),
+        ).toThrow('Failed type validation: data.tokenAddress: Required');
+      });
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
@@ -17,6 +17,8 @@ const mockContext: NativeTokenPeriodicContext = {
     address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     balance: toHex(parseUnits('10', 18)),
     balanceFormattedAsCurrency: '$🐊10.00',
+  },
+  tokenMetadata: {
     symbol: 'ETH',
     decimals: 18,
   },

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
@@ -18,6 +18,7 @@ const mockContext: NativeTokenPeriodicContext = {
     balance: toHex(parseUnits('10', 18)),
     balanceFormattedAsCurrency: '$🐊10.00',
     symbol: 'ETH',
+    decimals: 18,
   },
   permissionDetails: {
     periodAmount: '1',

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/context.test.ts
@@ -62,6 +62,7 @@ const alreadyPopulatedContext: NativeTokenPeriodicContext = {
     balance: toHex(parseUnits('10', 18)),
     balanceFormattedAsCurrency: '$🐊10.00',
     symbol: 'ETH',
+    decimals: 18,
   },
   permissionDetails: {
     periodAmount: '1',
@@ -155,6 +156,7 @@ describe('nativeTokenPeriodic:context', () => {
       ).toHaveBeenCalledWith(
         `eip155:1/slip44:60`,
         alreadyPopulatedContext.accountDetails.balance,
+        18,
       );
     });
   });

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/context.test.ts
@@ -61,6 +61,8 @@ const alreadyPopulatedContext: NativeTokenPeriodicContext = {
     address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     balance: toHex(parseUnits('10', 18)),
     balanceFormattedAsCurrency: '$🐊10.00',
+  },
+  tokenMetadata: {
     symbol: 'ETH',
     decimals: 18,
   },
@@ -124,7 +126,7 @@ describe('nativeTokenPeriodic:context', () => {
       mockTokenMetadataService = {
         getTokenBalanceAndMetadata: jest.fn(() => ({
           balance: BigInt(alreadyPopulatedContext.accountDetails.balance),
-          symbol: alreadyPopulatedContext.accountDetails.symbol,
+          symbol: alreadyPopulatedContext.tokenMetadata.symbol,
           decimals: 18,
         })),
       } as unknown as jest.Mocked<TokenMetadataService>;

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/validation.test.ts
@@ -73,7 +73,7 @@ describe('nativeTokenPeriodic:validation', () => {
 
         expect(() =>
           parseAndValidatePermission(zeroPeriodAmountRequest),
-        ).toThrow('Invalid periodAmount: must be a positive number');
+        ).toThrow('Invalid periodAmount: must be greater than 0');
       });
     });
 

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
@@ -31,7 +31,6 @@ const mockContext: NativeTokenStreamContext = {
 const mockMetadata: NativeTokenStreamMetadata = {
   amountPerSecond: '0.5',
   validationErrors: {},
-  rulesToAdd: [],
 };
 
 describe('nativeTokenStream:content', () => {
@@ -3345,7 +3344,6 @@ describe('nativeTokenStream:content', () => {
         },
         metadata: {
           ...mockMetadata,
-          rulesToAdd: ['Initial amount', 'Max amount'],
         },
         isJustificationCollapsed: true,
         origin: 'https://example.com',
@@ -4286,7 +4284,6 @@ describe('nativeTokenStream:content', () => {
         },
         metadata: {
           ...mockMetadata,
-          rulesToAdd: ['Initial amount', 'Max amount'],
         },
         isJustificationCollapsed: true,
         origin: 'https://example.com',

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
@@ -16,6 +16,8 @@ const mockContext: NativeTokenStreamContext = {
     address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     balance: toHex(parseUnits('10', 18)),
     balanceFormattedAsCurrency: '$🐊10.00',
+  },
+  tokenMetadata: {
     symbol: 'ETH',
     decimals: 18,
   },

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
@@ -17,6 +17,7 @@ const mockContext: NativeTokenStreamContext = {
     balance: toHex(parseUnits('10', 18)),
     balanceFormattedAsCurrency: '$🐊10.00',
     symbol: 'ETH',
+    decimals: 18,
   },
   permissionDetails: {
     initialAmount: '1',

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
@@ -240,7 +240,8 @@ describe('nativeTokenStream:context', () => {
         });
 
         expect(metadata.validationErrors).toStrictEqual({
-          initialAmountError: 'Initial amount must be greater than 0',
+          initialAmountError:
+            'Initial amount must be greater than or equal to 0',
         });
       });
     });

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
@@ -63,6 +63,8 @@ const alreadyPopulatedContext: NativeTokenStreamContext = {
     address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     balance: toHex(parseUnits('10', 18)),
     balanceFormattedAsCurrency: '$🐊10.00',
+  },
+  tokenMetadata: {
     symbol: 'ETH',
     decimals: 18,
   },
@@ -144,7 +146,7 @@ describe('nativeTokenStream:context', () => {
       mockTokenMetadataService = {
         getTokenBalanceAndMetadata: jest.fn(() => ({
           balance: BigInt(alreadyPopulatedContext.accountDetails.balance),
-          symbol: alreadyPopulatedContext.accountDetails.symbol,
+          symbol: alreadyPopulatedContext.tokenMetadata.symbol,
           decimals: 18,
         })),
       } as unknown as jest.Mocked<TokenMetadataService>;

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
@@ -64,6 +64,7 @@ const alreadyPopulatedContext: NativeTokenStreamContext = {
     balance: toHex(parseUnits('10', 18)),
     balanceFormattedAsCurrency: '$🐊10.00',
     symbol: 'ETH',
+    decimals: 18,
   },
   permissionDetails: {
     initialAmount: '1',
@@ -175,6 +176,7 @@ describe('nativeTokenStream:context', () => {
       ).toHaveBeenCalledWith(
         `eip155:1/slip44:60`,
         alreadyPopulatedContext.accountDetails.balance,
+        18,
       );
     });
   });

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
@@ -184,7 +184,7 @@ describe('nativeTokenStream:context', () => {
   describe('createContextMetadata()', () => {
     const context = {
       ...alreadyPopulatedContext,
-      expiry: convertTimestampToReadableDate(Date.now()),
+      expiry: convertTimestampToReadableDate(Date.now() / 1000 + 24 * 60 * 60), // 24 hours from now
       permissionDetails: {
         ...alreadyPopulatedContext.permissionDetails,
         startTime: convertTimestampToReadableDate(Date.now() / 1000),

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
@@ -199,7 +199,6 @@ describe('nativeTokenStream:context', () => {
       expect(metadata).toStrictEqual({
         amountPerSecond: '0.5',
         validationErrors: {},
-        rulesToAdd: [],
       });
     });
 

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/validation.test.ts
@@ -69,7 +69,7 @@ describe('nativeTokenStream:validation', () => {
         };
 
         expect(() => parseAndValidatePermission(zeroMaxAmountRequest)).toThrow(
-          'Invalid maxAmount: must be a positive number',
+          'Invalid maxAmount: must be greater than 0',
         );
       });
 
@@ -107,7 +107,7 @@ describe('nativeTokenStream:validation', () => {
 
         expect(() =>
           parseAndValidatePermission(zeroInitialAmountRequest),
-        ).toThrow('Invalid initialAmount: must be greater than zero');
+        ).toThrow('Invalid initialAmount: must be greater than 0');
       });
 
       it('should allow missing initialAmount', () => {
@@ -143,7 +143,7 @@ describe('nativeTokenStream:validation', () => {
 
         expect(() =>
           parseAndValidatePermission(zeroAmountPerSecondRequest),
-        ).toThrow('Invalid amountPerSecond: must be a positive number');
+        ).toThrow('Invalid amountPerSecond: must be greater than 0');
       });
     });
 

--- a/packages/gator-permissions-snap/test/permissions/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/validation.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from '@jest/globals';
+import type { Hex } from 'viem';
+
+import { validateHexInteger } from '../../src/permissions/validation';
+
+describe('validateHexInteger', () => {
+  describe('valid cases', () => {
+    it('should pass for valid hex integers', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0x1' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).not.toThrow();
+
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0xFF' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).not.toThrow();
+
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0x123456789ABCDEF' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).not.toThrow();
+    });
+
+    it('should pass for zero values when allowZero is true', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0x0' as Hex,
+          allowZero: true,
+          required: true,
+        }),
+      ).not.toThrow();
+    });
+
+    it('should pass for undefined values when not required', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: undefined,
+          allowZero: false,
+          required: false,
+        }),
+      ).not.toThrow();
+
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: undefined,
+          allowZero: true,
+          required: false,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('required validation', () => {
+    it('should throw error when value is undefined and required is true', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: undefined,
+          allowZero: false,
+          required: true,
+        }),
+      ).toThrow('Invalid testValue: must be defined');
+    });
+
+    it('should throw error when value is null and required is true', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: null as any,
+          allowZero: false,
+          required: true,
+        }),
+      ).toThrow('Invalid testValue: must be defined');
+    });
+
+    it('should use the provided name in error messages', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'customFieldName',
+          value: undefined,
+          allowZero: false,
+          required: true,
+        }),
+      ).toThrow('Invalid customFieldName: must be defined');
+    });
+  });
+
+  describe('hex format validation', () => {
+    it('should throw error for invalid hex strings', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: 'invalid' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).toThrow('Invalid testValue: must be a valid hex integer');
+
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0xGG' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).toThrow('Invalid testValue: must be a valid hex integer');
+
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: 'notahex' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).toThrow('Invalid testValue: must be a valid hex integer');
+    });
+  });
+
+  describe('zero value validation', () => {
+    it('should throw error for zero values when allowZero is false', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0x0' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).toThrow('Invalid testValue: must be greater than 0');
+
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0x00' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).toThrow('Invalid testValue: must be greater than 0');
+    });
+
+    it('should accept zero values when allowZero is true', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0x0' as Hex,
+          allowZero: true,
+          required: true,
+        }),
+      ).not.toThrow();
+
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0x00' as Hex,
+          allowZero: true,
+          required: true,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle large hex values', () => {
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value:
+            '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).not.toThrow();
+    });
+
+    it('should handle hex values without 0x prefix if BigInt can parse them', () => {
+      // Note: This test depends on how BigInt handles strings without 0x prefix
+      // BigInt('1') should work, but BigInt('FF') might not work as hex
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '1' as Hex,
+          allowZero: false,
+          required: true,
+        }),
+      ).not.toThrow();
+    });
+
+    it('should handle different parameter combinations', () => {
+      // Non-required, allowZero false, undefined value
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: undefined,
+          allowZero: false,
+          required: false,
+        }),
+      ).not.toThrow();
+
+      // Non-required, allowZero true, undefined value
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: undefined,
+          allowZero: true,
+          required: false,
+        }),
+      ).not.toThrow();
+
+      // Required, allowZero true, valid non-zero value
+      expect(() =>
+        validateHexInteger({
+          name: 'testValue',
+          value: '0x1' as Hex,
+          allowZero: true,
+          required: true,
+        }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/service/tokenPricesService.test.ts
+++ b/packages/gator-permissions-snap/test/service/tokenPricesService.test.ts
@@ -30,6 +30,7 @@ describe('TokenPricesService', () => {
           await tokenPricesService.getCryptoToFiatConversion(
             'eip155:1/slip44:60',
             toHex(parseUnits('.01', 18)), // 1 ETH in wei
+            18,
           );
 
         expect(humanReadableValue).toBe('$10.00');
@@ -54,6 +55,7 @@ describe('TokenPricesService', () => {
           await tokenPricesService.getCryptoToFiatConversion(
             'eip155:1/slip44:60',
             toHex(parseUnits('.01', 18)), // 1 ETH in wei
+            18,
           );
 
         expect(humanReadableValue).toBe('$10.00');
@@ -78,6 +80,7 @@ describe('TokenPricesService', () => {
           await tokenPricesService.getCryptoToFiatConversion(
             'eip155:1/slip44:60',
             toHex(parseUnits('.5', 18)), // 1 ETH in wei
+            18,
           );
 
         expect(humanReadableValue).toBe('$500.00');
@@ -102,6 +105,7 @@ describe('TokenPricesService', () => {
           await tokenPricesService.getCryptoToFiatConversion(
             'eip155:1/slip44:60',
             toHex(parseUnits('1', 18)), // 1 ETH in wei
+            18,
           );
 
         expect(humanReadableValue).toBe('$1,000.00');
@@ -126,6 +130,7 @@ describe('TokenPricesService', () => {
           await tokenPricesService.getCryptoToFiatConversion(
             'eip155:1/slip44:60',
             toHex(parseUnits('1.5', 18)), // 1.5 ETH in wei
+            18,
           );
 
         expect(humanReadableValue).toBe('$1,500.00');
@@ -150,6 +155,7 @@ describe('TokenPricesService', () => {
           await tokenPricesService.getCryptoToFiatConversion(
             'eip155:1/slip44:60',
             toHex(parseUnits('.01', 18)), // 1 ETH in wei
+            18,
           );
 
         expect(humanReadableValue).toBe('$<-->');

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "VvmzRf0CQohjyCGxQipja9d4Ghoq1q9w5kAJryTTw/8=",
+    "shasum": "S0ov2EamT+yz9yJnmK+pFZ5q8knPzSppoKBYMKfHSX8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "eRjmPTGFoDn0TmSiFtw7F6sYLP+OInKhcDoSPgOK2Wg=",
+    "shasum": "S0ov2EamT+yz9yJnmK+pFZ5q8knPzSppoKBYMKfHSX8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "S0ov2EamT+yz9yJnmK+pFZ5q8knPzSppoKBYMKfHSX8=",
+    "shasum": "eRjmPTGFoDn0TmSiFtw7F6sYLP+OInKhcDoSPgOK2Wg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/permissions-kernel-snap/src/permissions/index.ts
+++ b/packages/permissions-kernel-snap/src/permissions/index.ts
@@ -1,1 +1,2 @@
 export * from './origin';
+export * from './validation';

--- a/packages/permissions-kernel-snap/src/permissions/index.ts
+++ b/packages/permissions-kernel-snap/src/permissions/index.ts
@@ -1,2 +1,1 @@
 export * from './origin';
-export * from './validation';

--- a/packages/permissions-kernel-snap/test/constants.ts
+++ b/packages/permissions-kernel-snap/test/constants.ts
@@ -25,6 +25,13 @@ export const TEST_CASE_DEFAULT_STATE: KernelState = {
         proposedName: 'Native Token Periodic Transfer',
         type: 'native-token-periodic',
       },
+      {
+        hostId: 'npm:@metamask/gator-permissions-snap',
+        hostPermissionId:
+          '993eae62e4a0f122d7781f98ef0bcd611eacb051a7ee44b8990ad49c49e6c3e8',
+        proposedName: 'ERC20 Token Stream',
+        type: 'erc20-token-stream',
+      },
     ],
   },
 };

--- a/packages/shared/src/utils/snap-permission-registry.ts
+++ b/packages/shared/src/utils/snap-permission-registry.ts
@@ -12,6 +12,10 @@ export const DEFAULT_OFFERS: GatorPermission[] = [
     type: 'native-token-periodic',
     proposedName: 'Native Token Periodic Transfer',
   },
+  {
+    type: 'erc20-token-stream',
+    proposedName: 'ERC20 Token Stream',
+  },
 ];
 
 /**

--- a/packages/site/src/components/permissions/ERC20TokenStreamForm.tsx
+++ b/packages/site/src/components/permissions/ERC20TokenStreamForm.tsx
@@ -10,14 +10,16 @@ type ERC20TokenStreamFormProps = {
 export const ERC20TokenStreamForm = ({
   onChange,
 }: ERC20TokenStreamFormProps) => {
+  const decimals = 6;
+
   const [initialAmount, setInitialAmount] = useState<bigint | null>(
-    BigInt(toHex(parseUnits('.5', 18))),
+    BigInt(toHex(parseUnits('.5', decimals))),
   );
   const [amountPerSecond, setAmountPerSecond] = useState(
-    BigInt(toHex(parseUnits('.5', 18))),
+    BigInt(toHex(parseUnits('.5', decimals))),
   );
   const [maxAmount, setMaxAmount] = useState<bigint | null>(
-    BigInt(toHex(parseUnits('2.5', 18))),
+    BigInt(toHex(parseUnits('2.5', decimals))),
   );
   const [startTime, setStartTime] = useState(Math.floor(Date.now() / 1000));
   const [expiry, setExpiry] = useState(

--- a/packages/site/src/components/permissions/ERC20TokenStreamForm.tsx
+++ b/packages/site/src/components/permissions/ERC20TokenStreamForm.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useState } from 'react';
+import { parseUnits, toHex, type Hex } from 'viem';
+import { StyledForm } from './styles';
+import type { ERC20TokenStreamPermissionRequest } from './types';
+
+type ERC20TokenStreamFormProps = {
+  onChange: (request: ERC20TokenStreamPermissionRequest) => void;
+};
+
+export const ERC20TokenStreamForm = ({
+  onChange,
+}: ERC20TokenStreamFormProps) => {
+  const [initialAmount, setInitialAmount] = useState<bigint | null>(
+    BigInt(toHex(parseUnits('.5', 18))),
+  );
+  const [amountPerSecond, setAmountPerSecond] = useState(
+    BigInt(toHex(parseUnits('.5', 18))),
+  );
+  const [maxAmount, setMaxAmount] = useState<bigint | null>(
+    BigInt(toHex(parseUnits('2.5', 18))),
+  );
+  const [startTime, setStartTime] = useState(Math.floor(Date.now() / 1000));
+  const [expiry, setExpiry] = useState(
+    Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30, // 30 days from now
+  );
+  const [justification, setJustification] = useState(
+    'This is a very important request for streaming allowance for some very important thing',
+  );
+  const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
+  const [tokenAddress, setTokenAddress] = useState<Hex>(
+    '0x616553f076c6f66739a99fef373c6b4ae1b22a7a', // Consensys USDC
+  );
+
+  const handleInitialAmountChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputValue.trim() === '') {
+        setInitialAmount(null);
+      } else {
+        setInitialAmount(BigInt(inputValue));
+      }
+    },
+    [],
+  );
+
+  const handleAmountPerSecondChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setAmountPerSecond(BigInt(inputValue));
+    },
+    [],
+  );
+
+  const handleMaxAmountChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputValue.trim() === '') {
+        setMaxAmount(null);
+      } else {
+        setMaxAmount(BigInt(inputValue));
+      }
+    },
+    [],
+  );
+
+  const handleStartTimeChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setStartTime(Number(inputValue));
+    },
+    [],
+  );
+
+  const handleJustificationChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setJustification(inputValue);
+    },
+    [],
+  );
+
+  const handleExpiryChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setExpiry(Number(inputValue));
+    },
+    [],
+  );
+
+  const handleIsAdjustmentAllowedChange = useCallback(
+    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+      setIsAdjustmentAllowed(checked);
+    },
+    [],
+  );
+
+  const handleTokenAddressChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setTokenAddress(inputValue as Hex);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    onChange({
+      type: 'erc20-token-stream',
+      initialAmount: initialAmount ? toHex(initialAmount) : null,
+      amountPerSecond: toHex(amountPerSecond),
+      maxAmount: maxAmount ? toHex(maxAmount) : null,
+      startTime,
+      expiry,
+      justification,
+      isAdjustmentAllowed,
+      tokenAddress,
+    });
+  }, [
+    onChange,
+    initialAmount,
+    amountPerSecond,
+    maxAmount,
+    startTime,
+    expiry,
+    justification,
+    isAdjustmentAllowed,
+    tokenAddress,
+  ]);
+
+  return (
+    <StyledForm>
+      <div>
+        <label htmlFor="tokenAddress">Token Address:</label>
+        <input
+          type="text"
+          id="tokenAddress"
+          name="tokenAddress"
+          value={tokenAddress}
+          onChange={handleTokenAddressChange}
+          placeholder="0x..."
+        />
+      </div>
+      <div>
+        <label htmlFor="initialAmount">Initial Amount:</label>
+        <input
+          type="text"
+          id="initialAmount"
+          name="initialAmount"
+          value={initialAmount?.toString()}
+          onChange={handleInitialAmountChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="amountPerSecond">Amount Per Second:</label>
+        <input
+          type="text"
+          id="amountPerSecond"
+          name="amountPerSecond"
+          value={amountPerSecond.toString()}
+          onChange={handleAmountPerSecondChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="maxAmount">Max Amount:</label>
+        <input
+          type="text"
+          id="maxAmount"
+          name="maxAmount"
+          value={maxAmount?.toString()}
+          onChange={handleMaxAmountChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="startTime">Start Time:</label>
+        <input
+          type="number"
+          id="startTime"
+          name="startTime"
+          value={startTime}
+          onChange={handleStartTimeChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="justification">Justification:</label>
+        <textarea
+          id="justification"
+          name="justification"
+          rows={3}
+          value={justification}
+          onChange={handleJustificationChange}
+        ></textarea>
+      </div>
+      <div>
+        <label htmlFor="expiry">Expiry:</label>
+        <input
+          type="number"
+          id="expiry"
+          name="expiry"
+          value={expiry}
+          onChange={handleExpiryChange}
+        />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <label htmlFor="isAdjustmentAllowed">Allow Adjustments:</label>
+        <input
+          type="checkbox"
+          id="isAdjustmentAllowed"
+          name="isAdjustmentAllowed"
+          checked={isAdjustmentAllowed}
+          onChange={handleIsAdjustmentAllowedChange}
+          style={{ width: 'auto', marginLeft: '1rem' }}
+        />
+      </div>
+    </StyledForm>
+  );
+};

--- a/packages/site/src/components/permissions/NativeTokenPeriodicForm.tsx
+++ b/packages/site/src/components/permissions/NativeTokenPeriodicForm.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useState } from 'react';
+import { parseUnits, toHex } from 'viem';
+import { StyledForm } from './styles';
+import type { NativeTokenPeriodicPermissionRequest } from './types';
+
+type NativeTokenPeriodicFormProps = {
+  onChange: (request: NativeTokenPeriodicPermissionRequest) => void;
+};
+
+export const NativeTokenPeriodicForm = ({
+  onChange,
+}: NativeTokenPeriodicFormProps) => {
+  const [periodAmount, setPeriodAmount] = useState(
+    BigInt(toHex(parseUnits('1', 18))),
+  );
+  const [periodDuration, setPeriodDuration] = useState(2592000); // 30 days in seconds
+  const [startTime, setStartTime] = useState(Math.floor(Date.now() / 1000));
+  const [expiry, setExpiry] = useState(
+    Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30, // 30 days from now
+  );
+  const [justification, setJustification] = useState(
+    'This is a very important request for periodic allowance for some very important thing',
+  );
+  const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
+
+  const handlePeriodAmountChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setPeriodAmount(BigInt(inputValue));
+    },
+    [],
+  );
+
+  const handlePeriodDurationChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setPeriodDuration(Number(inputValue));
+    },
+    [],
+  );
+
+  const handleStartTimeChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setStartTime(Number(inputValue));
+    },
+    [],
+  );
+
+  const handleJustificationChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setJustification(inputValue);
+    },
+    [],
+  );
+
+  const handleExpiryChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setExpiry(Number(inputValue));
+    },
+    [],
+  );
+
+  const handleIsAdjustmentAllowedChange = useCallback(
+    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+      setIsAdjustmentAllowed(checked);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    onChange({
+      type: 'native-token-periodic',
+      periodAmount: toHex(periodAmount),
+      periodDuration,
+      startTime,
+      expiry,
+      justification,
+      isAdjustmentAllowed,
+    });
+  }, [
+    onChange,
+    periodAmount,
+    periodDuration,
+    startTime,
+    expiry,
+    justification,
+    isAdjustmentAllowed,
+  ]);
+
+  return (
+    <StyledForm>
+      <div>
+        <label htmlFor="periodAmount">Period Amount:</label>
+        <input
+          type="text"
+          id="periodAmount"
+          name="periodAmount"
+          value={periodAmount.toString()}
+          onChange={handlePeriodAmountChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="periodDuration">Period Duration:</label>
+        <input
+          type="number"
+          id="periodDuration"
+          name="periodDuration"
+          value={periodDuration}
+          onChange={handlePeriodDurationChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="startTime">Start Time:</label>
+        <input
+          type="number"
+          id="startTime"
+          name="startTime"
+          value={startTime}
+          onChange={handleStartTimeChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="justification">Justification:</label>
+        <textarea
+          id="justification"
+          name="justification"
+          rows={3}
+          value={justification}
+          onChange={handleJustificationChange}
+        ></textarea>
+      </div>
+      <div>
+        <label htmlFor="expiry">Expiry:</label>
+        <input
+          type="number"
+          id="expiry"
+          name="expiry"
+          value={expiry}
+          onChange={handleExpiryChange}
+        />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <label htmlFor="isAdjustmentAllowed">Allow Adjustments:</label>
+        <input
+          type="checkbox"
+          id="isAdjustmentAllowed"
+          name="isAdjustmentAllowed"
+          checked={isAdjustmentAllowed}
+          onChange={handleIsAdjustmentAllowedChange}
+          style={{ width: 'auto', marginLeft: '1rem' }}
+        />
+      </div>
+    </StyledForm>
+  );
+};

--- a/packages/site/src/components/permissions/NativeTokenStreamForm.tsx
+++ b/packages/site/src/components/permissions/NativeTokenStreamForm.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from 'react';
+import { parseUnits, toHex } from 'viem';
+import { StyledForm } from './styles';
+import type { NativeTokenStreamPermissionRequest } from './types';
+
+type NativeTokenStreamFormProps = {
+  onChange: (request: NativeTokenStreamPermissionRequest) => void;
+};
+
+export const NativeTokenStreamForm = ({
+  onChange,
+}: NativeTokenStreamFormProps) => {
+  const [initialAmount, setInitialAmount] = useState<bigint | null>(
+    BigInt(toHex(parseUnits('.5', 18))),
+  );
+  const [amountPerSecond, setAmountPerSecond] = useState(
+    BigInt(toHex(parseUnits('.5', 18))),
+  );
+  const [maxAmount, setMaxAmount] = useState<bigint | null>(
+    BigInt(toHex(parseUnits('2.5', 18))),
+  );
+  const [startTime, setStartTime] = useState(Math.floor(Date.now() / 1000));
+  const [expiry, setExpiry] = useState(
+    Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30, // 30 days from now
+  );
+  const [justification, setJustification] = useState(
+    'This is a very important request for streaming allowance for some very important thing',
+  );
+  const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
+
+  const handleInitialAmountChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputValue.trim() === '') {
+        setInitialAmount(null);
+      } else {
+        setInitialAmount(BigInt(inputValue));
+      }
+    },
+    [],
+  );
+
+  const handleAmountPerSecondChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setAmountPerSecond(BigInt(inputValue));
+    },
+    [],
+  );
+
+  const handleMaxAmountChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputValue.trim() === '') {
+        setMaxAmount(null);
+      } else {
+        setMaxAmount(BigInt(inputValue));
+      }
+    },
+    [],
+  );
+
+  const handleStartTimeChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setStartTime(Number(inputValue));
+    },
+    [],
+  );
+
+  const handleJustificationChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setJustification(inputValue);
+    },
+    [],
+  );
+
+  const handleExpiryChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setExpiry(Number(inputValue));
+    },
+    [],
+  );
+
+  const handleIsAdjustmentAllowedChange = useCallback(
+    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+      setIsAdjustmentAllowed(checked);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    onChange({
+      type: 'native-token-stream',
+      initialAmount,
+      amountPerSecond,
+      maxAmount,
+      startTime,
+      expiry,
+      justification,
+      isAdjustmentAllowed,
+    });
+  }, [
+    onChange,
+    initialAmount,
+    amountPerSecond,
+    maxAmount,
+    startTime,
+    expiry,
+    justification,
+    isAdjustmentAllowed,
+  ]);
+
+  return (
+    <StyledForm>
+      <div>
+        <label htmlFor="initialAmount">Initial Amount:</label>
+        <input
+          type="text"
+          id="initialAmount"
+          name="initialAmount"
+          value={initialAmount?.toString()}
+          onChange={handleInitialAmountChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="amountPerSecond">Amount Per Second:</label>
+        <input
+          type="text"
+          id="amountPerSecond"
+          name="amountPerSecond"
+          value={amountPerSecond.toString()}
+          onChange={handleAmountPerSecondChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="maxAmount">Max Amount:</label>
+        <input
+          type="text"
+          id="maxAmount"
+          name="maxAmount"
+          value={maxAmount?.toString()}
+          onChange={handleMaxAmountChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="startTime">Start Time:</label>
+        <input
+          type="number"
+          id="startTime"
+          name="startTime"
+          value={startTime}
+          onChange={handleStartTimeChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="justification">Justification:</label>
+        <textarea
+          id="justification"
+          name="justification"
+          rows={3}
+          value={justification}
+          onChange={handleJustificationChange}
+        ></textarea>
+      </div>
+      <div>
+        <label htmlFor="expiry">Expiry:</label>
+        <input
+          type="number"
+          id="expiry"
+          name="expiry"
+          value={expiry}
+          onChange={handleExpiryChange}
+        />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <label htmlFor="isAdjustmentAllowed">Allow Adjustments:</label>
+        <input
+          type="checkbox"
+          id="isAdjustmentAllowed"
+          name="isAdjustmentAllowed"
+          checked={isAdjustmentAllowed}
+          onChange={handleIsAdjustmentAllowedChange}
+          style={{ width: 'auto', marginLeft: '1rem' }}
+        />
+      </div>
+    </StyledForm>
+  );
+};

--- a/packages/site/src/components/permissions/index.ts
+++ b/packages/site/src/components/permissions/index.ts
@@ -1,0 +1,3 @@
+export { NativeTokenStreamForm } from './NativeTokenStreamForm';
+export { ERC20TokenStreamForm } from './ERC20TokenStreamForm';
+export { NativeTokenPeriodicForm } from './NativeTokenPeriodicForm';

--- a/packages/site/src/components/permissions/styles.tsx
+++ b/packages/site/src/components/permissions/styles.tsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+export const StyledForm = styled.form`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+
+  label {
+    display: inline-block;
+    width: 9rem;
+    margin-right: 1rem;
+    font-weight: 500;
+  }
+
+  textarea,
+  input {
+    padding: 0.8rem;
+    border: 1px solid ${({ theme }) => theme.colors.border?.default};
+    border-radius: 0.3rem;
+    flex-grow: 1;
+  }
+
+  div {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+`;

--- a/packages/site/src/components/permissions/types.ts
+++ b/packages/site/src/components/permissions/types.ts
@@ -1,0 +1,34 @@
+import { type Hex } from 'viem';
+
+export type BasePermissionRequest = {
+  justification: string;
+  startTime: number;
+  expiry: number;
+  isAdjustmentAllowed: boolean;
+};
+
+export type NativeTokenStreamPermissionRequest = BasePermissionRequest & {
+  type: 'native-token-stream';
+  initialAmount: bigint | null;
+  amountPerSecond: bigint;
+  maxAmount: bigint | null;
+};
+
+export type ERC20TokenStreamPermissionRequest = BasePermissionRequest & {
+  type: 'erc20-token-stream';
+  initialAmount: Hex | null;
+  amountPerSecond: Hex;
+  maxAmount: Hex | null;
+  tokenAddress: Hex;
+};
+
+export type NativeTokenPeriodicPermissionRequest = BasePermissionRequest & {
+  type: 'native-token-periodic';
+  periodAmount: Hex;
+  periodDuration: number;
+};
+
+export type PermissionRequest =
+  | NativeTokenStreamPermissionRequest
+  | ERC20TokenStreamPermissionRequest
+  | NativeTokenPeriodicPermissionRequest;

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -240,6 +240,9 @@ const Index = () => {
     'This is a very important request for streaming allowance for some very important thing',
   );
   const [permissionType, setPermissionType] = useState('native-token-stream');
+  const [tokenAddress, setTokenAddress] = useState<Hex>(
+    '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8',
+  );
   const [permissionResponse, setPermissionResponse] = useState<any>(null);
 
   const [isCopied, setIsCopied] = useState(false);
@@ -349,6 +352,12 @@ const Index = () => {
     setPeriodDuration(Number(inputValue));
   };
 
+  const handleTokenAddressChange = ({
+    target: { value: inputValue },
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setTokenAddress(inputValue as Hex);
+  };
+
   const handleRedeemPermission = async () => {
     if (!delegateAccount) {
       throw new Error('Delegate account not found');
@@ -409,6 +418,15 @@ const Index = () => {
         amountPerSecond,
         startTime,
         maxAmount,
+      };
+    } else if (permissionType === 'erc20-token-stream') {
+      permissionData = {
+        justification,
+        initialAmount: initialAmount ? toHex(initialAmount) : undefined,
+        amountPerSecond: toHex(amountPerSecond),
+        startTime: startTime,
+        maxAmount: maxAmount ? toHex(maxAmount) : undefined,
+        tokenAddress,
       };
     } else if (permissionType === 'native-token-periodic') {
       permissionData = {
@@ -613,13 +631,15 @@ const Index = () => {
                   <option value="native-token-stream">
                     Native Token Stream
                   </option>
+                  <option value="erc20-token-stream">ERC20 Token Stream</option>
                   <option value="native-token-periodic">
                     Native Token Periodic
                   </option>
                 </select>
               </div>
 
-              {permissionType === 'native-token-stream' && (
+              {(permissionType === 'native-token-stream' ||
+                permissionType === 'erc20-token-stream') && (
                 <>
                   <div>
                     <label htmlFor="initialAmount">Initial Amount:</label>
@@ -652,6 +672,20 @@ const Index = () => {
                     />
                   </div>
                 </>
+              )}
+
+              {permissionType === 'erc20-token-stream' && (
+                <div>
+                  <label htmlFor="tokenAddress">Token Address:</label>
+                  <input
+                    type="text"
+                    id="tokenAddress"
+                    name="tokenAddress"
+                    value={tokenAddress}
+                    onChange={handleTokenAddressChange}
+                    placeholder="0x..."
+                  />
+                </div>
               )}
 
               {permissionType === 'native-token-periodic' && (

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -1,15 +1,6 @@
 import { erc7715ProviderActions } from '@metamask/delegation-toolkit/experimental';
 import { useMemo, useState } from 'react';
-import styled from 'styled-components';
-import {
-  type Hex,
-  createClient,
-  http,
-  custom,
-  createPublicClient,
-  parseUnits,
-  toHex,
-} from 'viem';
+import { type Hex, createClient, http, custom, createPublicClient } from 'viem';
 import type { UserOperationReceipt } from 'viem/account-abstraction';
 import { sepolia as chain } from 'viem/chains';
 
@@ -21,169 +12,45 @@ import {
   Title,
 } from '../components';
 import {
-  kernelSnapOrigin,
-  gatorSnapOrigin,
-  messageSigningSnapOrigin,
-} from '../config';
+  NativeTokenStreamForm,
+  ERC20TokenStreamForm,
+  NativeTokenPeriodicForm,
+} from '../components/permissions';
+import {
+  Container,
+  Heading,
+  Span,
+  Subtitle,
+  CardContainer,
+  Box,
+  ErrorMessage,
+  StyledForm,
+  ResponseContainer,
+  CopyButton,
+} from '../styles';
+import { kernelSnapOrigin, gatorSnapOrigin } from '../config';
 import {
   useMetaMask,
   useMetaMaskContext,
   useRequestSnap,
   useDelegateAccount,
   useBundlerClient,
-  useInvokeSnap,
-  useRequest,
 } from '../hooks';
-import type { GetSnapsResponse } from '../types';
 import { isLocalSnap } from '../utils';
+import type {
+  PermissionRequest,
+  NativeTokenStreamPermissionRequest,
+  ERC20TokenStreamPermissionRequest,
+  NativeTokenPeriodicPermissionRequest,
+} from '../components/permissions/types';
 
 /* eslint-disable no-restricted-globals */
 const BUNDLER_RPC_URL = process.env.GATSBY_BUNDLER_RPC_URL;
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex: 1;
-  margin-top: 7.6rem;
-  margin-bottom: 7.6rem;
-  ${({ theme }) => theme.mediaQueries.small} {
-    padding-left: 2.4rem;
-    padding-right: 2.4rem;
-    margin-top: 2rem;
-    margin-bottom: 2rem;
-    width: auto;
-  }
-`;
-
-const Heading = styled.h1`
-  margin-top: 0;
-  margin-bottom: 2.4rem;
-  text-align: center;
-`;
-
-const Span = styled.span`
-  color: ${(props) => props.theme.colors.primary?.default};
-`;
-
-const Subtitle = styled.p`
-  font-size: ${({ theme }) => theme.fontSizes.large};
-  font-weight: 500;
-  margin-top: 0;
-  margin-bottom: 0;
-  ${({ theme }) => theme.mediaQueries.small} {
-    font-size: ${({ theme }) => theme.fontSizes.text};
-  }
-`;
-
-const CardContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  max-width: 64.8rem;
-  width: 100%;
-  height: 100%;
-  margin-top: 1.5rem;
-`;
-
-const Box = styled.div`
-  background-color: ${({ theme }) => theme.colors.background?.alternative};
-  border: 1px solid ${({ theme }) => theme.colors.border?.default};
-  color: ${({ theme }) => theme.colors.text?.alternative};
-  border-radius: ${({ theme }) => theme.radii.default};
-  padding: 2.4rem;
-  margin-top: 2.4rem;
-  max-width: 60rem;
-  width: 100%;
-
-  & > * {
-    margin: 0;
-  }
-  ${({ theme }) => theme.mediaQueries.small} {
-    margin-top: 1.2rem;
-    padding: 1.6rem;
-  }
-`;
-
-const ErrorMessage = styled.div`
-  background-color: ${({ theme }) => theme.colors.error?.muted};
-  border: 1px solid ${({ theme }) => theme.colors.error?.default};
-  color: ${({ theme }) => theme.colors.error?.alternative};
-  border-radius: ${({ theme }) => theme.radii.default};
-  padding: 2.4rem;
-  margin-bottom: 2.4rem;
-  margin-top: 2.4rem;
-  max-width: 60rem;
-  width: 100%;
-  ${({ theme }) => theme.mediaQueries.small} {
-    padding: 1.6rem;
-    margin-bottom: 1.2rem;
-    margin-top: 1.2rem;
-    max-width: 100%;
-  }
-`;
-
-const StyledForm = styled.form`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 1.2rem;
-
-  label {
-    display: inline-block;
-    width: 9rem;
-    margin-right: 1rem;
-    font-weight: 500;
-  }
-
-  textarea,
-  input {
-    padding: 0.8rem;
-    border: 1px solid ${({ theme }) => theme.colors.border?.default};
-    border-radius: 0.3rem;
-    flex-grow: 1;
-  }
-
-  div {
-    display: flex;
-    align-items: center;
-    margin-bottom: 1rem;
-  }
-
-  }
-`;
-
-const ResponseContainer = styled.div`
-  position: relative;
-  & pre {
-    max-height: 50rem;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-`;
-
-const CopyButton = styled.button`
-  position: absolute;
-  top: 0.6rem;
-  right: 0.6rem;
-  background-color: ${({ theme }) => theme.colors.primary?.default};
-  color: white;
-  border: none;
-  border-radius: 0.25rem;
-  padding: 0.5rem 1rem;
-  border: 1px solid transparent;
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.primary?.alternative};
-  }
-  cursor: pointer;
-  font-size: 2rem;
-`;
-
 const Index = () => {
   const { error: metaMaskContextError } = useMetaMaskContext();
   const [permissionResponseError, setPermissionResponseError] =
-    useState<Error | null>(null);
+    useState<Error | null>();
 
   const errors = [metaMaskContextError, permissionResponseError].filter((e) =>
     Boolean(e),
@@ -218,103 +85,18 @@ const Index = () => {
 
   const isKernelSnapReady = Boolean(installedSnaps[kernelSnapOrigin]);
   const isGatorSnapReady = Boolean(installedSnaps[gatorSnapOrigin]);
-  const isMessageSigningSnapReady = Boolean(
-    installedSnaps[messageSigningSnapOrigin],
-  );
 
   const chainId = chain.id;
-  const [initialAmount, setInitialAmount] = useState<bigint | null>(
-    BigInt(toHex(parseUnits('.5', 18))),
-  ); // .5 ETH in wei
-  const [amountPerSecond, setAmountPerSecond] = useState(
-    BigInt(toHex(parseUnits('.5', 18))),
-  ); // .5 ETH in wei
-  const [maxAmount, setMaxAmount] = useState<bigint | null>(
-    BigInt(toHex(parseUnits('2.5', 18))),
-  ); // 2.5 ETH in wei
-  const [startTime, setStartTime] = useState(Math.floor(Date.now() / 1000));
-  const [expiry, setExpiry] = useState(
-    Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30, // 30 days from now
-  );
-  const [justification, setJustification] = useState(
-    'This is a very important request for streaming allowance for some very important thing',
-  );
   const [permissionType, setPermissionType] = useState('native-token-stream');
-  const [tokenAddress, setTokenAddress] = useState<Hex>(
-    '0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8',
-  );
+  const [permissionRequest, setPermissionRequest] =
+    useState<PermissionRequest | null>(null);
   const [permissionResponse, setPermissionResponse] = useState<any>(null);
-
   const [isCopied, setIsCopied] = useState(false);
-
   const [to, setTo] = useState<Hex>('0x');
   const [data, setData] = useState<Hex>('0x');
   const [value, setValue] = useState<bigint>(0n);
   const [receipt, setReceipt] = useState<UserOperationReceipt | null>(null);
-
   const [isWorking, setIsWorking] = useState(false);
-  const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
-
-  const request = useRequest();
-  const requestMessageSigningSnap = useRequestSnap(messageSigningSnapOrigin);
-  const invokeMessageSigningSnap = useInvokeSnap(messageSigningSnapOrigin);
-  const [
-    messageSigningSnapPublicKeyResponse,
-    setMessageSigningSnapPublicKeyResponse,
-  ] = useState<string | null>(null);
-  const [
-    messageSigningSnapSignMessageResponse,
-    setMessageSigningSnapSignMessageResponse,
-  ] = useState<string | null>(null);
-
-  const [periodAmount, setPeriodAmount] = useState(
-    BigInt(toHex(parseUnits('1', 18))),
-  ); // 1 ETH in wei
-  const [periodDuration, setPeriodDuration] = useState(2592000); // 30 days in seconds
-
-  const handleInitialAmountChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    if (inputValue.trim() === '') {
-      setInitialAmount(null);
-    } else {
-      setInitialAmount(BigInt(inputValue));
-    }
-  };
-
-  const handleAmountPerSecondChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setAmountPerSecond(BigInt(inputValue));
-  };
-
-  const handleMaxAmountChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    if (inputValue.trim() === '') {
-      setMaxAmount(null);
-    } else {
-      setMaxAmount(BigInt(inputValue));
-    }
-  };
-
-  const handleStartTimeChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setStartTime(Number(inputValue));
-  };
-
-  const handleJustificationChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setJustification(inputValue);
-  };
-
-  const handleExpiryChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setExpiry(Number(inputValue));
-  };
 
   const handlePermissionTypeChange = ({
     target: { value: inputValue },
@@ -340,31 +122,13 @@ const Index = () => {
     setValue(BigInt(inputValue));
   };
 
-  const handlePeriodAmountChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setPeriodAmount(BigInt(inputValue));
-  };
-
-  const handlePeriodDurationChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setPeriodDuration(Number(inputValue));
-  };
-
-  const handleTokenAddressChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setTokenAddress(inputValue as Hex);
-  };
-
   const handleRedeemPermission = async () => {
     if (!delegateAccount) {
       throw new Error('Delegate account not found');
     }
     setIsWorking(true);
     setReceipt(null);
-    setPermissionResponseError(null);
+    setPermissionResponseError(undefined);
 
     const feePerGas = await getFeePerGas();
 
@@ -410,34 +174,12 @@ const Index = () => {
       throw new Error('Delegate account not found');
     }
 
-    let permissionData;
-    if (permissionType === 'native-token-stream') {
-      permissionData = {
-        justification,
-        initialAmount,
-        amountPerSecond,
-        startTime,
-        maxAmount,
-      };
-    } else if (permissionType === 'erc20-token-stream') {
-      permissionData = {
-        justification,
-        initialAmount: initialAmount ? toHex(initialAmount) : undefined,
-        amountPerSecond: toHex(amountPerSecond),
-        startTime: startTime,
-        maxAmount: maxAmount ? toHex(maxAmount) : undefined,
-        tokenAddress,
-      };
-    } else if (permissionType === 'native-token-periodic') {
-      permissionData = {
-        justification,
-        periodAmount: toHex(periodAmount),
-        periodDuration: periodDuration,
-        startTime: startTime,
-      };
-    } else {
-      throw new Error(`Unsupported permission type: ${permissionType}`);
+    if (!permissionRequest) {
+      throw new Error('No permission request data');
     }
+
+    const { type, expiry, isAdjustmentAllowed, ...permissionData } =
+      permissionRequest;
 
     const permissionsRequests = [
       {
@@ -451,7 +193,7 @@ const Index = () => {
         },
         isAdjustmentAllowed,
         permission: {
-          type: permissionType,
+          type,
           data: permissionData,
         },
       },
@@ -461,6 +203,7 @@ const Index = () => {
     setPermissionResponse(null);
     setReceipt(null);
     setPermissionResponseError(null);
+
     try {
       const response = await metaMaskClient?.grantPermissions(
         permissionsRequests,
@@ -485,40 +228,6 @@ const Index = () => {
           console.error('Failed to copy: ', clipboardError);
         });
     }
-  };
-
-  const handleGetPublicKey = async () => {
-    setMessageSigningSnapPublicKeyResponse(null);
-    const connectedSnaps = (await request({
-      method: 'wallet_getSnaps',
-    })) as GetSnapsResponse;
-    if (!connectedSnaps[messageSigningSnapOrigin]) {
-      await requestMessageSigningSnap();
-    }
-
-    const publicKey = await invokeMessageSigningSnap({
-      method: 'getPublicKey',
-      params: {},
-    });
-    setMessageSigningSnapPublicKeyResponse(publicKey as string);
-  };
-
-  const handleSignMessage = async () => {
-    setMessageSigningSnapSignMessageResponse(null);
-    const connectedSnaps = (await request({
-      method: 'wallet_getSnaps',
-    })) as GetSnapsResponse;
-    if (!connectedSnaps[messageSigningSnapOrigin]) {
-      await requestMessageSigningSnap();
-    }
-
-    const signature = await invokeMessageSigningSnap({
-      method: 'signMessage',
-      params: {
-        message: 'metamask: gator snap permission request',
-      },
-    });
-    setMessageSigningSnapSignMessageResponse(signature as string);
   };
 
   return (
@@ -638,168 +347,33 @@ const Index = () => {
                 </select>
               </div>
 
-              {(permissionType === 'native-token-stream' ||
-                permissionType === 'erc20-token-stream') && (
-                <>
-                  <div>
-                    <label htmlFor="initialAmount">Initial Amount:</label>
-                    <input
-                      type="text"
-                      id="initialAmount"
-                      name="initialAmount"
-                      value={initialAmount?.toString()}
-                      onChange={handleInitialAmountChange}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="amountPerSecond">Amount Per Second:</label>
-                    <input
-                      type="text"
-                      id="amountPerSecond"
-                      name="amountPerSecond"
-                      value={amountPerSecond.toString()}
-                      onChange={handleAmountPerSecondChange}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="maxAmount">Max Amount:</label>
-                    <input
-                      type="text"
-                      id="maxAmount"
-                      name="maxAmount"
-                      value={maxAmount?.toString()}
-                      onChange={handleMaxAmountChange}
-                    />
-                  </div>
-                </>
+              {permissionType === 'native-token-stream' && (
+                <NativeTokenStreamForm
+                  onChange={(request: NativeTokenStreamPermissionRequest) => {
+                    setPermissionRequest(request);
+                  }}
+                />
               )}
 
               {permissionType === 'erc20-token-stream' && (
-                <div>
-                  <label htmlFor="tokenAddress">Token Address:</label>
-                  <input
-                    type="text"
-                    id="tokenAddress"
-                    name="tokenAddress"
-                    value={tokenAddress}
-                    onChange={handleTokenAddressChange}
-                    placeholder="0x..."
-                  />
-                </div>
+                <ERC20TokenStreamForm
+                  onChange={(request: ERC20TokenStreamPermissionRequest) => {
+                    setPermissionRequest(request);
+                  }}
+                />
               )}
 
               {permissionType === 'native-token-periodic' && (
-                <>
-                  <div>
-                    <label htmlFor="periodAmount">Period Amount:</label>
-                    <input
-                      type="text"
-                      id="periodAmount"
-                      name="periodAmount"
-                      value={periodAmount.toString()}
-                      onChange={handlePeriodAmountChange}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="periodDuration">Period Duration:</label>
-                    <input
-                      type="number"
-                      id="periodDuration"
-                      name="periodDuration"
-                      value={periodDuration}
-                      onChange={handlePeriodDurationChange}
-                    />
-                  </div>
-                </>
+                <NativeTokenPeriodicForm
+                  onChange={(request: NativeTokenPeriodicPermissionRequest) => {
+                    setPermissionRequest(request);
+                  }}
+                />
               )}
-
-              <div>
-                <label htmlFor="startTime">Start Time:</label>
-                <input
-                  type="number"
-                  id="startTime"
-                  name="startTime"
-                  value={startTime}
-                  onChange={handleStartTimeChange}
-                />
-              </div>
-              <div>
-                <label htmlFor="justification">Justification:</label>
-                <textarea
-                  id="justification"
-                  name="justification"
-                  rows={3}
-                  value={justification}
-                  onChange={handleJustificationChange}
-                ></textarea>
-              </div>
-              <div>
-                <label htmlFor="expiry">Expiry:</label>
-                <input
-                  type="number"
-                  id="expiry"
-                  name="expiry"
-                  value={expiry}
-                  onChange={handleExpiryChange}
-                />
-              </div>
-              <div style={{ display: 'flex', alignItems: 'center' }}>
-                <label htmlFor="isAdjustmentAllowed">Allow Adjustments:</label>
-                <input
-                  type="checkbox"
-                  id="isAdjustmentAllowed"
-                  name="isAdjustmentAllowed"
-                  checked={isAdjustmentAllowed}
-                  onChange={(e) => setIsAdjustmentAllowed(e.target.checked)}
-                  style={{ width: 'auto', marginLeft: '1rem' }}
-                />
-              </div>
             </StyledForm>
             <CustomMessageButton
               text="Grant Permission"
               onClick={handleGrantPermissions}
-              disabled={isWorking}
-            />
-          </Box>
-        )}
-
-        {metaMaskClient && !isLocalSnap(messageSigningSnapOrigin) && (
-          <Box style={{ position: 'relative' }}>
-            <ResponseContainer>
-              <Title>Message Signing Snap(Get Public Key)</Title>
-              <pre>
-                Get Public Key Result:{' '}
-                {messageSigningSnapPublicKeyResponse
-                  ? JSON.stringify(messageSigningSnapPublicKeyResponse, null, 2)
-                  : ''}
-              </pre>
-            </ResponseContainer>
-
-            <CustomMessageButton
-              text="Get Public Key"
-              onClick={handleGetPublicKey}
-              disabled={isWorking}
-            />
-          </Box>
-        )}
-        {metaMaskClient && !isLocalSnap(messageSigningSnapOrigin) && (
-          <Box style={{ position: 'relative' }}>
-            <ResponseContainer>
-              <Title>Message Signing Snap(Sign Message )</Title>
-              <pre>
-                Sign Message Result:{' '}
-                {messageSigningSnapSignMessageResponse
-                  ? JSON.stringify(
-                      messageSigningSnapSignMessageResponse,
-                      null,
-                      2,
-                    )
-                  : ''}
-              </pre>
-            </ResponseContainer>
-            <CustomMessageButton
-              text="Sign Message"
-              onClick={handleSignMessage}
               disabled={isWorking}
             />
           </Box>

--- a/packages/site/src/styles.tsx
+++ b/packages/site/src/styles.tsx
@@ -1,0 +1,139 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  margin-top: 7.6rem;
+  margin-bottom: 7.6rem;
+  ${({ theme }) => theme.mediaQueries.small} {
+    padding-left: 2.4rem;
+    padding-right: 2.4rem;
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+    width: auto;
+  }
+`;
+
+export const Heading = styled.h1`
+  margin-top: 0;
+  margin-bottom: 2.4rem;
+  text-align: center;
+`;
+
+export const Span = styled.span`
+  color: ${(props) => props.theme.colors.primary?.default};
+`;
+
+export const Subtitle = styled.p`
+  font-size: ${({ theme }) => theme.fontSizes.large};
+  font-weight: 500;
+  margin-top: 0;
+  margin-bottom: 0;
+  ${({ theme }) => theme.mediaQueries.small} {
+    font-size: ${({ theme }) => theme.fontSizes.text};
+  }
+`;
+
+export const CardContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  max-width: 64.8rem;
+  width: 100%;
+  height: 100%;
+  margin-top: 1.5rem;
+`;
+
+export const Box = styled.div`
+  background-color: ${({ theme }) => theme.colors.background?.alternative};
+  border: 1px solid ${({ theme }) => theme.colors.border?.default};
+  color: ${({ theme }) => theme.colors.text?.alternative};
+  border-radius: ${({ theme }) => theme.radii.default};
+  padding: 2.4rem;
+  margin-top: 2.4rem;
+  max-width: 60rem;
+  width: 100%;
+
+  & > * {
+    margin: 0;
+  }
+  ${({ theme }) => theme.mediaQueries.small} {
+    margin-top: 1.2rem;
+    padding: 1.6rem;
+  }
+`;
+
+export const ErrorMessage = styled.div`
+  background-color: ${({ theme }) => theme.colors.error?.muted};
+  border: 1px solid ${({ theme }) => theme.colors.error?.default};
+  color: ${({ theme }) => theme.colors.error?.alternative};
+  border-radius: ${({ theme }) => theme.radii.default};
+  padding: 2.4rem;
+  margin-bottom: 2.4rem;
+  margin-top: 2.4rem;
+  max-width: 60rem;
+  width: 100%;
+  ${({ theme }) => theme.mediaQueries.small} {
+    padding: 1.6rem;
+    margin-bottom: 1.2rem;
+    margin-top: 1.2rem;
+    max-width: 100%;
+  }
+`;
+
+export const StyledForm = styled.form`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+
+  label {
+    display: inline-block;
+    width: 9rem;
+    margin-right: 1rem;
+    font-weight: 500;
+  }
+
+  textarea,
+  input {
+    padding: 0.8rem;
+    border: 1px solid ${({ theme }) => theme.colors.border?.default};
+    border-radius: 0.3rem;
+    flex-grow: 1;
+  }
+
+  div {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+`;
+
+export const ResponseContainer = styled.div`
+  position: relative;
+  & pre {
+    max-height: 50rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+`;
+
+export const CopyButton = styled.button`
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  background-color: ${({ theme }) => theme.colors.primary?.default};
+  color: white;
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid transparent;
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.primary?.alternative};
+  }
+  cursor: pointer;
+  font-size: 2rem;
+`;


### PR DESCRIPTION
# Add ERC20 Token Stream Permission Support

## Overview
This PR introduces support for ERC20 token streaming permissions.

## Key Changes
- Added new `erc20-token-stream` permission type with all supported components.
- Decomposed permission specific forms out of demo dapp page into individual components
- Updated addingNewPermissions.md documentation to guide developers extending the supported permissions.

## Note
- This permission does not yet show the permission icon
- Additional work is required to ensure security around the specified token (token alerts / token address) - UX input will be required to get this right