### PR TITLE
Add valueLTE caveat to erc20 streaming permission

### DIFF
--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "WwTyuE9UTnU+xFxt6WVlQLQIniNRtMZSXEyvV0G0dm0=",
+    "shasum": "LVsPU3JPEZJPby8z8oSovpKVsA91x6sheko2alRExeU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/caveats.ts
@@ -19,14 +19,16 @@ export async function appendCaveats({
   const { initialAmount, maxAmount, amountPerSecond, startTime } =
     permission.data;
 
-  caveatBuilder.addCaveat(
-    'erc20Streaming',
-    permission.data.tokenAddress,
-    BigInt(initialAmount),
-    BigInt(maxAmount),
-    BigInt(amountPerSecond),
-    startTime,
-  );
+  caveatBuilder
+    .addCaveat(
+      'erc20Streaming',
+      permission.data.tokenAddress,
+      BigInt(initialAmount),
+      BigInt(maxAmount),
+      BigInt(amountPerSecond),
+      startTime,
+    )
+    .addCaveat('valueLte', 0n);
 
   return caveatBuilder;
 }

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/caveats.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/caveats.test.ts
@@ -47,7 +47,9 @@ describe('erc20TokenStream:caveats', () => {
         startTime,
       );
 
-      expect(mockCaveatBuilder.addCaveat).toHaveBeenCalledTimes(1);
+      expect(mockCaveatBuilder.addCaveat).toHaveBeenCalledWith('valueLte', 0n);
+
+      expect(mockCaveatBuilder.addCaveat).toHaveBeenCalledTimes(2);
     });
 
     it('should return the modified caveat builder', async () => {


### PR DESCRIPTION
Ensure that no value is transferred by way of the `valueLte` caveat when granting an ERC20 Token Streaming permission