### PR TITLE
Add support for token icons

### DIFF
--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "Pc5W2/H3Rn9qvS43ug/hRYQl2reGRl6U4EItLCBO4XY=",
+    "shasum": "553JjDR5jSibR598AFJgVpPl0FYbFThitFNL18Ei0ww=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "553JjDR5jSibR598AFJgVpPl0FYbFThitFNL18Ei0ww=",
+    "shasum": "0f3SaFH5UO/2a3ZNnOS20ekBbGrZPNFwcnGnnp1bmX4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "RPO9XaxZh8ouWI9lgVk7iB59tXVMpEGmyAAn4d7QaWc=",
+    "shasum": "Pc5W2/H3Rn9qvS43ug/hRYQl2reGRl6U4EItLCBO4XY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "LVsPU3JPEZJPby8z8oSovpKVsA91x6sheko2alRExeU=",
+    "shasum": "RPO9XaxZh8ouWI9lgVk7iB59tXVMpEGmyAAn4d7QaWc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/clients/accountApiClient.ts
+++ b/packages/gator-permissions-snap/src/clients/accountApiClient.ts
@@ -97,11 +97,6 @@ export class AccountApiClient {
     // zeroAddress is the native token on the specified chain
     const tokenAddress = assetAddress ?? zeroAddress;
 
-    console.log(
-      'Fetching ' +
-        `${this.#baseUrl}/tokens/${tokenAddress}?accountAddresses=${account}&chainId=${chainId}`,
-    );
-
     const response = await this.#fetch(
       `${this.#baseUrl}/tokens/${tokenAddress}?accountAddresses=${account}&chainId=${chainId}`,
     );
@@ -138,8 +133,6 @@ export class AccountApiClient {
     }
 
     const balance = BigInt(accountData.rawBalance);
-
-    console.log('Icon url ' + iconUrl);
 
     return {
       balance,

--- a/packages/gator-permissions-snap/src/clients/blockchainMetadataClient.ts
+++ b/packages/gator-permissions-snap/src/clients/blockchainMetadataClient.ts
@@ -191,8 +191,8 @@ export class BlockchainTokenMetadataClient implements TokenMetadataClient {
       encoded: Hex | null | undefined;
       name: string;
     }): TReturn => {
-      if (encoded === null || encoded === undefined) {
-        throw new Error(`Failed to fetch ${name}`);
+      if (encoded === null || encoded === undefined || encoded === '0x') {
+        throw new Error(`Failed to fetch token ${name}`);
       }
 
       // @ts-expect-error - decodeAbiParameters does not work well

--- a/packages/gator-permissions-snap/src/clients/types.ts
+++ b/packages/gator-permissions-snap/src/clients/types.ts
@@ -83,6 +83,7 @@ export type TokenBalanceAndMetadata = {
   balance: bigint;
   decimals: number;
   symbol: string;
+  iconUrl?: string;
 };
 
 /**

--- a/packages/gator-permissions-snap/src/core/permissionHandler.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandler.ts
@@ -153,6 +153,7 @@ export class PermissionHandler<
       const showAddMoreRulesButton =
         this.#addMoreRulesModal?.hasRulesToAdd({
           context: args.context,
+          metadata: args.metadata,
         }) ?? false;
 
       const permissionContent =

--- a/packages/gator-permissions-snap/src/core/ruleModalManager.tsx
+++ b/packages/gator-permissions-snap/src/core/ruleModalManager.tsx
@@ -86,7 +86,6 @@ export class RuleModalManager<
     context: TContext;
     metadata: TMetadata;
   }) {
-    return [];
     return this.#rules.filter(
       (rule) => rule.getRuleData({ context, metadata }).value === undefined,
     );

--- a/packages/gator-permissions-snap/src/core/ruleModalManager.tsx
+++ b/packages/gator-permissions-snap/src/core/ruleModalManager.tsx
@@ -270,10 +270,10 @@ export class RuleModalManager<
       context: updatedContext,
     });
 
-    const error = selectedRule.getRuleData({
+    const { error } = selectedRule.getRuleData({
       context: updatedContext,
       metadata: updatedMetadata,
-    }).error;
+    });
 
     return error;
   }

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -55,6 +55,7 @@ export type BaseTokenPermissionContext = BaseContext & {
   tokenMetadata: {
     decimals: number;
     symbol: string;
+    iconDataBase64: string | null;
   };
 };
 
@@ -168,8 +169,18 @@ export type LifecycleOrchestrationHandlers<
 export type RuleType = 'number' | 'text' | 'dropdown';
 
 export type IconData = {
-  iconUrl: string;
+  iconDataBase64: string;
   iconAltText: string;
+};
+
+export type RuleData = {
+  value: string | undefined;
+  isVisible: boolean;
+  tooltip?: string | undefined;
+  iconData?: IconData | undefined;
+  error?: string | undefined;
+  options?: string[] | undefined;
+  isAdjustmentAllowed: boolean;
 };
 
 /**
@@ -182,16 +193,11 @@ export type RuleDefinition<
   TContext extends BaseContext = BaseContext,
   TMetadata extends object = object,
 > = {
-  label: string;
   name: string;
-  tooltip?: string | undefined;
   isOptional?: boolean;
+  label: string;
   type: RuleType;
-  value: (context: TContext) => string | undefined;
-  error?: (metadata: TMetadata) => string | undefined;
-  options?: string[];
-  isVisible?: (context: TContext) => boolean;
-  iconData?: IconData;
+  getRuleData: (config: { context: TContext; metadata: TMetadata }) => RuleData;
   // todo: it would be nice if we could make the value type more specific
   updateContext: (context: TContext, value: any) => TContext;
 };

--- a/packages/gator-permissions-snap/src/index.ts
+++ b/packages/gator-permissions-snap/src/index.ts
@@ -16,7 +16,7 @@ import type {
   OnRpcRequestHandler,
   OnUserInputHandler,
 } from '@metamask/snaps-sdk';
-import { lineaSepolia, sepolia } from 'viem/chains';
+import { mainnet, sepolia } from 'viem/chains';
 
 import {
   EoaAccountController,
@@ -76,7 +76,7 @@ const tokenMetadataService = new TokenMetadataService({
   tokenMetadataClient,
 });
 
-const supportedChains = [sepolia, lineaSepolia];
+const supportedChains = [sepolia, mainnet];
 
 const accountController: AccountController = useEoaAccountController
   ? new EoaAccountController({

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
@@ -7,6 +7,7 @@ import { renderRules } from '../../core/rules';
 import { AccountDetails } from '../../ui/components/AccountDetails';
 import type { ItemDetails } from '../../ui/components/RequestDetails';
 import { RequestDetails } from '../../ui/components/RequestDetails';
+import { TokenIcon } from '../../ui/components/TokenIcon';
 import { TooltipIcon } from '../../ui/components/TooltipIcon';
 import {
   initialAmountRule,
@@ -20,7 +21,6 @@ import type {
   Erc20TokenStreamContext,
   Erc20TokenStreamMetadata,
 } from './types';
-import { TokenIcon } from '../../ui/components/TokenIcon';
 
 /**
  * Creates the confirmation content for an ERC20 token stream permission request.

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
@@ -20,6 +20,7 @@ import type {
   Erc20TokenStreamContext,
   Erc20TokenStreamMetadata,
 } from './types';
+import { TokenIcon } from '../../ui/components/TokenIcon';
 
 /**
  * Creates the confirmation content for an ERC20 token stream permission request.
@@ -63,6 +64,12 @@ export async function createConfirmationContent({
     {
       label: 'Token',
       text: context.tokenMetadata.symbol,
+      icon: (
+        <TokenIcon
+          imageDataBase64={context.tokenMetadata.iconDataBase64}
+          altText={context.tokenMetadata.symbol}
+        />
+      ),
     },
   ];
 
@@ -95,6 +102,12 @@ export async function createConfirmationContent({
             </Box>
           </Box>
           <Field>
+            <Box>
+              <TokenIcon
+                imageDataBase64={context.tokenMetadata.iconDataBase64}
+                altText={context.tokenMetadata.symbol}
+              />
+            </Box>
             <Input
               name="stream-rate"
               type="text"

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/content.tsx
@@ -64,12 +64,12 @@ export async function createConfirmationContent({
     {
       label: 'Token',
       text: context.tokenMetadata.symbol,
-      icon: (
-        <TokenIcon
-          imageDataBase64={context.tokenMetadata.iconDataBase64}
-          altText={context.tokenMetadata.symbol}
-        />
-      ),
+      iconData: context.tokenMetadata.iconDataBase64
+        ? {
+            iconDataBase64: context.tokenMetadata.iconDataBase64,
+            altText: context.tokenMetadata.symbol,
+          }
+        : undefined,
     },
   ];
 

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -24,7 +24,7 @@ import type {
   PopulatedErc20TokenStreamPermission,
   Erc20TokenStreamPermission,
 } from './types';
-import { fetchIconDataBase64 } from '../iconUtil';
+import { fetchIconDataAsBase64 } from '../iconUtil';
 
 const DEFAULT_MAX_AMOUNT = toHex(maxUint256);
 const DEFAULT_INITIAL_AMOUNT = '0x0';
@@ -114,11 +114,13 @@ export async function buildContext({
   tokenPricesService,
   accountController,
   tokenMetadataService,
+  fetcher,
 }: {
   permissionRequest: Erc20TokenStreamPermissionRequest;
   tokenPricesService: TokenPricesService;
   accountController: AccountController;
   tokenMetadataService: TokenMetadataService;
+  fetcher?: typeof fetch;
 }): Promise<Erc20TokenStreamContext> {
   const chainId = Number(permissionRequest.chainId);
   const { tokenAddress } = permissionRequest.permission.data;
@@ -138,7 +140,10 @@ export async function buildContext({
     assetAddress: tokenAddress,
   });
 
-  const iconDataResponse = await fetchIconDataBase64(iconUrl);
+  const iconDataResponse = await fetchIconDataAsBase64({
+    iconUrl,
+    fetcher,
+  });
 
   const iconDataBase64 = iconDataResponse.success
     ? iconDataResponse.imageDataBase64

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -24,7 +24,6 @@ import type {
   PopulatedErc20TokenStreamPermission,
   Erc20TokenStreamPermission,
 } from './types';
-import { fetchIconDataAsBase64 } from '../iconUtil';
 
 const DEFAULT_MAX_AMOUNT = toHex(maxUint256);
 const DEFAULT_INITIAL_AMOUNT = '0x0';
@@ -114,13 +113,11 @@ export async function buildContext({
   tokenPricesService,
   accountController,
   tokenMetadataService,
-  fetcher,
 }: {
   permissionRequest: Erc20TokenStreamPermissionRequest;
   tokenPricesService: TokenPricesService;
   accountController: AccountController;
   tokenMetadataService: TokenMetadataService;
-  fetcher?: typeof fetch;
 }): Promise<Erc20TokenStreamContext> {
   const chainId = Number(permissionRequest.chainId);
   const { tokenAddress } = permissionRequest.permission.data;
@@ -140,10 +137,8 @@ export async function buildContext({
     assetAddress: tokenAddress,
   });
 
-  const iconDataResponse = await fetchIconDataAsBase64({
-    iconUrl,
-    fetcher,
-  });
+  const iconDataResponse =
+    await tokenMetadataService.fetchIconDataAsBase64(iconUrl);
 
   const iconDataBase64 = iconDataResponse.success
     ? iconDataResponse.imageDataBase64

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -24,6 +24,7 @@ import type {
   PopulatedErc20TokenStreamPermission,
   Erc20TokenStreamPermission,
 } from './types';
+import { fetchIconDataBase64 } from '../iconUtil';
 
 const DEFAULT_MAX_AMOUNT = toHex(maxUint256);
 const DEFAULT_INITIAL_AMOUNT = '0x0';
@@ -130,11 +131,18 @@ export async function buildContext({
     balance: rawBalance,
     decimals,
     symbol,
+    iconUrl,
   } = await tokenMetadataService.getTokenBalanceAndMetadata({
     chainId,
     account: address,
     assetAddress: tokenAddress,
   });
+
+  const iconDataResponse = await fetchIconDataBase64(iconUrl);
+
+  const iconDataBase64 = iconDataResponse.success
+    ? iconDataResponse.imageDataBase64
+    : null;
 
   const balanceFormatted = await tokenPricesService.getCryptoToFiatConversion(
     `eip155:${chainId}/erc20:${tokenAddress}`,
@@ -187,6 +195,7 @@ export async function buildContext({
     tokenMetadata: {
       symbol,
       decimals,
+      iconDataBase64,
     },
     permissionDetails: {
       initialAmount,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/rules.ts
@@ -1,5 +1,6 @@
 import type { RuleDefinition } from '../../core/types';
 import { TimePeriod } from '../../core/types';
+import { getIconData } from '../iconUtil';
 import type {
   Erc20TokenStreamContext,
   Erc20TokenStreamMetadata,
@@ -18,15 +19,18 @@ type Erc20TokenStreamRuleDefinition = RuleDefinition<
 >;
 
 export const initialAmountRule: Erc20TokenStreamRuleDefinition = {
-  label: 'Initial Amount',
   name: INITIAL_AMOUNT_ELEMENT,
+  label: 'Initial Amount',
   type: 'number',
   isOptional: true,
-  tooltip: 'The initial amount of tokens that can be streamed.',
-  value: (context: Erc20TokenStreamContext) =>
-    context.permissionDetails.initialAmount,
-  error: (metadata: Erc20TokenStreamMetadata) =>
-    metadata.validationErrors.initialAmountError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.initialAmount,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The initial amount of tokens that can be streamed.',
+    iconData: getIconData(context),
+    error: metadata.validationErrors.initialAmountError,
+  }),
   updateContext: (
     context: Erc20TokenStreamContext,
     value: string | undefined,
@@ -40,15 +44,18 @@ export const initialAmountRule: Erc20TokenStreamRuleDefinition = {
 };
 
 export const maxAmountRule: Erc20TokenStreamRuleDefinition = {
-  label: 'Max Amount',
   name: MAX_AMOUNT_ELEMENT,
-  tooltip: 'The maximum amount of tokens that can be streamed.',
+  label: 'Max Amount',
   type: 'number',
   isOptional: true,
-  value: (context: Erc20TokenStreamContext) =>
-    context.permissionDetails.maxAmount,
-  error: (metadata: Erc20TokenStreamMetadata) =>
-    metadata.validationErrors.maxAmountError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.maxAmount,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The maximum amount of tokens that can be streamed.',
+    iconData: getIconData(context),
+    error: metadata.validationErrors.maxAmountError,
+  }),
   updateContext: (
     context: Erc20TokenStreamContext,
     value: string | undefined,
@@ -62,14 +69,16 @@ export const maxAmountRule: Erc20TokenStreamRuleDefinition = {
 };
 
 export const startTimeRule: Erc20TokenStreamRuleDefinition = {
-  label: 'Start Time',
   name: START_TIME_ELEMENT,
+  label: 'Start Time',
   type: 'text',
-  tooltip: 'The start time of the stream.',
-  value: (context: Erc20TokenStreamContext) =>
-    context.permissionDetails.startTime,
-  error: (metadata: Erc20TokenStreamMetadata) =>
-    metadata.validationErrors.startTimeError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.startTime,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The start time of the stream.',
+    error: metadata.validationErrors.startTimeError,
+  }),
   updateContext: (context: Erc20TokenStreamContext, value: string) => ({
     ...context,
     permissionDetails: {
@@ -80,14 +89,17 @@ export const startTimeRule: Erc20TokenStreamRuleDefinition = {
 };
 
 export const streamAmountPerPeriodRule: Erc20TokenStreamRuleDefinition = {
-  label: 'Stream Amount',
   name: AMOUNT_PER_PERIOD_ELEMENT,
+  label: 'Stream Amount',
   type: 'number',
-  tooltip: 'The amount of tokens that can be streamed per period.',
-  value: (context: Erc20TokenStreamContext) =>
-    context.permissionDetails.amountPerPeriod,
-  error: (metadata: Erc20TokenStreamMetadata) =>
-    metadata.validationErrors.amountPerPeriodError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.amountPerPeriod,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The amount of tokens that can be streamed per period.',
+    iconData: getIconData(context),
+    error: metadata.validationErrors.amountPerPeriodError,
+  }),
   updateContext: (context: Erc20TokenStreamContext, value: string) => ({
     ...context,
     permissionDetails: {
@@ -98,13 +110,16 @@ export const streamAmountPerPeriodRule: Erc20TokenStreamRuleDefinition = {
 };
 
 export const streamPeriodRule: Erc20TokenStreamRuleDefinition = {
-  label: 'Stream Period',
   name: TIME_PERIOD_ELEMENT,
+  label: 'Stream Period',
   type: 'dropdown',
-  tooltip: 'The period of the stream.',
-  options: Object.values(TimePeriod),
-  value: (context: Erc20TokenStreamContext) =>
-    context.permissionDetails.timePeriod,
+  getRuleData: ({ context }) => ({
+    value: context.permissionDetails.timePeriod,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The period of the stream.',
+    options: Object.values(TimePeriod),
+  }),
   updateContext: (context: Erc20TokenStreamContext, value: TimePeriod) => ({
     ...context,
     permissionDetails: {
@@ -115,13 +130,16 @@ export const streamPeriodRule: Erc20TokenStreamRuleDefinition = {
 };
 
 export const expiryRule: Erc20TokenStreamRuleDefinition = {
-  label: 'Expiry',
   name: EXPIRY_ELEMENT,
+  label: 'Expiry',
   type: 'text',
-  tooltip: 'The expiry date of the permission.',
-  value: (context: Erc20TokenStreamContext) => context.expiry,
-  error: (metadata: Erc20TokenStreamMetadata) =>
-    metadata.validationErrors.expiryError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.expiry,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The expiry date of the permission.',
+    error: metadata.validationErrors.expiryError,
+  }),
   updateContext: (context: Erc20TokenStreamContext, value: string) => ({
     ...context,
     expiry: value,

--- a/packages/gator-permissions-snap/src/permissions/iconUtil.ts
+++ b/packages/gator-permissions-snap/src/permissions/iconUtil.ts
@@ -1,0 +1,77 @@
+import { logger } from '@metamask/7715-permissions-shared/utils';
+import { BaseTokenPermissionContext, IconData } from '../core/types';
+
+/**
+ * Fetches an icon from a URL and converts it to a base64 data URI.
+ *
+ * This function downloads an image from the provided URL, converts the binary data
+ * to a base64 string using a browser-compatible approach, and returns it as a
+ * data URI with PNG MIME type.
+ *
+ * @param iconUrl - The URL of the icon to fetch and convert
+ * @returns A Promise that resolves to a base64 data URI string, or undefined if iconUrl is empty
+ * @throws Will throw an error if the fetch request fails or if there's an issue processing the image data
+ */
+export const fetchIconDataBase64 = async (
+  iconUrl: string | undefined,
+): Promise<{ success: true; imageDataBase64: string } | { success: false }> => {
+  if (!iconUrl) {
+    return { success: false };
+  }
+
+  try {
+    let base64 = 'data:image/png;base64,';
+
+    const iconResponse = await fetch(iconUrl);
+    const iconBuffer = await iconResponse.arrayBuffer();
+    const uint8Array = new Uint8Array(iconBuffer);
+
+    // Convert uint8Array to base64 string using browser-compatible approach
+    const base64Chars =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+    let result = '';
+    for (let i = 0; i < uint8Array.length; i += 3) {
+      const a = uint8Array[i] ?? 0;
+      const b = uint8Array[i + 1] ?? 0;
+      const c = uint8Array[i + 2] ?? 0;
+
+      const combined = (a << 16) | (b << 8) | c;
+
+      result += base64Chars[(combined >>> 18) & 63];
+      result += base64Chars[(combined >>> 12) & 63];
+      result +=
+        i + 1 < uint8Array.length ? base64Chars[(combined >>> 6) & 63] : '=';
+      result += i + 2 < uint8Array.length ? base64Chars[combined & 63] : '=';
+    }
+    base64 += result;
+
+    return { success: true, imageDataBase64: base64 };
+  } catch (error) {
+    logger.error('Error fetching icon data', error);
+    return { success: false };
+  }
+};
+
+/**
+ * Extracts icon data from a token permission context.
+ *
+ * This function takes a token permission context and extracts the icon data
+ * from the token metadata. It returns an IconData object containing the base64
+ * encoded icon and alt text, or undefined if no icon data is available.
+ *
+ * @param context - The token permission context containing token metadata
+ * @returns An IconData object with iconDataBase64 and iconAltText, or undefined if no icon data exists
+ */
+export const getIconData = (
+  context: BaseTokenPermissionContext,
+): IconData | undefined => {
+  const { iconDataBase64: iconUrl } = context.tokenMetadata;
+  if (!iconUrl) {
+    return undefined;
+  }
+
+  return {
+    iconDataBase64: iconUrl,
+    iconAltText: context.tokenMetadata.symbol,
+  };
+};

--- a/packages/gator-permissions-snap/src/permissions/iconUtil.ts
+++ b/packages/gator-permissions-snap/src/permissions/iconUtil.ts
@@ -1,66 +1,4 @@
-import { logger } from '@metamask/7715-permissions-shared/utils';
-import { BaseTokenPermissionContext, IconData } from '../core/types';
-
-/**
- * Fetches an icon from a URL and converts it to a base64 data URI.
- *
- * This function downloads an image from the provided URL, converts the binary data
- * to a base64 string using a browser-compatible approach, and returns it as a
- * data URI with PNG MIME type.
- *
- * @param iconUrl - The URL of the icon to fetch and convert
- * @returns A Promise that resolves to a base64 data URI string, or undefined if iconUrl is empty
- * @throws Will throw an error if the fetch request fails or if there's an issue processing the image data
- */
-export const fetchIconDataAsBase64 = async ({
-  iconUrl,
-  fetcher = fetch,
-}: {
-  iconUrl: string | undefined;
-  fetcher?: typeof fetch | undefined;
-}): Promise<
-  { success: true; imageDataBase64: string } | { success: false }
-> => {
-  if (!iconUrl) {
-    return { success: false };
-  }
-
-  try {
-    let base64 = 'data:image/png;base64,';
-
-    const iconResponse = await fetcher(iconUrl);
-    if (!iconResponse.ok) {
-      return { success: false };
-    }
-
-    const iconBuffer = await iconResponse.arrayBuffer();
-    const uint8Array = new Uint8Array(iconBuffer);
-
-    // Convert uint8Array to base64 string using browser-compatible approach
-    const base64Chars =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-    let result = '';
-    for (let i = 0; i < uint8Array.length; i += 3) {
-      const a = uint8Array[i] ?? 0;
-      const b = uint8Array[i + 1] ?? 0;
-      const c = uint8Array[i + 2] ?? 0;
-
-      const combined = (a << 16) | (b << 8) | c;
-
-      result += base64Chars[(combined >>> 18) & 63];
-      result += base64Chars[(combined >>> 12) & 63];
-      result +=
-        i + 1 < uint8Array.length ? base64Chars[(combined >>> 6) & 63] : '=';
-      result += i + 2 < uint8Array.length ? base64Chars[combined & 63] : '=';
-    }
-    base64 += result;
-
-    return { success: true, imageDataBase64: base64 };
-  } catch (error) {
-    logger.error('Error fetching icon data', error);
-    return { success: false };
-  }
-};
+import type { BaseTokenPermissionContext, IconData } from '../core/types';
 
 /**
  * Extracts icon data from a token permission context.
@@ -69,8 +7,8 @@ export const fetchIconDataAsBase64 = async ({
  * from the token metadata. It returns an IconData object containing the base64
  * encoded icon and alt text, or undefined if no icon data is available.
  *
- * @param context - The token permission context containing token metadata
- * @returns An IconData object with iconDataBase64 and iconAltText, or undefined if no icon data exists
+ * @param context - The token permission context containing token metadata.
+ * @returns An IconData object with iconDataBase64 and iconAltText, or undefined if no icon data exists.
  */
 export const getIconData = (
   context: BaseTokenPermissionContext,

--- a/packages/gator-permissions-snap/src/permissions/iconUtil.ts
+++ b/packages/gator-permissions-snap/src/permissions/iconUtil.ts
@@ -12,9 +12,15 @@ import { BaseTokenPermissionContext, IconData } from '../core/types';
  * @returns A Promise that resolves to a base64 data URI string, or undefined if iconUrl is empty
  * @throws Will throw an error if the fetch request fails or if there's an issue processing the image data
  */
-export const fetchIconDataBase64 = async (
-  iconUrl: string | undefined,
-): Promise<{ success: true; imageDataBase64: string } | { success: false }> => {
+export const fetchIconDataAsBase64 = async ({
+  iconUrl,
+  fetcher = fetch,
+}: {
+  iconUrl: string | undefined;
+  fetcher?: typeof fetch | undefined;
+}): Promise<
+  { success: true; imageDataBase64: string } | { success: false }
+> => {
   if (!iconUrl) {
     return { success: false };
   }
@@ -22,7 +28,11 @@ export const fetchIconDataBase64 = async (
   try {
     let base64 = 'data:image/png;base64,';
 
-    const iconResponse = await fetch(iconUrl);
+    const iconResponse = await fetcher(iconUrl);
+    if (!iconResponse.ok) {
+      return { success: false };
+    }
+
     const iconBuffer = await iconResponse.arrayBuffer();
     const uint8Array = new Uint8Array(iconBuffer);
 

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/content.tsx
@@ -7,7 +7,6 @@ import { renderRules } from '../../core/rules';
 import { AccountDetails } from '../../ui/components/AccountDetails';
 import type { ItemDetails } from '../../ui/components/RequestDetails';
 import { RequestDetails } from '../../ui/components/RequestDetails';
-import { IconUrls } from '../../ui/iconConstant';
 import {
   periodAmountRule,
   periodTypeRule,
@@ -19,6 +18,7 @@ import type {
   NativeTokenPeriodicContext,
   NativeTokenPeriodicMetadata,
 } from './types';
+import { TokenIcon } from '../../ui/components/TokenIcon';
 
 /**
  * Creates UI content for a native token periodic permission confirmation.
@@ -59,8 +59,13 @@ export async function createConfirmationContent({
     },
     {
       label: 'Token',
-      text: 'ETH',
-      iconUrl: IconUrls.ethereum.token,
+      text: context.tokenMetadata.symbol,
+      icon: (
+        <TokenIcon
+          imageDataBase64={context.tokenMetadata.iconDataBase64}
+          altText={context.tokenMetadata.symbol}
+        />
+      ),
     },
   ];
 

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/content.tsx
@@ -7,6 +7,7 @@ import { renderRules } from '../../core/rules';
 import { AccountDetails } from '../../ui/components/AccountDetails';
 import type { ItemDetails } from '../../ui/components/RequestDetails';
 import { RequestDetails } from '../../ui/components/RequestDetails';
+import { TokenIcon } from '../../ui/components/TokenIcon';
 import {
   periodAmountRule,
   periodTypeRule,
@@ -18,7 +19,6 @@ import type {
   NativeTokenPeriodicContext,
   NativeTokenPeriodicMetadata,
 } from './types';
-import { TokenIcon } from '../../ui/components/TokenIcon';
 
 /**
  * Creates UI content for a native token periodic permission confirmation.

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/content.tsx
@@ -7,7 +7,6 @@ import { renderRules } from '../../core/rules';
 import { AccountDetails } from '../../ui/components/AccountDetails';
 import type { ItemDetails } from '../../ui/components/RequestDetails';
 import { RequestDetails } from '../../ui/components/RequestDetails';
-import { TokenIcon } from '../../ui/components/TokenIcon';
 import {
   periodAmountRule,
   periodTypeRule,
@@ -60,12 +59,12 @@ export async function createConfirmationContent({
     {
       label: 'Token',
       text: context.tokenMetadata.symbol,
-      icon: (
-        <TokenIcon
-          imageDataBase64={context.tokenMetadata.iconDataBase64}
-          altText={context.tokenMetadata.symbol}
-        />
-      ),
+      iconData: context.tokenMetadata.iconDataBase64
+        ? {
+            iconDataBase64: context.tokenMetadata.iconDataBase64,
+            altText: context.tokenMetadata.symbol,
+          }
+        : undefined,
     },
   ];
 

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -23,6 +23,7 @@ import type {
   PopulatedNativeTokenPeriodicPermission,
   NativeTokenPeriodicPermission,
 } from './types';
+import { fetchIconDataBase64 } from '../iconUtil';
 
 /**
  * Construct an amended NativeTokenPeriodicPermissionRequest, based on the specified request,
@@ -111,10 +112,17 @@ export async function buildContext({
     balance: rawBalance,
     decimals,
     symbol,
+    iconUrl,
   } = await tokenMetadataService.getTokenBalanceAndMetadata({
     chainId,
     account: address,
   });
+
+  const iconDataResponse = await fetchIconDataBase64(iconUrl);
+
+  const iconDataBase64 = iconDataResponse.success
+    ? iconDataResponse.imageDataBase64
+    : null;
 
   const balanceFormatted = await tokenPricesService.getCryptoToFiatConversion(
     `eip155:1/slip44:60`,
@@ -163,6 +171,7 @@ export async function buildContext({
     tokenMetadata: {
       symbol,
       decimals,
+      iconDataBase64,
     },
     permissionDetails: {
       periodAmount,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -23,7 +23,7 @@ import type {
   PopulatedNativeTokenPeriodicPermission,
   NativeTokenPeriodicPermission,
 } from './types';
-import { fetchIconDataBase64 } from '../iconUtil';
+import { fetchIconDataAsBase64 } from '../iconUtil';
 
 /**
  * Construct an amended NativeTokenPeriodicPermissionRequest, based on the specified request,
@@ -96,11 +96,13 @@ export async function buildContext({
   tokenPricesService,
   accountController,
   tokenMetadataService,
+  fetcher,
 }: {
   permissionRequest: NativeTokenPeriodicPermissionRequest;
   tokenPricesService: TokenPricesService;
   accountController: AccountController;
   tokenMetadataService: TokenMetadataService;
+  fetcher?: typeof fetch;
 }): Promise<NativeTokenPeriodicContext> {
   const chainId = Number(permissionRequest.chainId);
 
@@ -118,7 +120,10 @@ export async function buildContext({
     account: address,
   });
 
-  const iconDataResponse = await fetchIconDataBase64(iconUrl);
+  const iconDataResponse = await fetchIconDataAsBase64({
+    iconUrl,
+    fetcher,
+  });
 
   const iconDataBase64 = iconDataResponse.success
     ? iconDataResponse.imageDataBase64

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -23,7 +23,6 @@ import type {
   PopulatedNativeTokenPeriodicPermission,
   NativeTokenPeriodicPermission,
 } from './types';
-import { fetchIconDataAsBase64 } from '../iconUtil';
 
 /**
  * Construct an amended NativeTokenPeriodicPermissionRequest, based on the specified request,
@@ -96,13 +95,11 @@ export async function buildContext({
   tokenPricesService,
   accountController,
   tokenMetadataService,
-  fetcher,
 }: {
   permissionRequest: NativeTokenPeriodicPermissionRequest;
   tokenPricesService: TokenPricesService;
   accountController: AccountController;
   tokenMetadataService: TokenMetadataService;
-  fetcher?: typeof fetch;
 }): Promise<NativeTokenPeriodicContext> {
   const chainId = Number(permissionRequest.chainId);
 
@@ -120,10 +117,8 @@ export async function buildContext({
     account: address,
   });
 
-  const iconDataResponse = await fetchIconDataAsBase64({
-    iconUrl,
-    fetcher,
-  });
+  const iconDataResponse =
+    await tokenMetadataService.fetchIconDataAsBase64(iconUrl);
 
   const iconDataBase64 = iconDataResponse.success
     ? iconDataResponse.imageDataBase64

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/rules.ts
@@ -1,6 +1,7 @@
 import { TimePeriod } from '../../core/types';
 import type { RuleDefinition } from '../../core/types';
 import { TIME_PERIOD_TO_SECONDS } from '../../utils/time';
+import { getIconData } from '../iconUtil';
 import type {
   NativeTokenPeriodicContext,
   NativeTokenPeriodicMetadata,
@@ -16,14 +17,17 @@ export const periodAmountRule: RuleDefinition<
   NativeTokenPeriodicContext,
   NativeTokenPeriodicMetadata
 > = {
-  label: 'Amount',
   name: PERIOD_AMOUNT_ELEMENT,
-  tooltip: 'The amount of tokens granted during each period',
+  label: 'Amount',
   type: 'number',
-  value: (context: NativeTokenPeriodicContext) =>
-    context.permissionDetails.periodAmount,
-  error: (metadata: NativeTokenPeriodicMetadata) =>
-    metadata.validationErrors.periodAmountError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.periodAmount,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The amount of tokens granted during each period',
+    error: metadata.validationErrors.periodAmountError,
+    iconData: getIconData(context),
+  }),
   updateContext: (context: NativeTokenPeriodicContext, value: string) => ({
     ...context,
     permissionDetails: {
@@ -37,15 +41,17 @@ export const periodTypeRule: RuleDefinition<
   NativeTokenPeriodicContext,
   NativeTokenPeriodicMetadata
 > = {
-  label: 'Period duration',
   name: PERIOD_TYPE_ELEMENT,
-  tooltip: 'The duration of the period',
+  label: 'Period duration',
   type: 'dropdown',
-  options: [TimePeriod.DAILY, TimePeriod.WEEKLY, 'Other'],
-  value: (context: NativeTokenPeriodicContext) =>
-    context.permissionDetails.periodType,
-  error: (metadata: NativeTokenPeriodicMetadata) =>
-    metadata.validationErrors.periodTypeError,
+  getRuleData: ({ context, metadata }) => ({
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    value: context.permissionDetails.periodType,
+    isVisible: true,
+    tooltip: 'The duration of the period',
+    options: [TimePeriod.DAILY, TimePeriod.WEEKLY, 'Other'],
+    error: metadata.validationErrors.periodTypeError,
+  }),
   updateContext: (context: NativeTokenPeriodicContext, value: string) => {
     const periodType = value as TimePeriod | 'Other';
     const periodDuration =
@@ -68,14 +74,16 @@ export const periodDurationRule: RuleDefinition<
   NativeTokenPeriodicContext,
   NativeTokenPeriodicMetadata
 > = {
-  label: 'Duration (seconds)',
   name: PERIOD_DURATION_ELEMENT,
-  tooltip: 'The length of each period in seconds',
+  label: 'Duration (seconds)',
   type: 'number',
-  value: (context: NativeTokenPeriodicContext) =>
-    context.permissionDetails.periodDuration,
-  error: (metadata: NativeTokenPeriodicMetadata) =>
-    metadata.validationErrors.periodDurationError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.periodDuration,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: context.permissionDetails.periodType === 'Other',
+    tooltip: 'The length of each period in seconds',
+    error: metadata.validationErrors.periodDurationError,
+  }),
   updateContext: (context: NativeTokenPeriodicContext, value: string) => ({
     ...context,
     permissionDetails: {
@@ -83,22 +91,22 @@ export const periodDurationRule: RuleDefinition<
       periodDuration: value,
     },
   }),
-  isVisible: (context: NativeTokenPeriodicContext) =>
-    context.permissionDetails.periodType === 'Other',
 };
 
 export const startTimeRule: RuleDefinition<
   NativeTokenPeriodicContext,
   NativeTokenPeriodicMetadata
 > = {
-  label: 'Start Time',
   name: START_TIME_ELEMENT,
-  tooltip: 'The time at which the first period begins',
+  label: 'Start Time',
   type: 'text',
-  value: (context: NativeTokenPeriodicContext) =>
-    context.permissionDetails.startTime,
-  error: (metadata: NativeTokenPeriodicMetadata) =>
-    metadata.validationErrors.startTimeError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.startTime,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The time at which the first period begins',
+    error: metadata.validationErrors.startTimeError,
+  }),
   updateContext: (context: NativeTokenPeriodicContext, value: string) => ({
     ...context,
     permissionDetails: {
@@ -112,12 +120,15 @@ export const expiryRule: RuleDefinition<
   NativeTokenPeriodicContext,
   NativeTokenPeriodicMetadata
 > = {
-  label: 'Expiry',
   name: EXPIRY_ELEMENT,
+  label: 'Expiry',
   type: 'text',
-  value: (context: NativeTokenPeriodicContext) => context.expiry,
-  error: (metadata: NativeTokenPeriodicMetadata) =>
-    metadata.validationErrors.expiryError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.expiry,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    error: metadata.validationErrors.expiryError,
+  }),
   updateContext: (context: NativeTokenPeriodicContext, value: string) => ({
     ...context,
     expiry: value,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
@@ -1,12 +1,5 @@
 import type { GenericSnapElement } from '@metamask/snaps-sdk/jsx';
-import {
-  Box,
-  Field,
-  Input,
-  Section,
-  Text,
-  Image,
-} from '@metamask/snaps-sdk/jsx';
+import { Box, Field, Input, Section, Text } from '@metamask/snaps-sdk/jsx';
 
 import { getChainName } from '../../../../shared/src/utils/common';
 import { JUSTIFICATION_SHOW_MORE_BUTTON_NAME } from '../../core/permissionHandler';
@@ -15,7 +8,6 @@ import { AccountDetails } from '../../ui/components/AccountDetails';
 import type { ItemDetails } from '../../ui/components/RequestDetails';
 import { RequestDetails } from '../../ui/components/RequestDetails';
 import { TooltipIcon } from '../../ui/components/TooltipIcon';
-import { IconUrls } from '../../ui/iconConstant';
 import {
   initialAmountRule,
   maxAmountRule,
@@ -28,6 +20,7 @@ import type {
   NativeTokenStreamContext,
   NativeTokenStreamMetadata,
 } from './types';
+import { TokenIcon } from '../../ui/components/TokenIcon';
 
 /**
  * Creates the confirmation content for a native token stream permission request.
@@ -71,7 +64,12 @@ export async function createConfirmationContent({
     {
       label: 'Token',
       text: context.tokenMetadata.symbol,
-      iconUrl: IconUrls.ethereum.token,
+      icon: (
+        <TokenIcon
+          imageDataBase64={context.tokenMetadata.iconDataBase64}
+          altText={context.tokenMetadata.symbol}
+        />
+      ),
     },
   ];
 
@@ -105,9 +103,9 @@ export async function createConfirmationContent({
           </Box>
           <Field>
             <Box>
-              <Image
-                src={IconUrls.ethereum.token}
-                alt={`${context.tokenMetadata.symbol} token icon`}
+              <TokenIcon
+                imageDataBase64={context.tokenMetadata.iconDataBase64}
+                altText={context.tokenMetadata.symbol}
               />
             </Box>
             <Input

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
@@ -7,6 +7,7 @@ import { renderRules } from '../../core/rules';
 import { AccountDetails } from '../../ui/components/AccountDetails';
 import type { ItemDetails } from '../../ui/components/RequestDetails';
 import { RequestDetails } from '../../ui/components/RequestDetails';
+import { TokenIcon } from '../../ui/components/TokenIcon';
 import { TooltipIcon } from '../../ui/components/TooltipIcon';
 import {
   initialAmountRule,
@@ -20,7 +21,6 @@ import type {
   NativeTokenStreamContext,
   NativeTokenStreamMetadata,
 } from './types';
-import { TokenIcon } from '../../ui/components/TokenIcon';
 
 /**
  * Creates the confirmation content for a native token stream permission request.

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/content.tsx
@@ -64,12 +64,12 @@ export async function createConfirmationContent({
     {
       label: 'Token',
       text: context.tokenMetadata.symbol,
-      icon: (
-        <TokenIcon
-          imageDataBase64={context.tokenMetadata.iconDataBase64}
-          altText={context.tokenMetadata.symbol}
-        />
-      ),
+      iconData: context.tokenMetadata.iconDataBase64
+        ? {
+            iconDataBase64: context.tokenMetadata.iconDataBase64,
+            altText: context.tokenMetadata.symbol,
+          }
+        : undefined,
     },
   ];
 

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -24,7 +24,6 @@ import type {
   PopulatedNativeTokenStreamPermission,
   NativeTokenStreamPermission,
 } from './types';
-import { fetchIconDataAsBase64 } from '../iconUtil';
 
 const DEFAULT_MAX_AMOUNT = toHex(maxUint256);
 const DEFAULT_INITIAL_AMOUNT = '0x0';
@@ -113,13 +112,11 @@ export async function buildContext({
   tokenPricesService,
   accountController,
   tokenMetadataService,
-  fetcher,
 }: {
   permissionRequest: NativeTokenStreamPermissionRequest;
   tokenPricesService: TokenPricesService;
   accountController: AccountController;
   tokenMetadataService: TokenMetadataService;
-  fetcher?: typeof fetch;
 }): Promise<NativeTokenStreamContext> {
   const chainId = Number(permissionRequest.chainId);
 
@@ -137,10 +134,8 @@ export async function buildContext({
     account: address,
   });
 
-  const iconDataResponse = await fetchIconDataAsBase64({
-    iconUrl,
-    fetcher,
-  });
+  const iconDataResponse =
+    await tokenMetadataService.fetchIconDataAsBase64(iconUrl);
 
   const iconDataBase64 = iconDataResponse.success
     ? iconDataResponse.imageDataBase64

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -24,6 +24,7 @@ import type {
   PopulatedNativeTokenStreamPermission,
   NativeTokenStreamPermission,
 } from './types';
+import { fetchIconDataBase64 } from '../iconUtil';
 
 const DEFAULT_MAX_AMOUNT = toHex(maxUint256);
 const DEFAULT_INITIAL_AMOUNT = '0x0';
@@ -128,10 +129,17 @@ export async function buildContext({
     balance: rawBalance,
     decimals,
     symbol,
+    iconUrl,
   } = await tokenMetadataService.getTokenBalanceAndMetadata({
     chainId,
     account: address,
   });
+
+  const iconDataResponse = await fetchIconDataBase64(iconUrl);
+
+  const iconDataBase64 = iconDataResponse.success
+    ? iconDataResponse.imageDataBase64
+    : null;
 
   const balanceFormatted = await tokenPricesService.getCryptoToFiatConversion(
     `eip155:1/slip44:60`,
@@ -184,6 +192,7 @@ export async function buildContext({
     tokenMetadata: {
       symbol,
       decimals,
+      iconDataBase64,
     },
     permissionDetails: {
       initialAmount,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -24,7 +24,7 @@ import type {
   PopulatedNativeTokenStreamPermission,
   NativeTokenStreamPermission,
 } from './types';
-import { fetchIconDataBase64 } from '../iconUtil';
+import { fetchIconDataAsBase64 } from '../iconUtil';
 
 const DEFAULT_MAX_AMOUNT = toHex(maxUint256);
 const DEFAULT_INITIAL_AMOUNT = '0x0';
@@ -113,11 +113,13 @@ export async function buildContext({
   tokenPricesService,
   accountController,
   tokenMetadataService,
+  fetcher,
 }: {
   permissionRequest: NativeTokenStreamPermissionRequest;
   tokenPricesService: TokenPricesService;
   accountController: AccountController;
   tokenMetadataService: TokenMetadataService;
+  fetcher?: typeof fetch;
 }): Promise<NativeTokenStreamContext> {
   const chainId = Number(permissionRequest.chainId);
 
@@ -135,7 +137,10 @@ export async function buildContext({
     account: address,
   });
 
-  const iconDataResponse = await fetchIconDataBase64(iconUrl);
+  const iconDataResponse = await fetchIconDataAsBase64({
+    iconUrl,
+    fetcher,
+  });
 
   const iconDataBase64 = iconDataResponse.success
     ? iconDataResponse.imageDataBase64

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/rules.ts
@@ -1,6 +1,6 @@
 import type { RuleDefinition } from '../../core/types';
 import { TimePeriod } from '../../core/types';
-import { IconUrls } from '../../ui/iconConstant';
+import { getIconData } from '../iconUtil';
 import type {
   NativeTokenStreamContext,
   NativeTokenStreamMetadata,
@@ -20,19 +20,17 @@ type NativeTokenStreamRuleDefinition = RuleDefinition<
 >;
 
 export const initialAmountRule: NativeTokenStreamRuleDefinition = {
-  label: 'Initial Amount',
   name: INITIAL_AMOUNT_ELEMENT,
+  label: 'Initial Amount',
   type: 'number',
-  isOptional: true,
-  iconData: {
-    iconUrl: IconUrls.ethereum.token,
-    iconAltText: 'Ether token icon',
-  },
-  tooltip: 'The initial amount of tokens that can be streamed.',
-  value: (context: NativeTokenStreamContext) =>
-    context.permissionDetails.initialAmount,
-  error: (metadata: NativeTokenStreamMetadata) =>
-    metadata.validationErrors.initialAmountError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.initialAmount,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    iconData: getIconData(context),
+    tooltip: 'The initial amount of tokens that can be streamed.',
+    error: metadata.validationErrors.initialAmountError,
+  }),
   updateContext: (
     context: NativeTokenStreamContext,
     value: string | undefined,
@@ -46,19 +44,17 @@ export const initialAmountRule: NativeTokenStreamRuleDefinition = {
 };
 
 export const maxAmountRule: NativeTokenStreamRuleDefinition = {
-  label: 'Max Amount',
   name: MAX_AMOUNT_ELEMENT,
-  tooltip: 'The maximum amount of tokens that can be streamed.',
+  label: 'Max Amount',
   type: 'number',
-  isOptional: true,
-  iconData: {
-    iconUrl: IconUrls.ethereum.token,
-    iconAltText: 'Ether token icon',
-  },
-  value: (context: NativeTokenStreamContext) =>
-    context.permissionDetails.maxAmount,
-  error: (metadata: NativeTokenStreamMetadata) =>
-    metadata.validationErrors.maxAmountError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.maxAmount,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The maximum amount of tokens that can be streamed.',
+    iconData: getIconData(context),
+    error: metadata.validationErrors.maxAmountError,
+  }),
   updateContext: (
     context: NativeTokenStreamContext,
     value: string | undefined,
@@ -72,14 +68,16 @@ export const maxAmountRule: NativeTokenStreamRuleDefinition = {
 };
 
 export const startTimeRule: NativeTokenStreamRuleDefinition = {
-  label: 'Start Time',
   name: START_TIME_ELEMENT,
+  label: 'Start Time',
   type: 'text',
-  tooltip: 'The start time of the stream.',
-  value: (context: NativeTokenStreamContext) =>
-    context.permissionDetails.startTime,
-  error: (metadata: NativeTokenStreamMetadata) =>
-    metadata.validationErrors.startTimeError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.startTime,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The start time of the stream.',
+    error: metadata.validationErrors.startTimeError,
+  }),
   updateContext: (context: NativeTokenStreamContext, value: string) => ({
     ...context,
     permissionDetails: {
@@ -90,18 +88,17 @@ export const startTimeRule: NativeTokenStreamRuleDefinition = {
 };
 
 export const streamAmountPerPeriodRule: NativeTokenStreamRuleDefinition = {
-  label: 'Stream Amount',
   name: AMOUNT_PER_PERIOD_ELEMENT,
+  label: 'Stream Amount',
   type: 'number',
-  tooltip: 'The amount of tokens that can be streamed per period.',
-  iconData: {
-    iconUrl: IconUrls.ethereum.token,
-    iconAltText: 'Ether token icon',
-  },
-  value: (context: NativeTokenStreamContext) =>
-    context.permissionDetails.amountPerPeriod,
-  error: (metadata: NativeTokenStreamMetadata) =>
-    metadata.validationErrors.amountPerPeriodError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.amountPerPeriod,
+    isVisible: true,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    tooltip: 'The amount of tokens that can be streamed per period.',
+    iconData: getIconData(context),
+    error: metadata.validationErrors.amountPerPeriodError,
+  }),
   updateContext: (context: NativeTokenStreamContext, value: string) => ({
     ...context,
     permissionDetails: {
@@ -112,13 +109,16 @@ export const streamAmountPerPeriodRule: NativeTokenStreamRuleDefinition = {
 };
 
 export const streamPeriodRule: NativeTokenStreamRuleDefinition = {
-  label: 'Stream Period',
   name: TIME_PERIOD_ELEMENT,
+  label: 'Stream Period',
   type: 'dropdown',
-  tooltip: 'The period of the stream.',
-  options: Object.values(TimePeriod),
-  value: (context: NativeTokenStreamContext) =>
-    context.permissionDetails.timePeriod,
+  getRuleData: ({ context }) => ({
+    value: context.permissionDetails.timePeriod,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The period of the stream.',
+    options: Object.values(TimePeriod),
+  }),
   updateContext: (context: NativeTokenStreamContext, value: TimePeriod) => ({
     ...context,
     permissionDetails: {
@@ -129,13 +129,16 @@ export const streamPeriodRule: NativeTokenStreamRuleDefinition = {
 };
 
 export const expiryRule: NativeTokenStreamRuleDefinition = {
-  label: 'Expiry',
   name: EXPIRY_ELEMENT,
+  label: 'Expiry',
   type: 'text',
-  tooltip: 'The expiry date of the permission.',
-  value: (context: NativeTokenStreamContext) => context.expiry,
-  error: (metadata: NativeTokenStreamMetadata) =>
-    metadata.validationErrors.expiryError,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.expiry,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    isVisible: true,
+    tooltip: 'The expiry date of the permission.',
+    error: metadata.validationErrors.expiryError,
+  }),
   updateContext: (context: NativeTokenStreamContext, value: string) => ({
     ...context,
     expiry: value,

--- a/packages/gator-permissions-snap/src/ui/components/AccountDetails.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/AccountDetails.tsx
@@ -13,6 +13,7 @@ export type AccountDetailsProps = {
   tokenMetadata: {
     decimals: number;
     symbol: string;
+    iconDataBase64: string | null;
   };
   title: string;
   tooltip: string;
@@ -26,6 +27,7 @@ export const AccountDetails: SnapComponent<AccountDetailsProps> = ({
 }) => {
   const { address, balance, balanceFormattedAsCurrency } = account;
   const { decimals } = tokenMetadata;
+
   return (
     <Section>
       <Box direction="vertical">

--- a/packages/gator-permissions-snap/src/ui/components/InputField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/InputField.tsx
@@ -1,15 +1,8 @@
-import {
-  Box,
-  Text,
-  Input,
-  Button,
-  Field,
-  Image,
-  Icon,
-} from '@metamask/snaps-sdk/jsx';
+import { Box, Text, Input, Button, Field, Icon } from '@metamask/snaps-sdk/jsx';
 
 import { TextField } from './TextField';
 import { TooltipIcon } from './TooltipIcon';
+import { TokenIcon } from './TokenIcon';
 
 export type InputFieldParams = {
   label: string;
@@ -22,7 +15,7 @@ export type InputFieldParams = {
   errorMessage?: string | undefined;
   iconData?:
     | {
-        iconUrl: string;
+        iconDataBase64: string;
         iconAltText: string;
       }
     | undefined;
@@ -39,8 +32,22 @@ export const InputField = ({
   errorMessage,
   iconData,
 }: InputFieldParams) => {
+  const iconElement = iconData ? (
+    <TokenIcon
+      imageDataBase64={iconData.iconDataBase64}
+      altText={iconData.iconAltText}
+    />
+  ) : null;
+
   if (disabled) {
-    return <TextField label={label} value={value} tooltip={tooltip} />;
+    return (
+      <TextField
+        label={label}
+        value={value}
+        tooltip={tooltip}
+        iconData={iconData}
+      />
+    );
   }
 
   const tooltipElement = tooltip ? <TooltipIcon tooltip={tooltip} /> : null;
@@ -48,9 +55,6 @@ export const InputField = ({
     <Button name={removeButtonName} type="button">
       <Icon name="close" color="primary" size="md" />
     </Button>
-  ) : null;
-  const iconElement = iconData ? (
-    <Image src={iconData.iconUrl} alt={iconData.iconAltText} />
   ) : null;
 
   return (

--- a/packages/gator-permissions-snap/src/ui/components/InputField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/InputField.tsx
@@ -1,8 +1,8 @@
 import { Box, Text, Input, Button, Field, Icon } from '@metamask/snaps-sdk/jsx';
 
 import { TextField } from './TextField';
-import { TooltipIcon } from './TooltipIcon';
 import { TokenIcon } from './TokenIcon';
+import { TooltipIcon } from './TooltipIcon';
 
 export type InputFieldParams = {
   label: string;

--- a/packages/gator-permissions-snap/src/ui/components/RequestDetails.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/RequestDetails.tsx
@@ -1,4 +1,10 @@
-import { Text, Section, Box, Image } from '@metamask/snaps-sdk/jsx';
+import {
+  Text,
+  Section,
+  Box,
+  Image,
+  SnapElement,
+} from '@metamask/snaps-sdk/jsx';
 
 import { ShowMoreText } from './ShowMoreText';
 import { TooltipIcon } from './TooltipIcon';
@@ -15,6 +21,7 @@ export type ItemDetails = {
   text: string;
   tooltipText?: string | undefined;
   iconUrl?: string | undefined;
+  icon?: SnapElement;
 };
 
 export const RequestDetails = ({
@@ -24,8 +31,14 @@ export const RequestDetails = ({
   justificationShowMoreElementName,
 }: RequestDetailsProps) => {
   const requestDetailsFields = itemDetails.map(
-    ({ label, text, iconUrl, tooltipText }) => {
-      const iconElement = iconUrl ? <Image src={iconUrl} alt={text} /> : null;
+    ({ label, text, iconUrl, icon, tooltipText }) => {
+      let iconElement: SnapElement | null = null;
+
+      if (icon) {
+        iconElement = icon;
+      } else if (iconUrl) {
+        iconElement = <Image src={iconUrl} alt={text} />;
+      }
 
       const tooltipElement = tooltipText ? (
         <TooltipIcon tooltip={tooltipText} />

--- a/packages/gator-permissions-snap/src/ui/components/RequestDetails.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/RequestDetails.tsx
@@ -1,7 +1,7 @@
-import type { SnapElement } from '@metamask/snaps-sdk/jsx';
-import { Text, Section, Box, Image } from '@metamask/snaps-sdk/jsx';
+import { Text, Section, Box } from '@metamask/snaps-sdk/jsx';
 
 import { ShowMoreText } from './ShowMoreText';
+import { TokenIcon } from './TokenIcon';
 import { TooltipIcon } from './TooltipIcon';
 
 type RequestDetailsProps = {
@@ -15,8 +15,7 @@ export type ItemDetails = {
   label: string;
   text: string;
   tooltipText?: string | undefined;
-  iconUrl?: string | undefined;
-  icon?: SnapElement;
+  iconData?: { iconDataBase64: string; altText: string } | undefined;
 };
 
 export const RequestDetails = ({
@@ -26,17 +25,16 @@ export const RequestDetails = ({
   justificationShowMoreElementName,
 }: RequestDetailsProps) => {
   const requestDetailsFields = itemDetails.map(
-    ({ label, text, iconUrl, icon, tooltipText }) => {
-      let iconElement: SnapElement | null = null;
-
-      if (icon) {
-        iconElement = icon;
-      } else if (iconUrl) {
-        iconElement = <Image src={iconUrl} alt={text} />;
-      }
-
+    ({ label, text, iconData, tooltipText }) => {
       const tooltipElement = tooltipText ? (
         <TooltipIcon tooltip={tooltipText} />
+      ) : null;
+
+      const iconElement = iconData ? (
+        <TokenIcon
+          imageDataBase64={iconData.iconDataBase64}
+          altText={iconData.altText}
+        />
       ) : null;
 
       return (

--- a/packages/gator-permissions-snap/src/ui/components/RequestDetails.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/RequestDetails.tsx
@@ -1,10 +1,5 @@
-import {
-  Text,
-  Section,
-  Box,
-  Image,
-  SnapElement,
-} from '@metamask/snaps-sdk/jsx';
+import type { SnapElement } from '@metamask/snaps-sdk/jsx';
+import { Text, Section, Box, Image } from '@metamask/snaps-sdk/jsx';
 
 import { ShowMoreText } from './ShowMoreText';
 import { TooltipIcon } from './TooltipIcon';

--- a/packages/gator-permissions-snap/src/ui/components/TextField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TextField.tsx
@@ -1,14 +1,32 @@
 import { Box, Text } from '@metamask/snaps-sdk/jsx';
 
 import { TooltipIcon } from './TooltipIcon';
+import { TokenIcon } from './TokenIcon';
 
 export type TextFieldParams = {
   label: string;
   value: string;
   tooltip?: string | undefined;
+  iconData?:
+    | {
+        iconDataBase64: string;
+        iconAltText: string;
+      }
+    | undefined;
 };
 
-export const TextField = ({ label, value, tooltip }: TextFieldParams) => {
+export const TextField = ({
+  label,
+  value,
+  tooltip,
+  iconData,
+}: TextFieldParams) => {
+  const iconElement = iconData ? (
+    <TokenIcon
+      imageDataBase64={iconData.iconDataBase64}
+      altText={iconData.iconAltText}
+    />
+  ) : null;
   const tooltipElement = tooltip ? <TooltipIcon tooltip={tooltip} /> : null;
 
   return (
@@ -18,6 +36,7 @@ export const TextField = ({ label, value, tooltip }: TextFieldParams) => {
         {tooltipElement}
       </Box>
       <Box direction="horizontal">
+        {iconElement}
         <Text>{value}</Text>
       </Box>
     </Box>

--- a/packages/gator-permissions-snap/src/ui/components/TextField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TextField.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from '@metamask/snaps-sdk/jsx';
 
-import { TooltipIcon } from './TooltipIcon';
 import { TokenIcon } from './TokenIcon';
+import { TooltipIcon } from './TooltipIcon';
 
 export type TextFieldParams = {
   label: string;

--- a/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
@@ -1,0 +1,25 @@
+import { SnapComponent, Image, Text } from '@metamask/snaps-sdk/jsx';
+
+export type TokenIconParams = {
+  imageDataBase64: string | null;
+  altText: string;
+  width?: number;
+  height?: number;
+};
+
+export const TokenIcon: SnapComponent<TokenIconParams> = ({
+  imageDataBase64,
+  altText,
+  width = 24,
+  height = 24,
+}) => {
+  if (!imageDataBase64) {
+    return <Text> </Text>;
+  }
+
+  const imageSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="${imageDataBase64}" width="${width}" height="${height}" />
+  </svg>`;
+
+  return <Image src={imageSvg} alt={altText} />;
+};

--- a/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
@@ -1,4 +1,5 @@
-import { SnapComponent, Image, Text } from '@metamask/snaps-sdk/jsx';
+import type { SnapComponent } from '@metamask/snaps-sdk/jsx';
+import { Image, Text } from '@metamask/snaps-sdk/jsx';
 
 export type TokenIconParams = {
   imageDataBase64: string | null;

--- a/packages/gator-permissions-snap/test/client/accountApiClient.test.ts
+++ b/packages/gator-permissions-snap/test/client/accountApiClient.test.ts
@@ -64,6 +64,8 @@ describe('AccountApiClient', () => {
         balance: BigInt('1000000000000000000'),
         decimals: 18,
         symbol: 'ETH',
+        iconUrl:
+          'https://dev-static.cx.metamask.io/api/v1/tokenIcons/1/0x0000000000000000000000000000000000000000.png',
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -111,6 +113,8 @@ describe('AccountApiClient', () => {
         balance: BigInt('2000000000000000000'),
         decimals: 18,
         symbol: 'DAI',
+        iconUrl:
+          'https://dev-static.cx.metamask.io/api/v1/tokenIcons/1/0x6b175474e89094c44da98b954eedeac495271d0f.png',
       });
 
       expect(mockFetch).toHaveBeenCalledWith(

--- a/packages/gator-permissions-snap/test/client/blockchainMetadataClient.test.ts
+++ b/packages/gator-permissions-snap/test/client/blockchainMetadataClient.test.ts
@@ -143,7 +143,7 @@ describe('BlockchainTokenMetadataClient', () => {
           account: mockAccount,
           assetAddress: mockTokenAddress,
         }),
-      ).rejects.toThrow('Failed to fetch balance');
+      ).rejects.toThrow('Failed to fetch token balance');
     });
 
     it('throws an error if ERC20 token decimals fetch fails', async () => {
@@ -163,7 +163,7 @@ describe('BlockchainTokenMetadataClient', () => {
           account: mockAccount,
           assetAddress: mockTokenAddress,
         }),
-      ).rejects.toThrow('Failed to fetch decimals');
+      ).rejects.toThrow('Failed to fetch token decimals');
     });
 
     it('throws an error if ERC20 token symbol fetch fails', async () => {
@@ -183,7 +183,7 @@ describe('BlockchainTokenMetadataClient', () => {
           account: mockAccount,
           assetAddress: mockTokenAddress,
         }),
-      ).rejects.toThrow('Failed to fetch symbol');
+      ).rejects.toThrow('Failed to fetch token symbol');
     });
   });
 });

--- a/packages/gator-permissions-snap/test/core/ruleModalManager.test.ts
+++ b/packages/gator-permissions-snap/test/core/ruleModalManager.test.ts
@@ -37,27 +37,39 @@ const mockMetadata: TestMetadata = {
 };
 
 const rule1: RuleDefinition<TestContext, TestMetadata> = {
-  label: 'Rule 1',
   name: 'rule1',
+  label: 'Rule 1',
   type: 'text',
-  value: (context) => context.rule1Value,
+  getRuleData: ({ context }) => ({
+    value: context.rule1Value,
+    isVisible: true,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+  }),
   updateContext: (context, value) => ({ ...context, rule1Value: value }),
 };
 
 const rule2: RuleDefinition<TestContext, TestMetadata> = {
-  label: 'Rule 2',
   name: 'rule2',
+  label: 'Rule 2',
   type: 'number',
-  value: (context) => context.rule2Value,
-  error: (metadata) => metadata.validationErrors.rule2Value,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.rule2Value,
+    isVisible: true,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    error: metadata.validationErrors.rule2Value,
+  }),
   updateContext: (context, value) => ({ ...context, rule2Value: value }),
 };
 
 const rule3: RuleDefinition<TestContext, TestMetadata> = {
-  label: 'Rule 3',
   name: 'rule3',
+  label: 'Rule 3',
   type: 'text',
-  value: (context) => context.rule3Value,
+  getRuleData: ({ context }) => ({
+    value: context.rule3Value,
+    isVisible: true,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+  }),
   updateContext: (context, value) => ({ ...context, rule3Value: value }),
 };
 
@@ -112,7 +124,10 @@ describe('RuleModalManager', () => {
 
   describe('hasRulesToAdd()', () => {
     it('should return true when there are rules with undefined values', () => {
-      const result = ruleModalManager.hasRulesToAdd({ context: mockContext });
+      const result = ruleModalManager.hasRulesToAdd({
+        context: mockContext,
+        metadata: mockMetadata,
+      });
       expect(result).toBe(true);
     });
 
@@ -125,6 +140,7 @@ describe('RuleModalManager', () => {
 
       const result = ruleModalManager.hasRulesToAdd({
         context: contextWithAllValues,
+        metadata: mockMetadata,
       });
       expect(result).toBe(false);
     });
@@ -140,7 +156,10 @@ describe('RuleModalManager', () => {
         deriveMetadata: mockDeriveMetadata,
       });
 
-      const result = emptyRuleManager.hasRulesToAdd({ context: mockContext });
+      const result = emptyRuleManager.hasRulesToAdd({
+        context: mockContext,
+        metadata: mockMetadata,
+      });
       expect(result).toBe(false);
     });
   });
@@ -426,7 +445,6 @@ describe('RuleModalManager', () => {
             },
             "type": "Input",
           },
-          "error": "Invalid value",
         },
         "type": "Field",
       },
@@ -434,7 +452,7 @@ describe('RuleModalManager', () => {
         "key": null,
         "props": {
           "children": "Save",
-          "disabled": true,
+          "disabled": false,
           "name": "save-new-rule",
           "type": "submit",
         },
@@ -748,11 +766,15 @@ describe('RuleModalManager', () => {
   describe('validation logic', () => {
     it('should validate rule value with error function', async () => {
       const ruleWithError: RuleDefinition<TestContext, TestMetadata> = {
-        label: 'Rule with Error',
         name: 'rule-with-error',
+        label: 'Rule with Error',
         type: 'text',
-        value: () => undefined,
-        error: (metadata) => metadata.validationErrors.ruleWithError,
+        getRuleData: ({ metadata }) => ({
+          value: undefined,
+          isVisible: true,
+          isAdjustmentAllowed: true,
+          error: metadata.validationErrors.ruleWithError,
+        }),
         updateContext: (context, value) => ({
           ...context,
           ruleWithError: value,
@@ -894,7 +916,6 @@ describe('RuleModalManager', () => {
             },
             "type": "Input",
           },
-          "error": "Custom error message",
         },
         "type": "Field",
       },
@@ -902,7 +923,7 @@ describe('RuleModalManager', () => {
         "key": null,
         "props": {
           "children": "Save",
-          "disabled": true,
+          "disabled": false,
           "name": "save-new-rule",
           "type": "submit",
         },
@@ -921,10 +942,14 @@ describe('RuleModalManager', () => {
 
     it('should handle missing error function gracefully', async () => {
       const ruleWithoutError: RuleDefinition<TestContext, TestMetadata> = {
-        label: 'Rule without Error',
         name: 'rule-without-error',
+        label: 'Rule without Error',
         type: 'text',
-        value: () => undefined,
+        getRuleData: () => ({
+          value: undefined,
+          isVisible: true,
+          isAdjustmentAllowed: true,
+        }),
         updateContext: (context, value) => ({
           ...context,
           ruleWithoutError: value,

--- a/packages/gator-permissions-snap/test/core/rules.test.ts
+++ b/packages/gator-permissions-snap/test/core/rules.test.ts
@@ -38,46 +38,66 @@ const mockMetadata: TestMetadata = {
 };
 
 const textRule: RuleDefinition<TestContext, TestMetadata> = {
-  label: 'Test Text Rule',
   name: 'test-text-rule',
-  tooltip: 'This is a test text rule',
+  label: 'Test Text Rule',
   type: 'text',
-  value: (context) => context.testValue,
-  error: (metadata) => metadata.validationErrors.testValue,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.testValue,
+    isVisible: true,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    tooltip: 'This is a test text rule',
+    error: metadata.validationErrors.testValue,
+  }),
   updateContext: (context, value) => ({ ...context, testValue: value }),
 };
 
 const numberRule: RuleDefinition<TestContext, TestMetadata> = {
-  label: 'Test Number Rule',
   name: 'test-number-rule',
+  label: 'Test Number Rule',
   type: 'number',
-  value: (context) => context.numberValue,
+  getRuleData: ({ context }) => ({
+    value: context.numberValue,
+    isVisible: true,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+  }),
   updateContext: (context, value) => ({ ...context, numberValue: value }),
 };
 
 const dropdownRule: RuleDefinition<TestContext, TestMetadata> = {
-  label: 'Test Dropdown Rule',
   name: 'test-dropdown-rule',
+  label: 'Test Dropdown Rule',
   type: 'dropdown',
-  options: ['option1', 'option2', 'option3'],
-  value: (context) => context.dropdownValue,
+  getRuleData: ({ context }) => ({
+    value: context.dropdownValue,
+    isVisible: true,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+    options: ['option1', 'option2', 'option3'],
+  }),
   updateContext: (context, value) => ({ ...context, dropdownValue: value }),
 };
 
 const optionalRule: RuleDefinition<TestContext, TestMetadata> = {
-  label: 'Test Optional Rule',
   name: 'test-optional-rule',
+  label: 'Test Optional Rule',
   type: 'text',
   isOptional: true,
-  value: (context) => context.optionalValue,
+  getRuleData: ({ context }) => ({
+    value: context.optionalValue,
+    isVisible: true,
+    isAdjustmentAllowed: context.isAdjustmentAllowed,
+  }),
   updateContext: (context, value) => ({ ...context, optionalValue: value }),
 };
 
 const undefinedValueRule: RuleDefinition<TestContext, TestMetadata> = {
-  label: 'Undefined Value Rule',
   name: 'undefined-value-rule',
+  label: 'Undefined Value Rule',
   type: 'text',
-  value: () => undefined,
+  getRuleData: () => ({
+    value: undefined,
+    isVisible: true,
+    isAdjustmentAllowed: true,
+  }),
   updateContext: (context, value) => ({ ...context, testValue: value }),
 };
 
@@ -488,13 +508,16 @@ describe('rules', () => {
       {
         "key": null,
         "props": {
-          "children": {
-            "key": null,
-            "props": {
-              "children": "test-value",
+          "children": [
+            null,
+            {
+              "key": null,
+              "props": {
+                "children": "test-value",
+              },
+              "type": "Text",
             },
-            "type": "Text",
-          },
+          ],
           "direction": "horizontal",
         },
         "type": "Box",
@@ -620,10 +643,15 @@ describe('rules', () => {
 
     it('should throw error for dropdown rule without options', () => {
       const invalidDropdownRule: RuleDefinition<TestContext, TestMetadata> = {
-        label: 'Invalid Dropdown',
         name: 'invalid-dropdown',
+        label: 'Invalid Dropdown',
         type: 'dropdown',
-        value: (context) => context.dropdownValue,
+        getRuleData: ({ context }) => ({
+          value: context.dropdownValue,
+          isVisible: true,
+          isAdjustmentAllowed: context.isAdjustmentAllowed,
+          // intentionally omitting options to test error handling
+        }),
         updateContext: (context, value) => ({
           ...context,
           dropdownValue: value,

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
@@ -22,6 +22,8 @@ const mockContext: Erc20TokenStreamContext = {
   tokenMetadata: {
     decimals: tokenDecimals,
     symbol: 'USDC',
+    iconDataBase64:
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
   },
   permissionDetails: {
     initialAmount: '1',
@@ -214,7 +216,16 @@ describe('erc20TokenStream:content', () => {
                       "key": null,
                       "props": {
                         "children": [
-                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "alt": "USDC",
+                              "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                            },
+                            "type": "Image",
+                          },
                           {
                             "key": null,
                             "props": {
@@ -504,7 +515,16 @@ describe('erc20TokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "children": null,
+                              "children": {
+                                "key": null,
+                                "props": {
+                                  "alt": "USDC",
+                                  "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                                },
+                                "type": "Image",
+                              },
                             },
                             "type": "Box",
                           },
@@ -682,16 +702,34 @@ describe('erc20TokenStream:content', () => {
                   {
                     "key": null,
                     "props": {
-                      "children": {
-                        "key": null,
-                        "props": {
-                          "disabled": true,
-                          "name": "stream-rate",
-                          "type": "text",
-                          "value": "0.5 USDC/sec",
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "alt": "USDC",
+                                "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                              },
+                              "type": "Image",
+                            },
+                          },
+                          "type": "Box",
                         },
-                        "type": "Input",
-                      },
+                        {
+                          "key": null,
+                          "props": {
+                            "disabled": true,
+                            "name": "stream-rate",
+                            "type": "text",
+                            "value": "0.5 USDC/sec",
+                          },
+                          "type": "Input",
+                        },
+                      ],
                     },
                     "type": "Field",
                   },
@@ -765,7 +803,16 @@ describe('erc20TokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": null,
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "alt": "USDC",
+                                "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                              },
+                              "type": "Image",
+                            },
                           },
                           "type": "Box",
                         },
@@ -867,7 +914,16 @@ describe('erc20TokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": null,
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "alt": "USDC",
+                                "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                              },
+                              "type": "Image",
+                            },
                           },
                           "type": "Box",
                         },
@@ -1279,7 +1335,16 @@ describe('erc20TokenStream:content', () => {
                       "key": null,
                       "props": {
                         "children": [
-                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "alt": "USDC",
+                              "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                            },
+                            "type": "Image",
+                          },
                           {
                             "key": null,
                             "props": {
@@ -1569,7 +1634,16 @@ describe('erc20TokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "children": null,
+                              "children": {
+                                "key": null,
+                                "props": {
+                                  "alt": "USDC",
+                                  "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                                },
+                                "type": "Image",
+                              },
                             },
                             "type": "Box",
                           },
@@ -1748,16 +1822,34 @@ describe('erc20TokenStream:content', () => {
                   {
                     "key": null,
                     "props": {
-                      "children": {
-                        "key": null,
-                        "props": {
-                          "disabled": true,
-                          "name": "stream-rate",
-                          "type": "text",
-                          "value": "0.5 USDC/sec",
+                      "children": [
+                        {
+                          "key": null,
+                          "props": {
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "alt": "USDC",
+                                "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                              },
+                              "type": "Image",
+                            },
+                          },
+                          "type": "Box",
                         },
-                        "type": "Input",
-                      },
+                        {
+                          "key": null,
+                          "props": {
+                            "disabled": true,
+                            "name": "stream-rate",
+                            "type": "text",
+                            "value": "0.5 USDC/sec",
+                          },
+                          "type": "Input",
+                        },
+                      ],
                     },
                     "type": "Field",
                   },
@@ -1831,7 +1923,16 @@ describe('erc20TokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": null,
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "alt": "USDC",
+                                "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                              },
+                              "type": "Image",
+                            },
                           },
                           "type": "Box",
                         },
@@ -1934,7 +2035,16 @@ describe('erc20TokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": null,
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "alt": "USDC",
+                                "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+  </svg>",
+                              },
+                              "type": "Image",
+                            },
                           },
                           "type": "Box",
                         },

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/context.test.ts
@@ -134,7 +134,6 @@ describe('erc20TokenStream:context', () => {
     let mockTokenPricesService: jest.Mocked<TokenPricesService>;
     let mockAccountController: jest.Mocked<AccountController>;
     let mockTokenMetadataService: jest.Mocked<TokenMetadataService>;
-    let mockFetcher: jest.MockedFunction<typeof fetch>;
 
     beforeEach(() => {
       mockTokenPricesService = {
@@ -157,32 +156,27 @@ describe('erc20TokenStream:context', () => {
           decimals: USDC_DECIMALS,
           iconUrl: 'https://example.com/icon.png',
         })),
+        fetchIconDataAsBase64: jest.fn(async () =>
+          Promise.resolve({ success: false }),
+        ),
       } as unknown as jest.Mocked<TokenMetadataService>;
-
-      mockFetcher = jest.fn(() => {
-        Promise.resolve({
-          ok: false,
-        });
-      }) as unknown as jest.MockedFunction<typeof fetch>;
     });
 
     it('should create a context from a permission request', async () => {
       const text = 'The contents of the image';
-      const uint8Array = new TextEncoder().encode(text);
-      const arrayBuffer = uint8Array.buffer;
-      const base64 = Buffer.from(uint8Array).toString('base64');
+      /* eslint-disable no-restricted-globals */
+      const base64 = Buffer.from(text, 'utf8').toString('base64');
 
-      mockFetcher.mockResolvedValueOnce({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(arrayBuffer),
-      } as unknown as Response);
+      mockTokenMetadataService.fetchIconDataAsBase64.mockResolvedValueOnce({
+        success: true,
+        imageDataBase64: `data:image/png;base64,${base64}`,
+      });
 
       const context = await buildContext({
         permissionRequest: alreadyPopulatedPermissionRequest,
         tokenPricesService: mockTokenPricesService,
         accountController: mockAccountController,
         tokenMetadataService: mockTokenMetadataService,
-        fetcher: mockFetcher,
       });
 
       expect(context).toStrictEqual({
@@ -251,7 +245,6 @@ describe('erc20TokenStream:context', () => {
         tokenPricesService: mockTokenPricesService,
         accountController: mockAccountController,
         tokenMetadataService: mockTokenMetadataService,
-        fetcher: mockFetcher,
       });
 
       expect(context.tokenMetadata).toStrictEqual({

--- a/packages/gator-permissions-snap/test/permissions/iconUtil.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/iconUtil.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import type { Hex } from 'viem';
+
+import {
+  fetchIconDataAsBase64,
+  getIconData,
+} from '../../src/permissions/iconUtil';
+import type { BaseTokenPermissionContext } from '../../src/core/types';
+
+describe('iconUtil', () => {
+  describe('fetchIconDataAsBase64', () => {
+    let mockFetch: jest.MockedFunction<typeof fetch>;
+
+    beforeEach(() => {
+      mockFetch = jest.fn();
+    });
+
+    describe('success cases', () => {
+      it('should successfully fetch and convert icon to base64', async () => {
+        const mockImageData = 'test image data';
+        const mockArrayBuffer = new TextEncoder().encode(mockImageData).buffer;
+        const expectedBase64 = Buffer.from(mockArrayBuffer).toString('base64');
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+        } as Response);
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/icon.png',
+          fetcher: mockFetch,
+        });
+
+        expect(result).toEqual({
+          success: true,
+          imageDataBase64: `data:image/png;base64,${expectedBase64}`,
+        });
+        expect(mockFetch).toHaveBeenCalledWith('https://example.com/icon.png');
+      });
+
+      it('should handle binary image data correctly', async () => {
+        // Create a mock binary image data (simulating PNG header)
+        const mockBinaryData = new Uint8Array([
+          137, 80, 78, 71, 13, 10, 26, 10,
+        ]);
+        const mockArrayBuffer = mockBinaryData.buffer;
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+        } as Response);
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/icon.png',
+          fetcher: mockFetch,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.imageDataBase64).toMatch(/^data:image\/png;base64,/);
+          expect(result.imageDataBase64.length).toBeGreaterThan(30);
+        }
+      });
+
+      it('should use default fetch when no fetcher is provided', async () => {
+        const originalFetch = global.fetch;
+        const mockGlobalFetch = jest.fn();
+        global.fetch = mockGlobalFetch;
+
+        const mockArrayBuffer = new TextEncoder().encode('test').buffer;
+        mockGlobalFetch.mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+        } as Response);
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/icon.png',
+        });
+
+        expect(result.success).toBe(true);
+        expect(mockGlobalFetch).toHaveBeenCalledWith(
+          'https://example.com/icon.png',
+        );
+
+        global.fetch = originalFetch;
+      });
+    });
+
+    describe('failure cases', () => {
+      it('should return failure when iconUrl is undefined', async () => {
+        const result = await fetchIconDataAsBase64({
+          iconUrl: undefined,
+          fetcher: mockFetch,
+        });
+
+        expect(result).toEqual({ success: false });
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it('should return failure when iconUrl is empty string', async () => {
+        const result = await fetchIconDataAsBase64({
+          iconUrl: '',
+          fetcher: mockFetch,
+        });
+
+        expect(result).toEqual({ success: false });
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it('should return failure when fetch response is not ok', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        } as Response);
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/nonexistent.png',
+          fetcher: mockFetch,
+        });
+
+        expect(result).toEqual({ success: false });
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://example.com/nonexistent.png',
+        );
+      });
+
+      it('should return failure when fetch throws an error', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/icon.png',
+          fetcher: mockFetch,
+        });
+
+        expect(result).toEqual({ success: false });
+        expect(mockFetch).toHaveBeenCalledWith('https://example.com/icon.png');
+      });
+
+      it('should return failure when arrayBuffer() throws an error', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.reject(new Error('ArrayBuffer error')),
+        } as Response);
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/icon.png',
+          fetcher: mockFetch,
+        });
+
+        expect(result).toEqual({ success: false });
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle empty response body', async () => {
+        const emptyArrayBuffer = new ArrayBuffer(0);
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(emptyArrayBuffer),
+        } as Response);
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/empty.png',
+          fetcher: mockFetch,
+        });
+
+        expect(result).toEqual({
+          success: true,
+          imageDataBase64: 'data:image/png;base64,',
+        });
+      });
+
+      it('should handle very large image data', async () => {
+        // Create a large mock image (1MB)
+        const largeImageData = new Uint8Array(1024 * 1024).fill(255);
+        const mockArrayBuffer = largeImageData.buffer;
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+        } as Response);
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/large-icon.png',
+          fetcher: mockFetch,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.imageDataBase64).toMatch(/^data:image\/png;base64,/);
+          expect(result.imageDataBase64.length).toBeGreaterThan(1000000);
+        }
+      });
+
+      it('should handle special characters in URL', async () => {
+        const mockArrayBuffer = new TextEncoder().encode('test').buffer;
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+        } as Response);
+
+        const result = await fetchIconDataAsBase64({
+          iconUrl: 'https://example.com/icon with spaces & symbols.png',
+          fetcher: mockFetch,
+        });
+
+        expect(result.success).toBe(true);
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://example.com/icon with spaces & symbols.png',
+        );
+      });
+    });
+  });
+
+  describe('getIconData', () => {
+    const createMockContext = (
+      iconDataBase64: string | null,
+      symbol: string = 'USDC',
+    ): BaseTokenPermissionContext => ({
+      expiry: '05/01/2024',
+      isAdjustmentAllowed: true,
+      justification: 'Test permission',
+      accountDetails: {
+        address: '0x1234567890123456789012345678901234567890' as Hex,
+        balance: '0x1000000' as Hex,
+        balanceFormattedAsCurrency: '$100.00',
+      },
+      tokenMetadata: {
+        symbol,
+        decimals: 6,
+        iconDataBase64,
+      },
+    });
+
+    describe('success cases', () => {
+      it('should return IconData when iconDataBase64 is provided', () => {
+        const mockIconUrl =
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+        const context = createMockContext(mockIconUrl, 'USDC');
+
+        const result = getIconData(context);
+
+        expect(result).toEqual({
+          iconDataBase64: mockIconUrl,
+          iconAltText: 'USDC',
+        });
+      });
+
+      it('should use token symbol as alt text', () => {
+        const mockIconUrl = 'data:image/png;base64,test';
+        const context = createMockContext(mockIconUrl, 'ETH');
+
+        const result = getIconData(context);
+
+        expect(result).toEqual({
+          iconDataBase64: mockIconUrl,
+          iconAltText: 'ETH',
+        });
+      });
+
+      it('should handle different icon formats', () => {
+        const mockIconUrl = 'https://example.com/icon.svg';
+        const context = createMockContext(mockIconUrl, 'DAI');
+
+        const result = getIconData(context);
+
+        expect(result).toEqual({
+          iconDataBase64: mockIconUrl,
+          iconAltText: 'DAI',
+        });
+      });
+    });
+
+    describe('failure cases', () => {
+      it('should return undefined when iconDataBase64 is null', () => {
+        const context = createMockContext(null);
+
+        const result = getIconData(context);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined when iconDataBase64 is empty string', () => {
+        const context = createMockContext('');
+
+        const result = getIconData(context);
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle empty symbol', () => {
+        const mockIconUrl = 'data:image/png;base64,test';
+        const context = createMockContext(mockIconUrl, '');
+
+        const result = getIconData(context);
+
+        expect(result).toEqual({
+          iconDataBase64: mockIconUrl,
+          iconAltText: '',
+        });
+      });
+
+      it('should handle symbol with special characters', () => {
+        const mockIconUrl = 'data:image/png;base64,test';
+        const context = createMockContext(mockIconUrl, 'USDC-ETH LP');
+
+        const result = getIconData(context);
+
+        expect(result).toEqual({
+          iconDataBase64: mockIconUrl,
+          iconAltText: 'USDC-ETH LP',
+        });
+      });
+
+      it('should handle very long symbol', () => {
+        const mockIconUrl = 'data:image/png;base64,test';
+        const longSymbol = 'A'.repeat(100);
+        const context = createMockContext(mockIconUrl, longSymbol);
+
+        const result = getIconData(context);
+
+        expect(result).toEqual({
+          iconDataBase64: mockIconUrl,
+          iconAltText: longSymbol,
+        });
+      });
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/iconUtil.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/iconUtil.test.ts
@@ -1,223 +1,14 @@
-import { describe, expect, it, beforeEach } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import type { Hex } from 'viem';
 
-import {
-  fetchIconDataAsBase64,
-  getIconData,
-} from '../../src/permissions/iconUtil';
 import type { BaseTokenPermissionContext } from '../../src/core/types';
+import { getIconData } from '../../src/permissions/iconUtil';
 
 describe('iconUtil', () => {
-  describe('fetchIconDataAsBase64', () => {
-    let mockFetch: jest.MockedFunction<typeof fetch>;
-
-    beforeEach(() => {
-      mockFetch = jest.fn();
-    });
-
-    describe('success cases', () => {
-      it('should successfully fetch and convert icon to base64', async () => {
-        const mockImageData = 'test image data';
-        const mockArrayBuffer = new TextEncoder().encode(mockImageData).buffer;
-        const expectedBase64 = Buffer.from(mockArrayBuffer).toString('base64');
-
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
-        } as Response);
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/icon.png',
-          fetcher: mockFetch,
-        });
-
-        expect(result).toEqual({
-          success: true,
-          imageDataBase64: `data:image/png;base64,${expectedBase64}`,
-        });
-        expect(mockFetch).toHaveBeenCalledWith('https://example.com/icon.png');
-      });
-
-      it('should handle binary image data correctly', async () => {
-        // Create a mock binary image data (simulating PNG header)
-        const mockBinaryData = new Uint8Array([
-          137, 80, 78, 71, 13, 10, 26, 10,
-        ]);
-        const mockArrayBuffer = mockBinaryData.buffer;
-
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
-        } as Response);
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/icon.png',
-          fetcher: mockFetch,
-        });
-
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(result.imageDataBase64).toMatch(/^data:image\/png;base64,/);
-          expect(result.imageDataBase64.length).toBeGreaterThan(30);
-        }
-      });
-
-      it('should use default fetch when no fetcher is provided', async () => {
-        const originalFetch = global.fetch;
-        const mockGlobalFetch = jest.fn();
-        global.fetch = mockGlobalFetch;
-
-        const mockArrayBuffer = new TextEncoder().encode('test').buffer;
-        mockGlobalFetch.mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
-        } as Response);
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/icon.png',
-        });
-
-        expect(result.success).toBe(true);
-        expect(mockGlobalFetch).toHaveBeenCalledWith(
-          'https://example.com/icon.png',
-        );
-
-        global.fetch = originalFetch;
-      });
-    });
-
-    describe('failure cases', () => {
-      it('should return failure when iconUrl is undefined', async () => {
-        const result = await fetchIconDataAsBase64({
-          iconUrl: undefined,
-          fetcher: mockFetch,
-        });
-
-        expect(result).toEqual({ success: false });
-        expect(mockFetch).not.toHaveBeenCalled();
-      });
-
-      it('should return failure when iconUrl is empty string', async () => {
-        const result = await fetchIconDataAsBase64({
-          iconUrl: '',
-          fetcher: mockFetch,
-        });
-
-        expect(result).toEqual({ success: false });
-        expect(mockFetch).not.toHaveBeenCalled();
-      });
-
-      it('should return failure when fetch response is not ok', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 404,
-          statusText: 'Not Found',
-        } as Response);
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/nonexistent.png',
-          fetcher: mockFetch,
-        });
-
-        expect(result).toEqual({ success: false });
-        expect(mockFetch).toHaveBeenCalledWith(
-          'https://example.com/nonexistent.png',
-        );
-      });
-
-      it('should return failure when fetch throws an error', async () => {
-        mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/icon.png',
-          fetcher: mockFetch,
-        });
-
-        expect(result).toEqual({ success: false });
-        expect(mockFetch).toHaveBeenCalledWith('https://example.com/icon.png');
-      });
-
-      it('should return failure when arrayBuffer() throws an error', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.reject(new Error('ArrayBuffer error')),
-        } as Response);
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/icon.png',
-          fetcher: mockFetch,
-        });
-
-        expect(result).toEqual({ success: false });
-      });
-    });
-
-    describe('edge cases', () => {
-      it('should handle empty response body', async () => {
-        const emptyArrayBuffer = new ArrayBuffer(0);
-
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(emptyArrayBuffer),
-        } as Response);
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/empty.png',
-          fetcher: mockFetch,
-        });
-
-        expect(result).toEqual({
-          success: true,
-          imageDataBase64: 'data:image/png;base64,',
-        });
-      });
-
-      it('should handle very large image data', async () => {
-        // Create a large mock image (1MB)
-        const largeImageData = new Uint8Array(1024 * 1024).fill(255);
-        const mockArrayBuffer = largeImageData.buffer;
-
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
-        } as Response);
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/large-icon.png',
-          fetcher: mockFetch,
-        });
-
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(result.imageDataBase64).toMatch(/^data:image\/png;base64,/);
-          expect(result.imageDataBase64.length).toBeGreaterThan(1000000);
-        }
-      });
-
-      it('should handle special characters in URL', async () => {
-        const mockArrayBuffer = new TextEncoder().encode('test').buffer;
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
-        } as Response);
-
-        const result = await fetchIconDataAsBase64({
-          iconUrl: 'https://example.com/icon with spaces & symbols.png',
-          fetcher: mockFetch,
-        });
-
-        expect(result.success).toBe(true);
-        expect(mockFetch).toHaveBeenCalledWith(
-          'https://example.com/icon with spaces & symbols.png',
-        );
-      });
-    });
-  });
-
   describe('getIconData', () => {
     const createMockContext = (
       iconDataBase64: string | null,
-      symbol: string = 'USDC',
+      symbol = 'USDC',
     ): BaseTokenPermissionContext => ({
       expiry: '05/01/2024',
       isAdjustmentAllowed: true,
@@ -234,99 +25,92 @@ describe('iconUtil', () => {
       },
     });
 
-    describe('success cases', () => {
-      it('should return IconData when iconDataBase64 is provided', () => {
-        const mockIconUrl =
-          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
-        const context = createMockContext(mockIconUrl, 'USDC');
+    it('returns IconData when iconDataBase64 is provided', () => {
+      const mockIconUrl =
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+      const context = createMockContext(mockIconUrl, 'USDC');
 
-        const result = getIconData(context);
+      const result = getIconData(context);
 
-        expect(result).toEqual({
-          iconDataBase64: mockIconUrl,
-          iconAltText: 'USDC',
-        });
-      });
-
-      it('should use token symbol as alt text', () => {
-        const mockIconUrl = 'data:image/png;base64,test';
-        const context = createMockContext(mockIconUrl, 'ETH');
-
-        const result = getIconData(context);
-
-        expect(result).toEqual({
-          iconDataBase64: mockIconUrl,
-          iconAltText: 'ETH',
-        });
-      });
-
-      it('should handle different icon formats', () => {
-        const mockIconUrl = 'https://example.com/icon.svg';
-        const context = createMockContext(mockIconUrl, 'DAI');
-
-        const result = getIconData(context);
-
-        expect(result).toEqual({
-          iconDataBase64: mockIconUrl,
-          iconAltText: 'DAI',
-        });
+      expect(result).toStrictEqual({
+        iconDataBase64: mockIconUrl,
+        iconAltText: 'USDC',
       });
     });
 
-    describe('failure cases', () => {
-      it('should return undefined when iconDataBase64 is null', () => {
-        const context = createMockContext(null);
+    it('uses token symbol as alt text', () => {
+      const mockIconUrl = 'data:image/png;base64,test';
+      const context = createMockContext(mockIconUrl, 'ETH');
 
-        const result = getIconData(context);
+      const result = getIconData(context);
 
-        expect(result).toBeUndefined();
-      });
-
-      it('should return undefined when iconDataBase64 is empty string', () => {
-        const context = createMockContext('');
-
-        const result = getIconData(context);
-
-        expect(result).toBeUndefined();
+      expect(result).toStrictEqual({
+        iconDataBase64: mockIconUrl,
+        iconAltText: 'ETH',
       });
     });
 
-    describe('edge cases', () => {
-      it('should handle empty symbol', () => {
-        const mockIconUrl = 'data:image/png;base64,test';
-        const context = createMockContext(mockIconUrl, '');
+    it('handles different icon formats', () => {
+      const mockIconUrl = 'https://example.com/icon.svg';
+      const context = createMockContext(mockIconUrl, 'DAI');
 
-        const result = getIconData(context);
+      const result = getIconData(context);
 
-        expect(result).toEqual({
-          iconDataBase64: mockIconUrl,
-          iconAltText: '',
-        });
+      expect(result).toStrictEqual({
+        iconDataBase64: mockIconUrl,
+        iconAltText: 'DAI',
       });
+    });
+    it('returns undefined when iconDataBase64 is null', () => {
+      const context = createMockContext(null);
 
-      it('should handle symbol with special characters', () => {
-        const mockIconUrl = 'data:image/png;base64,test';
-        const context = createMockContext(mockIconUrl, 'USDC-ETH LP');
+      const result = getIconData(context);
 
-        const result = getIconData(context);
+      expect(result).toBeUndefined();
+    });
 
-        expect(result).toEqual({
-          iconDataBase64: mockIconUrl,
-          iconAltText: 'USDC-ETH LP',
-        });
+    it('returns undefined when iconDataBase64 is empty string', () => {
+      const context = createMockContext('');
+
+      const result = getIconData(context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('handles empty symbol', () => {
+      const mockIconUrl = 'data:image/png;base64,test';
+      const context = createMockContext(mockIconUrl, '');
+
+      const result = getIconData(context);
+
+      expect(result).toStrictEqual({
+        iconDataBase64: mockIconUrl,
+        iconAltText: '',
       });
+    });
 
-      it('should handle very long symbol', () => {
-        const mockIconUrl = 'data:image/png;base64,test';
-        const longSymbol = 'A'.repeat(100);
-        const context = createMockContext(mockIconUrl, longSymbol);
+    it('handles symbol with special characters', () => {
+      const mockIconUrl = 'data:image/png;base64,test';
+      const context = createMockContext(mockIconUrl, 'USDC-ETH LP');
 
-        const result = getIconData(context);
+      const result = getIconData(context);
 
-        expect(result).toEqual({
-          iconDataBase64: mockIconUrl,
-          iconAltText: longSymbol,
-        });
+      expect(result).toStrictEqual({
+        iconDataBase64: mockIconUrl,
+        iconAltText: 'USDC-ETH LP',
+      });
+    });
+
+    it('handles very long symbol', () => {
+      const mockIconUrl = 'data:image/png;base64,test';
+      const longSymbol = 'A'.repeat(100);
+      const context = createMockContext(mockIconUrl, longSymbol);
+
+      const result = getIconData(context);
+
+      expect(result).toStrictEqual({
+        iconDataBase64: mockIconUrl,
+        iconAltText: longSymbol,
       });
     });
   });

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
@@ -215,13 +215,7 @@ describe('nativeTokenPeriodic:content', () => {
                           "key": null,
                           "props": {
                             "children": [
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": " ",
-                                },
-                                "type": "Text",
-                              },
+                              null,
                               {
                                 "key": null,
                                 "props": {
@@ -994,13 +988,7 @@ describe('nativeTokenPeriodic:content', () => {
                           "key": null,
                           "props": {
                             "children": [
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": " ",
-                                },
-                                "type": "Text",
-                              },
+                              null,
                               {
                                 "key": null,
                                 "props": {

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
@@ -21,6 +21,7 @@ const mockContext: NativeTokenPeriodicContext = {
   tokenMetadata: {
     symbol: 'ETH',
     decimals: 18,
+    iconDataBase64: null,
   },
   permissionDetails: {
     periodAmount: '1',
@@ -217,26 +218,9 @@ describe('nativeTokenPeriodic:content', () => {
                               {
                                 "key": null,
                                 "props": {
-                                  "alt": "ETH",
-                                  "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                                  "children": " ",
                                 },
-                                "type": "Image",
+                                "type": "Text",
                               },
                               {
                                 "key": null,
@@ -1013,26 +997,9 @@ describe('nativeTokenPeriodic:content', () => {
                               {
                                 "key": null,
                                 "props": {
-                                  "alt": "ETH",
-                                  "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                                  "children": " ",
                                 },
-                                "type": "Image",
+                                "type": "Text",
                               },
                               {
                                 "key": null,

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/context.test.ts
@@ -109,7 +109,6 @@ describe('nativeTokenPeriodic:context', () => {
     let mockTokenPricesService: jest.Mocked<TokenPricesService>;
     let mockAccountController: jest.Mocked<AccountController>;
     let mockTokenMetadataService: jest.Mocked<TokenMetadataService>;
-    let mockFetcher: jest.MockedFunction<typeof fetch>;
     beforeEach(() => {
       mockTokenPricesService = {
         getCryptoToFiatConversion: jest.fn(
@@ -131,32 +130,27 @@ describe('nativeTokenPeriodic:context', () => {
           decimals: 18,
           iconUrl: 'https://example.com/icon.png',
         })),
+        fetchIconDataAsBase64: jest.fn(async () =>
+          Promise.resolve({ success: false }),
+        ),
       } as unknown as jest.Mocked<TokenMetadataService>;
-
-      mockFetcher = jest.fn(() => {
-        Promise.resolve({
-          ok: false,
-        });
-      }) as unknown as jest.MockedFunction<typeof fetch>;
     });
 
     it('should create a context from a permission request', async () => {
       const text = 'The contents of the image';
-      const uint8Array = new TextEncoder().encode(text);
-      const arrayBuffer = uint8Array.buffer;
-      const base64 = Buffer.from(uint8Array).toString('base64');
+      /* eslint-disable no-restricted-globals */
+      const base64 = Buffer.from(text, 'utf8').toString('base64');
 
-      mockFetcher.mockResolvedValueOnce({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(arrayBuffer),
-      } as unknown as Response);
+      mockTokenMetadataService.fetchIconDataAsBase64.mockResolvedValueOnce({
+        success: true,
+        imageDataBase64: `data:image/png;base64,${base64}`,
+      });
 
       const context = await buildContext({
         permissionRequest: alreadyPopulatedPermissionRequest,
         tokenPricesService: mockTokenPricesService,
         accountController: mockAccountController,
         tokenMetadataService: mockTokenMetadataService,
-        fetcher: mockFetcher,
       });
 
       expect(context).toStrictEqual({

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/context.test.ts
@@ -65,6 +65,7 @@ const alreadyPopulatedContext: NativeTokenPeriodicContext = {
   tokenMetadata: {
     symbol: 'ETH',
     decimals: 18,
+    iconDataBase64: null,
   },
   permissionDetails: {
     periodAmount: '1',
@@ -108,7 +109,7 @@ describe('nativeTokenPeriodic:context', () => {
     let mockTokenPricesService: jest.Mocked<TokenPricesService>;
     let mockAccountController: jest.Mocked<AccountController>;
     let mockTokenMetadataService: jest.Mocked<TokenMetadataService>;
-
+    let mockFetcher: jest.MockedFunction<typeof fetch>;
     beforeEach(() => {
       mockTokenPricesService = {
         getCryptoToFiatConversion: jest.fn(
@@ -128,19 +129,43 @@ describe('nativeTokenPeriodic:context', () => {
           balance: BigInt(alreadyPopulatedContext.accountDetails.balance),
           symbol: alreadyPopulatedContext.tokenMetadata.symbol,
           decimals: 18,
+          iconUrl: 'https://example.com/icon.png',
         })),
       } as unknown as jest.Mocked<TokenMetadataService>;
+
+      mockFetcher = jest.fn(() => {
+        Promise.resolve({
+          ok: false,
+        });
+      }) as unknown as jest.MockedFunction<typeof fetch>;
     });
 
     it('should create a context from a permission request', async () => {
+      const text = 'The contents of the image';
+      const uint8Array = new TextEncoder().encode(text);
+      const arrayBuffer = uint8Array.buffer;
+      const base64 = Buffer.from(uint8Array).toString('base64');
+
+      mockFetcher.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(arrayBuffer),
+      } as unknown as Response);
+
       const context = await buildContext({
         permissionRequest: alreadyPopulatedPermissionRequest,
         tokenPricesService: mockTokenPricesService,
         accountController: mockAccountController,
         tokenMetadataService: mockTokenMetadataService,
+        fetcher: mockFetcher,
       });
 
-      expect(context).toStrictEqual(alreadyPopulatedContext);
+      expect(context).toStrictEqual({
+        ...alreadyPopulatedContext,
+        tokenMetadata: {
+          ...alreadyPopulatedContext.tokenMetadata,
+          iconDataBase64: `data:image/png;base64,${base64}`,
+        },
+      });
 
       expect(mockAccountController.getAccountAddress).toHaveBeenCalledWith({
         chainId: Number(alreadyPopulatedPermissionRequest.chainId),

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
@@ -213,13 +213,7 @@ describe('nativeTokenStream:content', () => {
                       "key": null,
                       "props": {
                         "children": [
-                          {
-                            "key": null,
-                            "props": {
-                              "children": " ",
-                            },
-                            "type": "Text",
-                          },
+                          null,
                           {
                             "key": null,
                             "props": {
@@ -1264,13 +1258,7 @@ describe('nativeTokenStream:content', () => {
                       "key": null,
                       "props": {
                         "children": [
-                          {
-                            "key": null,
-                            "props": {
-                              "children": " ",
-                            },
-                            "type": "Text",
-                          },
+                          null,
                           {
                             "key": null,
                             "props": {
@@ -2314,13 +2302,7 @@ describe('nativeTokenStream:content', () => {
                       "key": null,
                       "props": {
                         "children": [
-                          {
-                            "key": null,
-                            "props": {
-                              "children": " ",
-                            },
-                            "type": "Text",
-                          },
+                          null,
                           {
                             "key": null,
                             "props": {
@@ -3233,13 +3215,7 @@ describe('nativeTokenStream:content', () => {
                       "key": null,
                       "props": {
                         "children": [
-                          {
-                            "key": null,
-                            "props": {
-                              "children": " ",
-                            },
-                            "type": "Text",
-                          },
+                          null,
                           {
                             "key": null,
                             "props": {
@@ -4116,13 +4092,7 @@ describe('nativeTokenStream:content', () => {
                       "key": null,
                       "props": {
                         "children": [
-                          {
-                            "key": null,
-                            "props": {
-                              "children": " ",
-                            },
-                            "type": "Text",
-                          },
+                          null,
                           {
                             "key": null,
                             "props": {

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
@@ -20,6 +20,7 @@ const mockContext: NativeTokenStreamContext = {
   tokenMetadata: {
     symbol: 'ETH',
     decimals: 18,
+    iconDataBase64: null,
   },
   permissionDetails: {
     initialAmount: '1',
@@ -215,26 +216,9 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "alt": "ETH",
-                              "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                              "children": " ",
                             },
-                            "type": "Image",
+                            "type": "Text",
                           },
                           {
                             "key": null,
@@ -525,30 +509,7 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "children": {
-                                "key": null,
-                                "props": {
-                                  "alt": "Ether token icon",
-                                  "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                                },
-                                "type": "Image",
-                              },
+                              "children": null,
                             },
                             "type": "Box",
                           },
@@ -733,26 +694,9 @@ describe('nativeTokenStream:content', () => {
                             "children": {
                               "key": null,
                               "props": {
-                                "alt": "ETH token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                                "children": " ",
                               },
-                              "type": "Image",
+                              "type": "Text",
                             },
                           },
                           "type": "Box",
@@ -841,30 +785,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "alt": "Ether token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                              },
-                              "type": "Image",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -880,23 +801,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "children": {
-                                  "key": null,
-                                  "props": {
-                                    "color": "primary",
-                                    "name": "close",
-                                    "size": "md",
-                                  },
-                                  "type": "Icon",
-                                },
-                                "name": "native-token-stream-initial-amount_removeButton",
-                                "type": "button",
-                              },
-                              "type": "Button",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -966,30 +871,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "alt": "Ether token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                              },
-                              "type": "Image",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -1005,23 +887,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "children": {
-                                  "key": null,
-                                  "props": {
-                                    "color": "primary",
-                                    "name": "close",
-                                    "size": "md",
-                                  },
-                                  "type": "Icon",
-                                },
-                                "name": "native-token-stream-max-amount_removeButton",
-                                "type": "button",
-                              },
-                              "type": "Button",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -1401,26 +1267,9 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "alt": "ETH",
-                              "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                              "children": " ",
                             },
-                            "type": "Image",
+                            "type": "Text",
                           },
                           {
                             "key": null,
@@ -1711,30 +1560,7 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "children": {
-                                "key": null,
-                                "props": {
-                                  "alt": "Ether token icon",
-                                  "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                                },
-                                "type": "Image",
-                              },
+                              "children": null,
                             },
                             "type": "Box",
                           },
@@ -1920,26 +1746,9 @@ describe('nativeTokenStream:content', () => {
                             "children": {
                               "key": null,
                               "props": {
-                                "alt": "ETH token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                                "children": " ",
                               },
-                              "type": "Image",
+                              "type": "Text",
                             },
                           },
                           "type": "Box",
@@ -2028,30 +1837,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "alt": "Ether token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                              },
-                              "type": "Image",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -2067,23 +1853,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "children": {
-                                  "key": null,
-                                  "props": {
-                                    "color": "primary",
-                                    "name": "close",
-                                    "size": "md",
-                                  },
-                                  "type": "Icon",
-                                },
-                                "name": "native-token-stream-initial-amount_removeButton",
-                                "type": "button",
-                              },
-                              "type": "Button",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -2154,30 +1924,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "alt": "Ether token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                              },
-                              "type": "Image",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -2193,23 +1940,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "children": {
-                                  "key": null,
-                                  "props": {
-                                    "color": "primary",
-                                    "name": "close",
-                                    "size": "md",
-                                  },
-                                  "type": "Icon",
-                                },
-                                "name": "native-token-stream-max-amount_removeButton",
-                                "type": "button",
-                              },
-                              "type": "Button",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -2586,26 +2317,9 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "alt": "ETH",
-                              "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                              "children": " ",
                             },
-                            "type": "Image",
+                            "type": "Text",
                           },
                           {
                             "key": null,
@@ -2885,13 +2599,16 @@ describe('nativeTokenStream:content', () => {
                     {
                       "key": null,
                       "props": {
-                        "children": {
-                          "key": null,
-                          "props": {
-                            "children": "302400",
+                        "children": [
+                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "302400",
+                            },
+                            "type": "Text",
                           },
-                          "type": "Text",
-                        },
+                        ],
                         "direction": "horizontal",
                       },
                       "type": "Box",
@@ -2947,13 +2664,16 @@ describe('nativeTokenStream:content', () => {
                     {
                       "key": null,
                       "props": {
-                        "children": {
-                          "key": null,
-                          "props": {
-                            "children": "Weekly",
+                        "children": [
+                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "Weekly",
+                            },
+                            "type": "Text",
                           },
-                          "type": "Text",
-                        },
+                        ],
                         "direction": "horizontal",
                       },
                       "type": "Box",
@@ -3024,26 +2744,9 @@ describe('nativeTokenStream:content', () => {
                             "children": {
                               "key": null,
                               "props": {
-                                "alt": "ETH token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                                "children": " ",
                               },
-                              "type": "Image",
+                              "type": "Text",
                             },
                           },
                           "type": "Box",
@@ -3121,13 +2824,16 @@ describe('nativeTokenStream:content', () => {
                   {
                     "key": null,
                     "props": {
-                      "children": {
-                        "key": null,
-                        "props": {
-                          "children": "1",
+                      "children": [
+                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "children": "1",
+                          },
+                          "type": "Text",
                         },
-                        "type": "Text",
-                      },
+                      ],
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -3183,13 +2889,16 @@ describe('nativeTokenStream:content', () => {
                   {
                     "key": null,
                     "props": {
-                      "children": {
-                        "key": null,
-                        "props": {
-                          "children": "10",
+                      "children": [
+                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "children": "10",
+                          },
+                          "type": "Text",
                         },
-                        "type": "Text",
-                      },
+                      ],
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -3245,13 +2954,16 @@ describe('nativeTokenStream:content', () => {
                   {
                     "key": null,
                     "props": {
-                      "children": {
-                        "key": null,
-                        "props": {
-                          "children": "10/26/1985",
+                      "children": [
+                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "children": "10/26/1985",
+                          },
+                          "type": "Text",
                         },
-                        "type": "Text",
-                      },
+                      ],
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -3307,13 +3019,16 @@ describe('nativeTokenStream:content', () => {
                   {
                     "key": null,
                     "props": {
-                      "children": {
-                        "key": null,
-                        "props": {
-                          "children": "05/01/2024",
+                      "children": [
+                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "children": "05/01/2024",
+                          },
+                          "type": "Text",
                         },
-                        "type": "Text",
-                      },
+                      ],
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -3521,26 +3236,9 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "alt": "ETH",
-                              "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                              "children": " ",
                             },
-                            "type": "Image",
+                            "type": "Text",
                           },
                           {
                             "key": null,
@@ -3831,30 +3529,7 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "children": {
-                                "key": null,
-                                "props": {
-                                  "alt": "Ether token icon",
-                                  "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                                },
-                                "type": "Image",
-                              },
+                              "children": null,
                             },
                             "type": "Box",
                           },
@@ -4039,26 +3714,9 @@ describe('nativeTokenStream:content', () => {
                             "children": {
                               "key": null,
                               "props": {
-                                "alt": "ETH token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                                "children": " ",
                               },
-                              "type": "Image",
+                              "type": "Text",
                             },
                           },
                           "type": "Box",
@@ -4461,26 +4119,9 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "alt": "ETH",
-                              "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                              "children": " ",
                             },
-                            "type": "Image",
+                            "type": "Text",
                           },
                           {
                             "key": null,
@@ -4771,30 +4412,7 @@ describe('nativeTokenStream:content', () => {
                           {
                             "key": null,
                             "props": {
-                              "children": {
-                                "key": null,
-                                "props": {
-                                  "alt": "Ether token icon",
-                                  "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                                },
-                                "type": "Image",
-                              },
+                              "children": null,
                             },
                             "type": "Box",
                           },
@@ -4979,26 +4597,9 @@ describe('nativeTokenStream:content', () => {
                             "children": {
                               "key": null,
                               "props": {
-                                "alt": "ETH token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
+                                "children": " ",
                               },
-                              "type": "Image",
+                              "type": "Text",
                             },
                           },
                           "type": "Box",
@@ -5087,30 +4688,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "alt": "Ether token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                              },
-                              "type": "Image",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -5126,23 +4704,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "children": {
-                                  "key": null,
-                                  "props": {
-                                    "color": "primary",
-                                    "name": "close",
-                                    "size": "md",
-                                  },
-                                  "type": "Icon",
-                                },
-                                "name": "native-token-stream-initial-amount_removeButton",
-                                "type": "button",
-                              },
-                              "type": "Button",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -5212,30 +4774,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "alt": "Ether token icon",
-                                "src": "<svg width="16" height="16" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<circle cx="16" cy="16" r="16" fill="#F2F4F6"/>
-<circle cx="16" cy="16" r="15.5" stroke="#B7BBC8" stroke-opacity="0.4"/>
-<g clip-path="url(#clip0_373_6813)">
-<rect width="32" height="32" fill="url(#pattern0_373_6813)"/>
-</g>
-<defs>
-<pattern id="pattern0_373_6813" patternContentUnits="objectBoundingBox" width="1" height="1">
-<use xlink:href="#image0_373_6813" transform="scale(0.0166667)"/>
-</pattern>
-<clipPath id="clip0_373_6813">
-<rect width="32" height="32" rx="16" fill="white"/>
-</clipPath>
-<image id="image0_373_6813" width="60" height="60" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAPAAAAACL3+lcAAAI1klEQVRoBdVbfXBUVxU/973dzSaQhJDsZqvQwsiXBS0opek4VjttLZKprVOxoxWGJLX+0xl1/KI2yTwTEOs4078pTYhYqhXpJCJfdUbqKCqWSouVTrFQWj6S7oavbL72473r7zyyy35vXvY9G85M8u6799xzzu+ee8679763ghykpvbBB4mMO6AiIIj8UpJfkPRLlFkt6oKSRFAIvlIQVQNEypHtHXV93O4EQad99PWNV2rK3PFGgHwQIFZD8swpSh/G4BwQQvSOR937XvjZrMtTlJPVzRbALW3BFYagLRB2f5YGOyoAnlTR1q35jpYqriTALVpwgaHTFhjxMDxakqxiQOBxCR2/iyuidYfmO1mMP1/7lIxcr1262WXEWhGFTRDsyifcofq4lLJbqMpP4PELVnVYBtzSHmo0SL6AjlVWldnJjyQ3JAyxrnuT7/dW5CpWmJvaQu2GlHs+bLBsM9sghextag8+ZQXDpDy8QZNeYYR6wPyIFeH/P165Mxz2f3PXM2KsmM6igDdowYCiI0sKuq2YsA+1XdKxqC4an/+pr7+QHQWn9DXP0v5pD5YRClrhUeVetnnKgBUjtANTYHkhAdOqDaA59ArZlNfDzW3Bjei4tlDn6djGeWbC9pzm5YzhptbgV4RCL6JH3gHJKW36VBqGQY09m/wHMk3KAtz8w1ClLDNOYR3ry2S+oe6l/CCiuhbt1GqHUu3O9qBXPuU02M8s99LcgJpqh/1lIerLDP3HmYLTAPOSkaT8TiaTnfdlHkEP3zeDVi3zktuVNcHsVEVYfn97nRY2t6IJwWmAVSPeQUKUJRqduH75nhlUPVOhGeWCli10O6EiKRP7Ga/LGO1IVqCQBPxY6+DHMSTfSG20uxyoVemeVeVJsbfO91D1jKQJyXpbC1I81qJdWpaQmdSmK8Yz2H45GljrHqgkJamRSIW2Oz7p6ITChCXVMOK/SAPMmZlI3p2odOLKiWrJ/OwpHKhT6WNzsuvttUHe/ah20dzdmeONqG3EfPfYq+S6NI7Xr96f/7Rn5VIPcTJzihibVzfWsHwTsCHkQ04pY7mPrJ5JMyvyA2Kwn77VsfE2oQEjn7Elk9YXzVoH/i2e5yaezsVowVw31c5KCfBiHSy2Y7jv4y7KBu1iA24cOb1wISmtR6KaLDV8wstJxin6CGNVFN1ocErDF+6sIE5KkyX28BLMCKeIsSo4JpnnhIKaKoUaP1eRU3RcJ4rFcSqVg5Yv9lCF1yE3CxngoAnk0Fty1aONleTNyLxjEUn/fT9Gf39jjI4cj5jlcdSlktstaBWmthMETQEXVlcBnBbYSiuWeIj/EjQ0YtD7/XG6eAWunSDdILoQ1Kk/pFPdLJXm1KtUhSUn083YWPDm4uzAdf6JbqVdJM3D8p2ntH2I+RHD3mUavKzD6Dgx4HyEA3YKgY//qrDMnFPvIt9sxdxcXAiOEA+MXQSU8LDNU5o3ByNjBp08E6XxaPp0LWY4D8yJ01EqPy9M4EsXeOj4yWixblbaGbAYRw/bFrTssdPnYthlWrEjnZdj/Z2zMUdWXxw0A+nqSrt78cAwHXp1jFzq1MOEs/Slqzq9fSZWmjHZvQcUOMJWwLxB4GTU3RumE6di5EHWnSx5ywRFEQZvvRtDWCCbWniGT0YHY1WQr2wFzImq7VuzzSx99ESEtveF6XLYgMfzm6RiNriQPk++F6P+izrNvUmlxrsqKDxqY8Zi9cDKSctewFcMevlvo/TE16rNKbljT5j2vDJK5kLksxWkIohSw7sc0/fMhTjx83h2lUorl3mIDwoOH4vQyGgqZ/4Bs9AyoH7qrh8sB/J7LXQqysqPoroaFV4uo8/fXo6dkmJm39dORCmMDL4QG4X+QYMGrxp07oM4DgKw2FhaRg04DKgELycsm7OzabOQ1OcyJL2uTD7MioJNMDz/hzAtvsUD4Ard21BOd97mpd4/jdArR8do29nwNQOgl3dTvJxM7IeH4dV//juSEGPrlbGKxx+X7nh9KAQvV9sqHcLmf9RFG1tq0uK3f1Cn3+wfRhY26HZMXz7QSxAvMg4eHqVBhIXdhOAYcg/46pRnnxUxKfB20AF693yc+uDVVLoJmfe766rhdW8aWOb5F5KcE2An9O9nrObwYsvUm2qUneX98Bg/nooRr6n5ceQUJTCagMdVZR8OrW1dwyUM5xXXtpeG6Opw/mk6Nm7QX5CVnSLGJiO0l+WbgK+9fxGHnFI4BLDbdqe94kmq4gH5K8COR/IPSJJ5ygVxqPvnPjNTJjOGori+P2V5k+j41ukY/fEf2V8kvHkqikeUzdvADHsMqX4vUZUE3KXNfhODza9IHaNdLw9jYxFPyucE9cbbjkRSUgdj+mVn7X8SFUnAXCEV90ZMMceGW4fkrbuuUhS5iY95/vzaGOE9rmOE2B1XdPePUhWkAe7Ras6QkM+lMthdZq/+9mCYjmBx4cDSMcNcsbVrc817qZVpgLkhrlS088ikMtldPvTqOJ3C8tFJwlQeolj55kwdWYB/pVUG8WriiUzGG+1eGrJp+5bKUKbdWYCZobvD34XL05nMN9D90z2b6l/KZW+BbYMUze0hztprc3WcxnW7uzt8sBl7oxyU08PX+IQ0FN969Ho9R79pWiWPw2a81M8Nlo0uAJioRxNYdaoP4FF1dpoiTDXrXFxX17DNqZWZ5YKAmfk5rfbc8LBvMZ7SOzM7T597/rjUt2jH5rrzxWwqEMPZXc1PdSV14g2fpX7ZkuypwczjOG3f3unfNFmJlg1vbg19iRTj14iT3G/KJqu5RD5+zjr+gTjbaH6BrigLMbhbcXt9YVwiAAvdoVNui8XFEqtfw7MOyx5ONWy9Flrk0mUnRnut09N8YvruVlR6skvzv5Nqh5VySYATipq10EoCcAzf6kSdnVcM6EG8MXiyq9N/rFS5tgBOGME/1PJ6Ymvwq5OH4HEGn//TnUSn3Ffzh1p4avZFYq690+6HWrltJrL6UzwsF/pxlHoYn/3uyyez1Pr/AUtRB20FBeloAAAAAElFTkSuQmCC"/>
-</defs>
-</svg>
-",
-                              },
-                              "type": "Image",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },
@@ -5251,23 +4790,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": {
-                              "key": null,
-                              "props": {
-                                "children": {
-                                  "key": null,
-                                  "props": {
-                                    "color": "primary",
-                                    "name": "close",
-                                    "size": "md",
-                                  },
-                                  "type": "Icon",
-                                },
-                                "name": "native-token-stream-max-amount_removeButton",
-                                "type": "button",
-                              },
-                              "type": "Button",
-                            },
+                            "children": null,
                           },
                           "type": "Box",
                         },

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/context.test.ts
@@ -67,6 +67,7 @@ const alreadyPopulatedContext: NativeTokenStreamContext = {
   tokenMetadata: {
     symbol: 'ETH',
     decimals: 18,
+    iconDataBase64: null,
   },
   permissionDetails: {
     initialAmount: '1',
@@ -128,7 +129,7 @@ describe('nativeTokenStream:context', () => {
     let mockTokenPricesService: jest.Mocked<TokenPricesService>;
     let mockAccountController: jest.Mocked<AccountController>;
     let mockTokenMetadataService: jest.Mocked<TokenMetadataService>;
-
+    let mockFetcher: jest.MockedFunction<typeof fetch>;
     beforeEach(() => {
       mockTokenPricesService = {
         getCryptoToFiatConversion: jest.fn(
@@ -148,19 +149,43 @@ describe('nativeTokenStream:context', () => {
           balance: BigInt(alreadyPopulatedContext.accountDetails.balance),
           symbol: alreadyPopulatedContext.tokenMetadata.symbol,
           decimals: 18,
+          iconUrl: 'https://example.com/icon.png',
         })),
       } as unknown as jest.Mocked<TokenMetadataService>;
+
+      mockFetcher = jest.fn(() => {
+        Promise.resolve({
+          ok: false,
+        });
+      }) as unknown as jest.MockedFunction<typeof fetch>;
     });
 
     it('should create a context from a permission request', async () => {
+      const text = 'The contents of the image';
+      const uint8Array = new TextEncoder().encode(text);
+      const arrayBuffer = uint8Array.buffer;
+      const base64 = Buffer.from(uint8Array).toString('base64');
+
+      mockFetcher.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(arrayBuffer),
+      } as unknown as Response);
+
       const context = await buildContext({
         permissionRequest: alreadyPopulatedPermissionRequest,
         tokenPricesService: mockTokenPricesService,
         accountController: mockAccountController,
         tokenMetadataService: mockTokenMetadataService,
+        fetcher: mockFetcher,
       });
 
-      expect(context).toStrictEqual(alreadyPopulatedContext);
+      expect(context).toStrictEqual({
+        ...alreadyPopulatedContext,
+        tokenMetadata: {
+          ...alreadyPopulatedContext.tokenMetadata,
+          iconDataBase64: `data:image/png;base64,${base64}`,
+        },
+      });
 
       expect(mockAccountController.getAccountAddress).toHaveBeenCalledWith({
         chainId: Number(alreadyPopulatedPermissionRequest.chainId),

--- a/packages/gator-permissions-snap/test/services/tokenMetadataService.test.ts
+++ b/packages/gator-permissions-snap/test/services/tokenMetadataService.test.ts
@@ -346,24 +346,6 @@ describe('TokenMetadataService', () => {
 
       consoleErrorSpy.mockRestore();
     });
-
-    it('uses injected fetcher instead of global fetch', async () => {
-      const globalFetchSpy = jest.spyOn(global, 'fetch');
-      /* eslint-disable no-restricted-globals */
-      const mockImageData = Buffer.from('test data', 'utf8');
-
-      mockFetcher.mockResolvedValueOnce({
-        ok: true,
-        arrayBuffer: async () => Promise.resolve(mockImageData.buffer),
-      } as Response);
-
-      await tokenMetadataService.fetchIconDataAsBase64(mockIconUrl);
-
-      expect(mockFetcher).toHaveBeenCalledWith(mockIconUrl);
-      expect(globalFetchSpy).not.toHaveBeenCalled();
-
-      globalFetchSpy.mockRestore();
-    });
   });
 
   describe('constructor with default fetcher', () => {

--- a/packages/gator-permissions-snap/test/services/tokenMetadataService.test.ts
+++ b/packages/gator-permissions-snap/test/services/tokenMetadataService.test.ts
@@ -12,6 +12,7 @@ describe('TokenMetadataService', () => {
   let tokenMetadataService: TokenMetadataService;
   let mockAccountApiClient: jest.Mocked<AccountApiClient>;
   let mockTokenMetadataClient: jest.Mocked<TokenMetadataClient>;
+  let mockFetcher: jest.MockedFunction<typeof fetch>;
 
   const mockAddress = '0x1234567890abcdef1234567890abcdef12345678' as Address;
   const mockAssetAddress =
@@ -32,9 +33,12 @@ describe('TokenMetadataService', () => {
       getTokenBalanceAndMetadata: jest.fn(),
     } as unknown as jest.Mocked<TokenMetadataClient>;
 
+    mockFetcher = jest.fn();
+
     tokenMetadataService = new TokenMetadataService({
       accountApiClient: mockAccountApiClient,
       tokenMetadataClient: mockTokenMetadataClient,
+      fetcher: mockFetcher,
     });
   });
 
@@ -242,6 +246,134 @@ describe('TokenMetadataService', () => {
         expect(typeof result.symbol).toBe('string');
         expect(typeof result.decimals).toBe('number');
       });
+    });
+  });
+
+  describe('fetchIconDataAsBase64', () => {
+    const mockIconUrl = 'https://example.com/icon.png';
+
+    it('successfully fetches and converts icon to base64', async () => {
+      /* eslint-disable no-restricted-globals */
+      const mockImageData = Buffer.from('mock image data', 'utf8');
+      const expectedBase64 = `data:image/png;base64,${mockImageData.toString('base64')}`;
+
+      const arrayBuffer = new ArrayBuffer(mockImageData.length);
+      const uint8Array = new Uint8Array(arrayBuffer);
+      uint8Array.set(mockImageData);
+
+      const response = {
+        ok: true,
+        arrayBuffer: jest.fn(async () => Promise.resolve(mockImageData)),
+      };
+
+      mockFetcher.mockResolvedValueOnce(response as unknown as Response);
+
+      const result =
+        await tokenMetadataService.fetchIconDataAsBase64(mockIconUrl);
+
+      expect(response.arrayBuffer).toHaveBeenCalledTimes(1);
+      expect(mockFetcher).toHaveBeenCalledWith(mockIconUrl);
+      expect(result).toStrictEqual({
+        success: true,
+        imageDataBase64: expectedBase64,
+      });
+    });
+
+    it('returns success false when iconUrl is undefined', async () => {
+      const result =
+        await tokenMetadataService.fetchIconDataAsBase64(undefined);
+
+      expect(mockFetcher).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        success: false,
+      });
+    });
+
+    it('returns success false when iconUrl is empty string', async () => {
+      const result = await tokenMetadataService.fetchIconDataAsBase64('');
+
+      expect(mockFetcher).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        success: false,
+      });
+    });
+
+    it('returns success false when fetch response is not ok', async () => {
+      mockFetcher.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      const result =
+        await tokenMetadataService.fetchIconDataAsBase64(mockIconUrl);
+
+      expect(mockFetcher).toHaveBeenCalledWith(mockIconUrl);
+      expect(result).toStrictEqual({
+        success: false,
+      });
+    });
+
+    it('returns success false when fetch throws an error', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error');
+      mockFetcher.mockRejectedValueOnce(new Error('Network error'));
+
+      const result =
+        await tokenMetadataService.fetchIconDataAsBase64(mockIconUrl);
+
+      expect(mockFetcher).toHaveBeenCalledWith(mockIconUrl);
+      expect(result).toStrictEqual({
+        success: false,
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('returns success false when arrayBuffer() throws an error', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error');
+
+      mockFetcher.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => Promise.reject(new Error('ArrayBuffer error')),
+      } as Response);
+
+      const result =
+        await tokenMetadataService.fetchIconDataAsBase64(mockIconUrl);
+
+      expect(mockFetcher).toHaveBeenCalledWith(mockIconUrl);
+      expect(result).toStrictEqual({
+        success: false,
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('uses injected fetcher instead of global fetch', async () => {
+      const globalFetchSpy = jest.spyOn(global, 'fetch');
+      /* eslint-disable no-restricted-globals */
+      const mockImageData = Buffer.from('test data', 'utf8');
+
+      mockFetcher.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => Promise.resolve(mockImageData.buffer),
+      } as Response);
+
+      await tokenMetadataService.fetchIconDataAsBase64(mockIconUrl);
+
+      expect(mockFetcher).toHaveBeenCalledWith(mockIconUrl);
+      expect(globalFetchSpy).not.toHaveBeenCalled();
+
+      globalFetchSpy.mockRestore();
+    });
+  });
+
+  describe('constructor with default fetcher', () => {
+    it('uses global fetch when no fetcher is provided', () => {
+      const serviceWithDefaultFetcher = new TokenMetadataService({
+        accountApiClient: mockAccountApiClient,
+        tokenMetadataClient: mockTokenMetadataClient,
+      });
+
+      expect(serviceWithDefaultFetcher).toBeInstanceOf(TokenMetadataService);
     });
   });
 });

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "9fjQZdZPpXAzVHjej5S6QTNGi7UobI0vEu5H0diUyRY=",
+    "shasum": "ZpujQu+1AUOtJI6gowQELom4JbpkxNlz69zL4Ar2We4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "ZpujQu+1AUOtJI6gowQELom4JbpkxNlz69zL4Ar2We4=",
+    "shasum": "9fjQZdZPpXAzVHjej5S6QTNGi7UobI0vEu5H0diUyRY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/site/src/components/permissions/ERC20TokenStreamForm.tsx
+++ b/packages/site/src/components/permissions/ERC20TokenStreamForm.tsx
@@ -30,7 +30,7 @@ export const ERC20TokenStreamForm = ({
   );
   const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
   const [tokenAddress, setTokenAddress] = useState<Hex>(
-    '0x616553f076c6f66739a99fef373c6b4ae1b22a7a', // Consensys USDC
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // Consensys USDC
   );
 
   const handleInitialAmountChange = useCallback(


### PR DESCRIPTION
## **Description**

Adds support for retrieving and displaying token icons for all supported permission types. Token metadata is fetched from the accounts API for supported networks (mainnet). For unsupported networks, no icon is shown.

Because token icons are only supported on a limited set of networks, we add support for `Mainnet` (and remove support for `LineaSepolia` as this network does not support Delegation Framework 1.3.0.

In this PR we simplify the `RuleDefinition` type to combine multiple callbacks into a single function.

## **Manual testing steps**

1. Open the demo dapp at `localhost:8000`
2. Select `Mainnet` or `Sepolia`, and any of the supported permission types.
3. Click "Grant permission"

If `Mainnet` was selected, expect to see the associated token icon (either Eth, or USDC by default) on all value fields. If `Sepolia` was selected, no token icons should show.

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/1363ce0a-1481-4da4-b492-f5f0318ccdd5)
![image](https://github.com/user-attachments/assets/ec695538-ee45-418d-bb41-376c0265feb4)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.