### PR TITLE
EOA fails to sign delegation

### DIFF
--- a/packages/gator-permissions-snap/src/accountController/eoaAccountController.ts
+++ b/packages/gator-permissions-snap/src/accountController/eoaAccountController.ts
@@ -1,6 +1,7 @@
 import { logger } from '@metamask/7715-permissions-shared/utils';
 import { type Hex, type Delegation } from '@metamask/delegation-core';
 import type { SnapsEthereumProvider, SnapsProvider } from '@metamask/snaps-sdk';
+import { bigIntToHex } from '@metamask/utils';
 
 import { getChainMetadata } from '../core/chainMetadata';
 import { BaseAccountController } from './baseAccountController';
@@ -169,7 +170,7 @@ export class EoaAccountController
 
     const primaryType = 'Delegation';
 
-    const message = delegation;
+    const message = { ...delegation, salt: bigIntToHex(delegation.salt) };
 
     return { domain, types, primaryType, message };
   }

--- a/packages/gator-permissions-snap/test/accountController/eoaAccountController.test.ts
+++ b/packages/gator-permissions-snap/test/accountController/eoaAccountController.test.ts
@@ -200,6 +200,79 @@ describe('EoaAccountController', () => {
         }),
       ).rejects.toThrow(`Unsupported ChainId: ${invalidChainId}`);
     });
+
+    it('calls eth_signTypedData_v4 with the correct params', async () => {
+      await accountController.signDelegation({
+        chainId: sepolia,
+        delegation: unsignedDelegation,
+      });
+
+      expect(mockEthereumProvider.request).toHaveBeenCalledWith({
+        method: 'eth_signTypedData_v4',
+        params: [
+          mockAddress,
+          {
+            domain: {
+              chainId: sepolia,
+              name: 'DelegationManager',
+              version: '1',
+              verifyingContract: '0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3',
+            },
+            types: {
+              Caveat: [
+                { name: 'enforcer', type: 'address' },
+                { name: 'terms', type: 'bytes' },
+              ],
+              Delegation: [
+                {
+                  name: 'delegate',
+                  type: 'address',
+                },
+                {
+                  name: 'delegator',
+                  type: 'address',
+                },
+                {
+                  name: 'authority',
+                  type: 'bytes32',
+                },
+                {
+                  name: 'caveats',
+                  type: 'Caveat[]',
+                },
+                {
+                  name: 'salt',
+                  type: 'uint256',
+                },
+              ],
+              EIP712Domain: [
+                {
+                  name: 'name',
+                  type: 'string',
+                },
+                {
+                  name: 'version',
+                  type: 'string',
+                },
+                {
+                  name: 'chainId',
+                  type: 'uint256',
+                },
+                {
+                  name: 'verifyingContract',
+                  type: 'address',
+                },
+              ],
+            },
+            primaryType: 'Delegation',
+            message: {
+              ...unsignedDelegation,
+              salt: '0x1',
+            },
+          },
+        ],
+      });
+    });
   });
 
   describe('getAccountMetadata()', () => {


### PR DESCRIPTION
## **Description**

When signing a delegation, the `EoaAccountController` attempts to call `eth_signTypedData_v4`, passing the `delegation` as the message. With the recent change to use @metamask/delegation-core, we removed the `Delegation` type with `salt` represented as `Hex` (rather than mirroring the contract structs, as `bigint`).

This change simply serializes the salt as `Hex` when constructing the message for `eth_signTypedData_v4`.

## **Manual testing steps**

1. Configure your system to use EOA, by setting the environment variable `USE_EOA_ACCOUNT=true`
2. Install a version of Flask that allows internal accounts to sign delegations
3. Attempt to grant a permission

Previously the request would fail and return an error message to the caller.

With this fix, a `eth_signTypedData_v4` confirmation should show, and after approving the request, the granted permission should be returned to the caller.

## **Screenshots/Recordings**

### **Before**

RPC `eth_signTypedData_v4` fails because salt is `bigint`.

<img width="674" height="120" alt="image" src="https://github.com/user-attachments/assets/db651441-15d7-45b3-bfb4-855543d0314a" />

### **After**

RPC `eth_signTypedData_v4` succeeds because salt is serialised as `Hex`.

<img width="397" height="620" alt="image" src="https://github.com/user-attachments/assets/6839d8f4-89d4-4412-856d-e59ee722864b" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.