### PR TITLE
Fix link to architecture documentation for gator-permissions-snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This Snap manages a `permissions offer registry`, which lists all the permission
 
 This Snap creates a [DeleGator account](https://github.com/MetaMask/delegation-framework) and enables the site to request [ERC-7715](https://eip.tools/eip/7715) permissions from that account. Users can review and adjust the granted permissions through a custom interactive confirmation dialog rendered by the Snap.
 
-[Read more on "@metamask/gator-permissions-snap" ->](/packages/gator-permissions-snap/ARCHITECTURE.md)
+[Read more on "@metamask/gator-permissions-snap" ->](/packages/gator-permissions-snap/docs/architecture.md)
 
 ## Development
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes a broken link in the `README.md` file.  
On line 30, the link to the architecture document was incorrectly pointing to `/packages/gator-permissions-snap/ARCHITECTURE.md`, which does not exist.  
It has been updated to the correct path: `/packages/gator-permissions-snap/docs/architecture.md`.

## **Related issues**

Fixes: *(no related issue found)*

## **Manual testing steps**

1. Open the `README.md` file.
2. Scroll to the "Architecture" section (around line 30).
3. Click the link and confirm it now leads to the correct document.

## **Screenshots/Recordings**

### **Before**

Broken link to:  
`/packages/gator-permissions-snap/ARCHITECTURE.md`

### **After**

Corrected link to:  
`/packages/gator-permissions-snap/docs/architecture.md`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.