### PR TITLE
Add the nonce enforcer as a default caveat for all permissions

### DIFF
--- a/packages/gator-permissions-snap/package.json
+++ b/packages/gator-permissions-snap/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@metamask/abi-utils": "3.0.0",
-    "@metamask/delegation-core": "0.1.0",
+    "@metamask/delegation-core": "0.2.0-rc.1",
     "@metamask/delegation-toolkit": "0.10.2",
     "@metamask/profile-sync-controller": "21.0.0",
     "@metamask/snaps-sdk": "8.1.0",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "3bSJ9Th+sBdj3zy04EW1ibs58wv6LJLELNYiLv52FbU=",
+    "shasum": "LQuyOq8GRZWtgf5dh0pkR6FZbfWAifYbZHB9AAzB7G8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/clients/nonceCaveatClient.ts
+++ b/packages/gator-permissions-snap/src/clients/nonceCaveatClient.ts
@@ -35,7 +35,7 @@ export class NonceCaveatClient {
   }: {
     chainId: number;
     account: Hex;
-  }): Promise<number> {
+  }): Promise<bigint> {
     logger.debug('BlockchainTokenMetadataClient:getTokenBalanceAndMetadata()');
 
     if (!chainId) {
@@ -89,7 +89,7 @@ export class NonceCaveatClient {
 
     try {
       const nonce = decodeSingle('uint256', nonceEncoded);
-      return Number(nonce);
+      return nonce;
     } catch (error) {
       logger.error(
         `Failed to fetch nonce: ${(error as Error).message}.`,

--- a/packages/gator-permissions-snap/src/clients/nonceCaveatClient.ts
+++ b/packages/gator-permissions-snap/src/clients/nonceCaveatClient.ts
@@ -83,8 +83,8 @@ export class NonceCaveatClient {
     }
 
     if (!nonceEncoded) {
-      logger.error('Failed to fetch token symbol');
-      throw new Error('Failed to fetch token symbol');
+      logger.error('Failed to fetch nonce');
+      throw new Error('Failed to fetch nonce');
     }
 
     try {
@@ -92,10 +92,10 @@ export class NonceCaveatClient {
       return Number(nonce);
     } catch (error) {
       logger.error(
-        `Failed to fetch token balance and metadata: ${(error as Error).message}.`,
+        `Failed to fetch nonce: ${(error as Error).message}.`,
       );
 
-      throw new Error('Failed to fetch token balance and metadata');
+      throw new Error('Failed to fetch nonce');
     }
   }
 }

--- a/packages/gator-permissions-snap/src/clients/nonceCaveatClient.ts
+++ b/packages/gator-permissions-snap/src/clients/nonceCaveatClient.ts
@@ -1,0 +1,101 @@
+import { logger } from '@metamask/7715-permissions-shared/utils';
+import { decodeSingle } from '@metamask/abi-utils';
+import type { Hex } from '@metamask/delegation-core';
+import type { SnapsEthereumProvider } from '@metamask/snaps-sdk';
+
+import { getChainMetadata } from '../core/chainMetadata';
+
+/**
+ * Client that fetches nonce from nonce caveat enforcer.
+ */
+export class NonceCaveatClient {
+  readonly #ethereumProvider: SnapsEthereumProvider;
+
+  // keccak256('currentNonce()')
+  static readonly #currentNonceCalldata = '0x2bd4ed21';
+
+  constructor({
+    ethereumProvider,
+  }: {
+    ethereumProvider: SnapsEthereumProvider;
+  }) {
+    this.#ethereumProvider = ethereumProvider;
+  }
+
+  /**
+   * Fetch the token balance and metadata for a given account and token.
+   * @param args - The parameters for fetching the token balance.
+   * @param args.chainId - The chain ID to fetch the balance from.
+   * @param args.account - The account address to fetch the nonce for.
+   * @returns The nonce.
+   */
+  public async getNonce({
+    chainId,
+    account,
+  }: {
+    chainId: number;
+    account: Hex;
+  }): Promise<number> {
+    logger.debug('BlockchainTokenMetadataClient:getTokenBalanceAndMetadata()');
+
+    if (!chainId) {
+      const message = 'No chainId provided to fetch nonce';
+      logger.error(message);
+      throw new Error(message);
+    }
+
+    const { contracts } = getChainMetadata({ chainId });
+
+    if (!account) {
+      const message = 'No account address provided to fetch nonce';
+      logger.error(message);
+      throw new Error(message);
+    }
+
+    // Check if we're on the correct chain
+    const selectedChain = await this.#ethereumProvider.request({
+      method: 'eth_chainId',
+      params: [],
+    });
+
+    if (Number(selectedChain) !== chainId) {
+      throw new Error('Selected chain does not match the requested chain');
+    }
+
+    let nonceEncoded;
+    try {
+      nonceEncoded = await this.#ethereumProvider.request<Hex>({
+        method: 'eth_call',
+        params: [
+          {
+            to: contracts.enforcers.NonceEnforcer,
+            data:
+              NonceCaveatClient.#currentNonceCalldata +
+              contracts.delegationManager.slice(2).padStart(64, '0') +
+              account.slice(2).padStart(64, '0'),
+          },
+          'latest',
+        ],
+      });
+    } catch (error) {
+      logger.error(`Failed to fetch nonce: ${(error as Error).message}.`);
+      throw new Error('Failed to fetch nonce');
+    }
+
+    if (!nonceEncoded) {
+      logger.error('Failed to fetch token symbol');
+      throw new Error('Failed to fetch token symbol');
+    }
+
+    try {
+      const nonce = decodeSingle('uint256', nonceEncoded);
+      return Number(nonce);
+    } catch (error) {
+      logger.error(
+        `Failed to fetch token balance and metadata: ${(error as Error).message}.`,
+      );
+
+      throw new Error('Failed to fetch token balance and metadata');
+    }
+  }
+}

--- a/packages/gator-permissions-snap/src/clients/nonceCaveatClient.ts
+++ b/packages/gator-permissions-snap/src/clients/nonceCaveatClient.ts
@@ -91,9 +91,7 @@ export class NonceCaveatClient {
       const nonce = decodeSingle('uint256', nonceEncoded);
       return nonce;
     } catch (error) {
-      logger.error(
-        `Failed to fetch nonce: ${(error as Error).message}.`,
-      );
+      logger.error(`Failed to fetch nonce: ${(error as Error).message}.`);
 
       throw new Error('Failed to fetch nonce');
     }

--- a/packages/gator-permissions-snap/src/core/chainMetadata.ts
+++ b/packages/gator-permissions-snap/src/core/chainMetadata.ts
@@ -9,6 +9,7 @@ export enum Enforcers {
   ValueLteEnforcer = 'ValueLteEnforcer',
   TimestampEnforcer = 'TimestampEnforcer',
   ExactCalldataEnforcer = 'ExactCalldataEnforcer',
+  NonceEnforcer = 'NonceEnforcer',
 }
 
 export type DelegationContracts = {
@@ -38,6 +39,7 @@ const CONTRACTS_1_3_0: DelegationContracts = {
     [Enforcers.TimestampEnforcer]: '0x1046bb45C8d673d4ea75321280DB34899413c069',
     [Enforcers.ExactCalldataEnforcer]:
       '0x99F2e9bF15ce5eC84685604836F71aB835DBBdED',
+    [Enforcers.NonceEnforcer]: '0xDE4f2FAC4B3D87A1d9953Ca5FC09FCa7F366254f',
   },
 };
 

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -10,6 +10,7 @@ import {
   ROOT_AUTHORITY,
 } from '@metamask/delegation-core';
 import { bytesToHex, hexToNumber, numberToHex } from '@metamask/utils';
+import type { NonceCaveatService } from 'src/services/nonceCaveatService';
 
 import type { AccountController } from '../accountController';
 import type { UserEventDispatcher } from '../userEventDispatcher';
@@ -33,18 +34,23 @@ export class PermissionRequestLifecycleOrchestrator {
 
   readonly #userEventDispatcher: UserEventDispatcher;
 
+  readonly #nonceCaveatService: NonceCaveatService;
+
   constructor({
     accountController,
     confirmationDialogFactory,
     userEventDispatcher,
+    nonceCaveatService,
   }: {
     accountController: AccountController;
     confirmationDialogFactory: ConfirmationDialogFactory;
     userEventDispatcher: UserEventDispatcher;
+    nonceCaveatService: NonceCaveatService;
   }) {
     this.#accountController = accountController;
     this.#confirmationDialogFactory = confirmationDialogFactory;
     this.#userEventDispatcher = userEventDispatcher;
+    this.#nonceCaveatService = nonceCaveatService;
   }
 
   /**
@@ -267,6 +273,17 @@ export class PermissionRequestLifecycleOrchestrator {
       }),
       args: '0x',
     });
+
+    const nonce = await this.#nonceCaveatService.getNonce(chainId, address);
+    console.log('nonce', nonce);
+
+    // caveats.push({
+    //   enforcer: contracts.enforcers.NonceEnforcer,
+    //   terms: createNonceTerms({
+    //     nonce,
+    //   }),
+    //   args: '0x',
+    // });
 
     // eslint-disable-next-line no-restricted-globals
     const saltBytes = crypto.getRandomValues(new Uint8Array(32));

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -280,7 +280,10 @@ export class PermissionRequestLifecycleOrchestrator {
       args: '0x',
     });
 
-    const nonce = await this.#nonceCaveatService.getNonce(chainId, address);
+    const nonce = await this.#nonceCaveatService.getNonce({
+      chainId,
+      account: address,
+    });
 
     caveats.push({
       enforcer: contracts.enforcers.NonceEnforcer,

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -5,11 +5,17 @@ import type {
 } from '@metamask/7715-permissions-shared/types';
 import type { Delegation } from '@metamask/delegation-core';
 import {
+  createNonceTerms,
   createTimestampTerms,
   encodeDelegations,
   ROOT_AUTHORITY,
 } from '@metamask/delegation-core';
-import { bytesToHex, hexToNumber, numberToHex } from '@metamask/utils';
+import {
+  bigIntToHex,
+  bytesToHex,
+  hexToNumber,
+  numberToHex,
+} from '@metamask/utils';
 import type { NonceCaveatService } from 'src/services/nonceCaveatService';
 
 import type { AccountController } from '../accountController';
@@ -275,15 +281,14 @@ export class PermissionRequestLifecycleOrchestrator {
     });
 
     const nonce = await this.#nonceCaveatService.getNonce(chainId, address);
-    console.log('nonce', nonce);
 
-    // caveats.push({
-    //   enforcer: contracts.enforcers.NonceEnforcer,
-    //   terms: createNonceTerms({
-    //     nonce,
-    //   }),
-    //   args: '0x',
-    // });
+    caveats.push({
+      enforcer: contracts.enforcers.NonceEnforcer,
+      terms: createNonceTerms({
+        nonce: bigIntToHex(nonce),
+      }),
+      args: '0x',
+    });
 
     // eslint-disable-next-line no-restricted-globals
     const saltBytes = crypto.getRandomValues(new Uint8Array(32));

--- a/packages/gator-permissions-snap/src/index.ts
+++ b/packages/gator-permissions-snap/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from './accountController';
 import { AccountApiClient } from './clients/accountApiClient';
 import { BlockchainTokenMetadataClient } from './clients/blockchainMetadataClient';
+import { NonceCaveatClient } from './clients/nonceCaveatClient';
 import { PriceApiClient } from './clients/priceApiClient';
 import { ConfirmationDialogFactory } from './core/confirmationFactory';
 import { PermissionHandlerFactory } from './core/permissionHandlerFactory';
@@ -37,6 +38,7 @@ import {
 import { isMethodAllowedForOrigin } from './rpc/permissions';
 import { createRpcHandler } from './rpc/rpcHandler';
 import { RpcMethod } from './rpc/rpcMethod';
+import { NonceCaveatService } from './services/nonceCaveatService';
 import { TokenMetadataService } from './services/tokenMetadataService';
 import { TokenPricesService } from './services/tokenPricesService';
 import { createStateManager } from './stateManagement';
@@ -80,6 +82,14 @@ const tokenMetadataClient = new BlockchainTokenMetadataClient({
 const tokenMetadataService = new TokenMetadataService({
   accountApiClient,
   tokenMetadataClient,
+});
+
+const nonceCaveatClient = new NonceCaveatClient({
+  ethereumProvider: ethereum,
+});
+
+const nonceCaveatService = new NonceCaveatService({
+  nonceCaveatClient,
 });
 
 const accountController: AccountController = useEoaAccountController
@@ -151,6 +161,7 @@ const orchestrator = new PermissionRequestLifecycleOrchestrator({
   accountController,
   confirmationDialogFactory,
   userEventDispatcher,
+  nonceCaveatService,
 });
 
 const permissionHandlerFactory = new PermissionHandlerFactory({

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/caveats.ts
@@ -36,7 +36,7 @@ export async function createPermissionCaveats({
   const exactCalldataCaveat: Caveat = {
     enforcer: contracts.enforcers.ExactCalldataEnforcer,
     terms: createExactCalldataTerms({
-      callData: '0x',
+      calldata: '0x',
     }),
     args: '0x',
   };

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/caveats.ts
@@ -38,7 +38,7 @@ export async function createPermissionCaveats({
   const exactCalldataCaveat: Caveat = {
     enforcer: contracts.enforcers.ExactCalldataEnforcer,
     terms: createExactCalldataTerms({
-      callData: '0x',
+      calldata: '0x',
     }),
     args: '0x',
   };

--- a/packages/gator-permissions-snap/src/services/nonceCaveatService.ts
+++ b/packages/gator-permissions-snap/src/services/nonceCaveatService.ts
@@ -1,0 +1,39 @@
+import { logger } from '@metamask/7715-permissions-shared/utils';
+import type { Hex } from '@metamask/delegation-core';
+
+import type { NonceCaveatClient } from '../clients/nonceCaveatClient';
+
+/**
+ * Service responsible for providing the nonce of caveat enforcer for a given account.
+ */
+export class NonceCaveatService {
+  readonly #nonceCaveatClient: NonceCaveatClient;
+
+  /**
+   * Initializes a new NonceCaveatService instance.
+   * @param config - The configuration object.
+   * @param config.nonceCaveatClient - The client for interacting with the nonce caveat enforcer.
+   */
+  constructor({ nonceCaveatClient }: { nonceCaveatClient: NonceCaveatClient }) {
+    this.#nonceCaveatClient = nonceCaveatClient;
+  }
+
+  /**
+   * Retrieves the nonce of caveat enforcer for the specified account.
+   * @param chainId - The chain ID.
+   * @param account - The address of the account.
+   * @returns A promise resolving to the nonce.
+   */
+  public async getNonce(chainId: number, account: Hex): Promise<number> {
+    logger.debug('NonceCaveatService:getNonce()');
+
+    const nonce = await this.#nonceCaveatClient.getNonce({
+      chainId,
+      account,
+    });
+
+    logger.debug('NonceCaveatService:getNonce() - nonce resolved');
+
+    return nonce;
+  }
+}

--- a/packages/gator-permissions-snap/src/services/nonceCaveatService.ts
+++ b/packages/gator-permissions-snap/src/services/nonceCaveatService.ts
@@ -24,7 +24,7 @@ export class NonceCaveatService {
    * @param account - The address of the account.
    * @returns A promise resolving to the nonce.
    */
-  public async getNonce(chainId: number, account: Hex): Promise<number> {
+  public async getNonce(chainId: number, account: Hex): Promise<bigint> {
     logger.debug('NonceCaveatService:getNonce()');
 
     const nonce = await this.#nonceCaveatClient.getNonce({

--- a/packages/gator-permissions-snap/src/services/nonceCaveatService.ts
+++ b/packages/gator-permissions-snap/src/services/nonceCaveatService.ts
@@ -3,6 +3,11 @@ import type { Hex } from '@metamask/delegation-core';
 
 import type { NonceCaveatClient } from '../clients/nonceCaveatClient';
 
+export type GetNonceOptions = {
+  chainId: number;
+  account: Hex;
+};
+
 /**
  * Service responsible for providing the nonce of caveat enforcer for a given account.
  */
@@ -20,17 +25,15 @@ export class NonceCaveatService {
 
   /**
    * Retrieves the nonce of caveat enforcer for the specified account.
-   * @param chainId - The chain ID.
-   * @param account - The address of the account.
+   * @param options - The options for fetching the nonce.
+   * @param options.chainId - The chain ID.
+   * @param options.account - The address of the account.
    * @returns A promise resolving to the nonce.
    */
-  public async getNonce(chainId: number, account: Hex): Promise<bigint> {
+  public async getNonce(options: GetNonceOptions): Promise<bigint> {
     logger.debug('NonceCaveatService:getNonce()');
 
-    const nonce = await this.#nonceCaveatClient.getNonce({
-      chainId,
-      account,
-    });
+    const nonce = await this.#nonceCaveatClient.getNonce(options);
 
     logger.debug('NonceCaveatService:getNonce() - nonce resolved');
 

--- a/packages/gator-permissions-snap/test/client/nonceCaveatClient.test.ts
+++ b/packages/gator-permissions-snap/test/client/nonceCaveatClient.test.ts
@@ -78,17 +78,6 @@ describe('NonceCaveatClient', () => {
       expect(mockEthereumProvider.request).not.toHaveBeenCalled();
     });
 
-    it('throws an error if selected chain does not match requested chain', async () => {
-      mockEthereumProvider.request.mockResolvedValueOnce('0x01'); // eth_chainId
-
-      await expect(
-        client.getNonce({
-          chainId: mockChainId,
-          account: mockAccount,
-        }),
-      ).rejects.toThrow('Selected chain does not match the requested chain');
-    });
-
     it('throws an error if nonce fetch fails', async () => {
       mockEthereumProvider.request
         .mockResolvedValueOnce(mockChainIdHex) // eth_chainId

--- a/packages/gator-permissions-snap/test/client/nonceCaveatClient.test.ts
+++ b/packages/gator-permissions-snap/test/client/nonceCaveatClient.test.ts
@@ -112,7 +112,7 @@ describe('NonceCaveatClient', () => {
           chainId: mockChainId,
           account: mockAccount,
         }),
-      ).rejects.toThrow('Failed to fetch token symbol');
+      ).rejects.toThrow('Failed to fetch nonce');
     });
 
     it('throws an error if nonce decoding fails', async () => {
@@ -127,7 +127,7 @@ describe('NonceCaveatClient', () => {
           chainId: mockChainId,
           account: mockAccount,
         }),
-      ).rejects.toThrow('Failed to fetch token balance and metadata');
+      ).rejects.toThrow('Failed to fetch nonce');
     });
 
     it('handles large nonce values correctly', async () => {

--- a/packages/gator-permissions-snap/test/client/nonceCaveatClient.test.ts
+++ b/packages/gator-permissions-snap/test/client/nonceCaveatClient.test.ts
@@ -1,0 +1,165 @@
+import { numberToHex } from '@metamask/utils';
+
+import { NonceCaveatClient } from '../../src/clients/nonceCaveatClient';
+
+describe('NonceCaveatClient', () => {
+  const mockEthereumProvider = {
+    request: jest.fn(),
+  };
+  let client = new NonceCaveatClient({
+    ethereumProvider: mockEthereumProvider,
+  });
+
+  beforeEach(() => {
+    mockEthereumProvider.request.mockClear();
+    client = new NonceCaveatClient({
+      ethereumProvider: mockEthereumProvider,
+    });
+  });
+
+  describe('getNonce', () => {
+    const mockAccount = '0x4f10501E98476Bc5c7C322a8ae87226aFC8a66a2';
+    const mockChainId = 11155111;
+    const mockChainIdHex = numberToHex(mockChainId);
+    const mockDelegationManager = '0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3';
+    const mockNonceEnforcer = '0xDE4f2FAC4B3D87A1d9953Ca5FC09FCa7F366254f';
+
+    it('fetches nonce successfully', async () => {
+      const mockNonceEncoded =
+        '0x0000000000000000000000000000000000000000000000000000000000000005';
+
+      mockEthereumProvider.request
+        .mockResolvedValueOnce(mockChainIdHex) // eth_chainId
+        .mockResolvedValueOnce(mockNonceEncoded); // eth_call
+
+      const result = await client.getNonce({
+        chainId: mockChainId,
+        account: mockAccount,
+      });
+
+      expect(result).toBe(5);
+
+      expect(mockEthereumProvider.request).toHaveBeenCalledTimes(2);
+      expect(mockEthereumProvider.request).toHaveBeenNthCalledWith(1, {
+        method: 'eth_chainId',
+        params: [],
+      });
+      expect(mockEthereumProvider.request).toHaveBeenNthCalledWith(2, {
+        method: 'eth_call',
+        params: [
+          {
+            to: mockNonceEnforcer,
+            data: `0x2bd4ed21${mockDelegationManager
+              .slice(2)
+              .padStart(64, '0')}${mockAccount.slice(2).padStart(64, '0')}`,
+          },
+          'latest',
+        ],
+      });
+    });
+
+    it('throws an error if chainId is not provided', async () => {
+      await expect(
+        client.getNonce({
+          chainId: 0,
+          account: mockAccount,
+        }),
+      ).rejects.toThrow('No chainId provided to fetch nonce');
+      expect(mockEthereumProvider.request).not.toHaveBeenCalled();
+    });
+
+    it('throws an error if account is not provided', async () => {
+      await expect(
+        client.getNonce({
+          chainId: mockChainId,
+          account: '' as any,
+        }),
+      ).rejects.toThrow('No account address provided to fetch nonce');
+      expect(mockEthereumProvider.request).not.toHaveBeenCalled();
+    });
+
+    it('throws an error if selected chain does not match requested chain', async () => {
+      mockEthereumProvider.request.mockResolvedValueOnce('0x01'); // eth_chainId
+
+      await expect(
+        client.getNonce({
+          chainId: mockChainId,
+          account: mockAccount,
+        }),
+      ).rejects.toThrow('Selected chain does not match the requested chain');
+    });
+
+    it('throws an error if nonce fetch fails', async () => {
+      mockEthereumProvider.request
+        .mockResolvedValueOnce(mockChainIdHex) // eth_chainId
+        .mockRejectedValueOnce(new Error('RPC error')); // eth_call
+
+      await expect(
+        client.getNonce({
+          chainId: mockChainId,
+          account: mockAccount,
+        }),
+      ).rejects.toThrow('Failed to fetch nonce');
+    });
+
+    it('throws an error if nonce response is null', async () => {
+      mockEthereumProvider.request
+        .mockResolvedValueOnce(mockChainIdHex) // eth_chainId
+        .mockResolvedValueOnce(null); // eth_call
+
+      await expect(
+        client.getNonce({
+          chainId: mockChainId,
+          account: mockAccount,
+        }),
+      ).rejects.toThrow('Failed to fetch token symbol');
+    });
+
+    it('throws an error if nonce decoding fails', async () => {
+      const invalidNonceEncoded = '0xinvalid';
+
+      mockEthereumProvider.request
+        .mockResolvedValueOnce(mockChainIdHex) // eth_chainId
+        .mockResolvedValueOnce(invalidNonceEncoded); // eth_call
+
+      await expect(
+        client.getNonce({
+          chainId: mockChainId,
+          account: mockAccount,
+        }),
+      ).rejects.toThrow('Failed to fetch token balance and metadata');
+    });
+
+    it('handles large nonce values correctly', async () => {
+      const largeNonceEncoded =
+        '0x000000000000000000000000000000000000000000000000000000000000ffff';
+
+      mockEthereumProvider.request
+        .mockResolvedValueOnce(mockChainIdHex) // eth_chainId
+        .mockResolvedValueOnce(largeNonceEncoded); // eth_call
+
+      const result = await client.getNonce({
+        chainId: mockChainId,
+        account: mockAccount,
+      });
+
+      expect(result).toBe(65535);
+    });
+
+    it('handles zero nonce correctly', async () => {
+      const zeroNonceEncoded =
+        '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+      mockEthereumProvider.request
+        .mockResolvedValueOnce(mockChainIdHex) // eth_chainId
+        .mockResolvedValueOnce(zeroNonceEncoded); // eth_call
+
+      const result = await client.getNonce({
+        chainId: mockChainId,
+        account: mockAccount,
+      });
+
+      expect(result).toBe(0);
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/client/nonceCaveatClient.test.ts
+++ b/packages/gator-permissions-snap/test/client/nonceCaveatClient.test.ts
@@ -37,7 +37,7 @@ describe('NonceCaveatClient', () => {
         account: mockAccount,
       });
 
-      expect(result).toBe(5);
+      expect(result).toBe(5n);
 
       expect(mockEthereumProvider.request).toHaveBeenCalledTimes(2);
       expect(mockEthereumProvider.request).toHaveBeenNthCalledWith(1, {
@@ -143,7 +143,7 @@ describe('NonceCaveatClient', () => {
         account: mockAccount,
       });
 
-      expect(result).toBe(65535);
+      expect(result).toBe(65535n);
     });
 
     it('handles zero nonce correctly', async () => {
@@ -159,7 +159,7 @@ describe('NonceCaveatClient', () => {
         account: mockAccount,
       });
 
-      expect(result).toBe(0);
+      expect(result).toBe(0n);
     });
   });
 });

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -3,9 +3,10 @@ import {
   decodeDelegations,
   ROOT_AUTHORITY,
   createTimestampTerms,
+  createNonceTerms,
 } from '@metamask/delegation-core';
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
-import { bytesToHex } from '@metamask/utils';
+import { bigIntToHex, bytesToHex } from '@metamask/utils';
 import type { NonceCaveatService } from 'src/services/nonceCaveatService';
 
 import type { AccountController } from '../../src/accountController';
@@ -165,7 +166,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
     );
     mockConfirmationDialog.updateContent.mockResolvedValue(undefined);
 
-    mockNonceCaveatService.getNonce.mockResolvedValue(0);
+    mockNonceCaveatService.getNonce.mockResolvedValue(0n);
 
     permissionRequestLifecycleOrchestrator =
       new PermissionRequestLifecycleOrchestrator({
@@ -311,7 +312,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
 
         const {
           contracts: {
-            enforcers: { TimestampEnforcer },
+            enforcers: { TimestampEnforcer, NonceEnforcer },
           },
         } = getChainMetadata({
           chainId: Number(mockPermissionRequest.chainId),
@@ -328,6 +329,13 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
               terms: createTimestampTerms({
                 timestampAfterThreshold: 0,
                 timestampBeforeThreshold: mockPermissionRequest.expiry,
+              }),
+            },
+            {
+              enforcer: NonceEnforcer.toLowerCase(),
+              args: '0x',
+              terms: createNonceTerms({
+                nonce: bigIntToHex(0n),
               }),
             },
           ],

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@metamask/delegation-core';
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 import { bytesToHex } from '@metamask/utils';
+import type { NonceCaveatService } from 'src/services/nonceCaveatService';
 
 import type { AccountController } from '../../src/accountController';
 import { getChainMetadata } from '../../src/core/chainMetadata';
@@ -100,6 +101,10 @@ const mockUserEventDispatcher = {
   waitForPendingHandlers: jest.fn().mockResolvedValue(undefined),
 } as unknown as jest.Mocked<UserEventDispatcher>;
 
+const mockNonceCaveatService = {
+  getNonce: jest.fn(),
+} as unknown as jest.Mocked<NonceCaveatService>;
+
 type TestLifecycleHandlersMocks = {
   parseAndValidatePermission: jest.Mock;
   buildContext: jest.Mock;
@@ -160,11 +165,14 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
     );
     mockConfirmationDialog.updateContent.mockResolvedValue(undefined);
 
+    mockNonceCaveatService.getNonce.mockResolvedValue(0);
+
     permissionRequestLifecycleOrchestrator =
       new PermissionRequestLifecycleOrchestrator({
         accountController: mockAccountController,
         confirmationDialogFactory: mockConfirmationDialogFactory,
         userEventDispatcher: mockUserEventDispatcher,
+        nonceCaveatService: mockNonceCaveatService,
       });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,14 +3329,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-core@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@metamask/delegation-core@npm:0.1.0"
+"@metamask/delegation-core@npm:0.2.0-rc.1":
+  version: 0.2.0-rc.1
+  resolution: "@metamask/delegation-core@npm:0.2.0-rc.1"
   dependencies:
     "@metamask/abi-utils": ^3.0.0
     "@metamask/utils": ^11.4.0
     "@noble/hashes": ^1.8.0
-  checksum: 438ba9ca13fc1ac02733c64011f1520b7731b7d16175ad40ddbb8b680c2cc4fc24d8202fc0f075577c6a78f98aafe40ff684452efdfeb5d523fbf5c3239b425e
+  checksum: d14829231644235391e9769d66bc1181391b026500db13700543b4d73cca20d672f719d0e64cd887db3ba0ad19a4e54dba2cc0fd7f3554398dfe089f6d991947
   languageName: node
   linkType: hard
 
@@ -3525,7 +3525,7 @@ __metadata:
     "@metamask/7715-permissions-shared": "workspace:*"
     "@metamask/abi-utils": 3.0.0
     "@metamask/auto-changelog": 5.0.2
-    "@metamask/delegation-core": 0.1.0
+    "@metamask/delegation-core": 0.2.0-rc.1
     "@metamask/delegation-toolkit": 0.10.2
     "@metamask/eslint-config": 12.2.0
     "@metamask/eslint-config-jest": 12.1.0


### PR DESCRIPTION
## **Description**

Adding NonceEnforcer to all granted permissions will allow us to revoke in batch duing the revocation proccess.

## **Manual testing steps**

1. Go to http://localhost:8000/
2. Click grant permission
3. You can check permission encoded context
4. Redeem permission - should still work as before


## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.