### PR TITLE
Don't check manifest when targeting dev branch

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -81,9 +81,18 @@ jobs:
       - name: Require clean working directory
         shell: bash
         run: |
-          if ! git diff --exit-code; then
-            echo "Working tree dirty at end of job"
-            exit 1
+          # Check if target branch is 'dev' and exclude snap.manifest.json files if so
+          if [[ "${{ github.base_ref }}" == "dev" || "${{ github.ref_name }}" == "dev" ]]; then
+            echo "Target branch is 'dev', ignoring changes to snap.manifest.json files"
+            if ! git diff --exit-code -- . ':!**/snap.manifest.json'; then
+              echo "Working tree dirty at end of job (excluding snap.manifest.json)"
+              exit 1
+            fi
+          else
+            if ! git diff --exit-code; then
+              echo "Working tree dirty at end of job"
+              exit 1
+            fi
           fi
 
   lint:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR disregards changes to snap.manifest.json after building, when the the base branch of the PR is `dev`. This allows us to merge multiple PRs into `dev` branch without having to recreate the manifest file.
