### PR TITLE
[Test ] validate whether actions succeed with invalid shasum

### DIFF
--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "3bSJ9Th+sBdj3zy04EW1ibs58wv6LJLELNYiLv52FbU=",
+    "shasum": "Ui6fFgBqd58pNXpVCmZ6T2FSZBZLabXrqMT0mvfQ3Fw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -35,6 +35,6 @@
     "snap_getPreferences": {},
     "endowment:page-home": {}
   },
-  "platformVersion": "8.1.0",
+  "platformVersion": "9.3.0",
   "manifestVersion": "0.1"
 }


### PR DESCRIPTION
This PR introduces an invalid shasum in the gator-permissions-snap project, validating that the workflows will succeed even with a shasum mismatch.

DO NOT MERGE