### PR TITLE
Switch expiry and startTime types to number since we are expecting a timestamp

### DIFF
--- a/packages/gator-permissions-snap/src/core/rules.tsx
+++ b/packages/gator-permissions-snap/src/core/rules.tsx
@@ -241,15 +241,17 @@ export function bindRuleHandlers<
         currentValues.time = event.value as string;
       }
 
-      // Fix type mismatch: Convert string timestamp to number before passing to utility functions
-      const timestampNumber = Number(currentValues.timestamp);
-      if (!isNaN(timestampNumber) && timestampNumber > 0) {
+      if (!isNaN(currentValues.timestamp) && currentValues.timestamp > 0) {
         if (!currentValues.date) {
-          currentValues.date = convertTimestampToReadableDate(timestampNumber);
+          currentValues.date = convertTimestampToReadableDate(
+            currentValues.timestamp,
+          );
         }
 
         if (!currentValues.time) {
-          currentValues.time = convertTimestampToReadableTime(timestampNumber);
+          currentValues.time = convertTimestampToReadableTime(
+            currentValues.timestamp,
+          );
         }
       }
 
@@ -258,13 +260,13 @@ export function bindRuleHandlers<
           currentValues.date,
           currentValues.time,
         );
-        currentValues.timestamp = timestamp.toString();
+        currentValues.timestamp = timestamp;
       } catch (error) {
-        currentValues.timestamp = '';
+        // this is to trigger an error state on the date time field - "Invalid date" handled in validation
+        currentValues.timestamp = -1;
         logger.error('Error combining date and time', error);
       }
 
-      // Fix race condition: Use the stored context reference instead of calling getContext() again
       const updatedContext = rule.updateContext(context, currentValues);
       await onContextChanged({ context: updatedContext });
     };

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -40,7 +40,7 @@ export type TypedPermissionRequest<TPermission extends Permission> =
  */
 export type BaseContext = {
   expiry: {
-    timestamp: string;
+    timestamp: number;
     isAdjustmentAllowed: boolean;
   };
   isAdjustmentAllowed: boolean;

--- a/packages/gator-permissions-snap/src/permissions/contextValidation.ts
+++ b/packages/gator-permissions-snap/src/permissions/contextValidation.ts
@@ -1,9 +1,5 @@
 import type { TimePeriod } from '../core/types';
-import {
-  convertReadableDateToTimestamp,
-  getStartOfTodayLocal,
-  TIME_PERIOD_TO_SECONDS,
-} from '../utils/time';
+import { getStartOfTodayLocal, TIME_PERIOD_TO_SECONDS } from '../utils/time';
 import { parseUnits, formatUnits } from '../utils/value';
 
 export type ValidationErrors = {
@@ -59,14 +55,16 @@ export function validateAndParseAmount(
 
 /**
  * Validates a start time to ensure it's today or later.
- * @param startTime - The start time string to validate.
+ * @param startTime - The start time number to validate. Start time -1 is used to indicate that something is wrong with the start time date field.
  * @returns Validation error message or undefined if valid.
  */
-export function validateStartTime(startTime: string): string | undefined {
-  try {
-    const startTimeDate = convertReadableDateToTimestamp(startTime);
+export function validateStartTime(startTime: number): string | undefined {
+  if (startTime === -1) {
+    return 'Invalid start time';
+  }
 
-    if (startTimeDate < getStartOfTodayLocal()) {
+  try {
+    if (startTime < getStartOfTodayLocal()) {
       return 'Start time must be today or later';
     }
     return undefined;
@@ -77,14 +75,17 @@ export function validateStartTime(startTime: string): string | undefined {
 
 /**
  * Validates an expiry time to ensure it's in the future.
- * @param expiry - The expiry time string to validate.
+ * @param expiry - The expiry time to validate. Expiry -1 is used to indicate that something is wrong with the expiry date field.
  * @returns Validation error message or undefined if valid.
  */
-export function validateExpiry(expiry: string): string | undefined {
+export function validateExpiry(expiry: number): string | undefined {
+  if (expiry === -1) {
+    return 'Invalid expiry';
+  }
+
   try {
-    const expiryDate = convertReadableDateToTimestamp(expiry);
     const nowSeconds = Math.floor(Date.now() / 1000);
-    if (expiryDate < nowSeconds) {
+    if (expiry < nowSeconds) {
       return 'Expiry must be in the future';
     }
     return undefined;
@@ -100,18 +101,15 @@ export function validateExpiry(expiry: string): string | undefined {
  * @returns Validation error message or undefined if valid.
  */
 export function validateStartTimeVsExpiry(
-  startTime: string,
-  expiry: string,
+  startTime: number,
+  expiry: number,
 ): string | undefined {
   try {
-    const startTimeDate = convertReadableDateToTimestamp(startTime);
-    const expiryDate = convertReadableDateToTimestamp(expiry);
-    if (startTimeDate >= expiryDate) {
+    if (startTime >= expiry) {
       return 'Start time must be before expiry';
     }
     return undefined;
   } catch (error) {
-    // If date conversion fails, return undefined to let individual validation handle it
     return undefined;
   }
 }

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/context.ts
@@ -8,10 +8,7 @@ import {
 
 import { TimePeriod } from '../../core/types';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
-import {
-  convertReadableDateToTimestamp,
-  TIME_PERIOD_TO_SECONDS,
-} from '../../utils/time';
+import { TIME_PERIOD_TO_SECONDS } from '../../utils/time';
 import { parseUnits, formatUnitsFromHex } from '../../utils/value';
 import {
   validateAndParseAmount,
@@ -51,7 +48,7 @@ export async function applyContext({
     tokenMetadata: { decimals },
   } = context;
 
-  const expiry = convertReadableDateToTimestamp(context.expiry.timestamp);
+  const expiry = context.expiry.timestamp;
 
   let isExpiryRuleFound = false;
 
@@ -78,7 +75,7 @@ export async function applyContext({
       parseUnits({ formatted: permissionDetails.periodAmount, decimals }),
     ),
     periodDuration: parseInt(permissionDetails.periodDuration, 10),
-    startTime: convertReadableDateToTimestamp(permissionDetails.startTime),
+    startTime: permissionDetails.startTime,
     justification: originalRequest.permission.data.justification,
     tokenAddress: originalRequest.permission.data.tokenAddress,
   };
@@ -169,7 +166,7 @@ export async function buildContext({
   }
 
   const expiry = {
-    timestamp: expiryRule.data.timestamp.toString(),
+    timestamp: expiryRule.data.timestamp,
     isAdjustmentAllowed: expiryRule.isAdjustmentAllowed ?? true,
   };
 
@@ -193,8 +190,7 @@ export async function buildContext({
     periodType = 'Other';
   }
 
-  const startTime =
-    data.startTime?.toString() ?? Math.floor(Date.now() / 1000).toString();
+  const startTime = data.startTime ?? Math.floor(Date.now() / 1000);
 
   const tokenAddressCaip19 = toCaipAssetType(
     CHAIN_NAMESPACE,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/rules.ts
@@ -101,7 +101,7 @@ export const startTimeRule: RuleDefinition<
   label: 'Start Time',
   type: 'datetime',
   getRuleData: ({ context, metadata }) => ({
-    value: context.permissionDetails.startTime,
+    value: context.permissionDetails.startTime.toString(),
     isAdjustmentAllowed: context.isAdjustmentAllowed,
     isVisible: true,
     tooltip: 'The time at which the first period begins(mm/dd/yyyy hh:mm:ss).',
@@ -135,7 +135,7 @@ export const expiryRule: RuleDefinition<
   label: 'Expiry',
   type: 'datetime',
   getRuleData: ({ context, metadata }) => ({
-    value: context.expiry.timestamp,
+    value: context.expiry.timestamp.toString(),
     isAdjustmentAllowed: context.expiry.isAdjustmentAllowed,
     isVisible: true,
     tooltip: 'The expiry date of the permission(mm/dd/yyyy hh:mm:ss).',

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/types.ts
@@ -30,7 +30,7 @@ export type Erc20TokenPeriodicContext = BaseContext & {
     periodAmount: string;
     periodType: TimePeriod | 'Other';
     periodDuration: string;
-    startTime: string;
+    startTime: number;
   };
 };
 

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -8,10 +8,7 @@ import {
 
 import { TimePeriod } from '../../core/types';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
-import {
-  convertReadableDateToTimestamp,
-  TIME_PERIOD_TO_SECONDS,
-} from '../../utils/time';
+import { TIME_PERIOD_TO_SECONDS } from '../../utils/time';
 import { parseUnits, formatUnits, formatUnitsFromHex } from '../../utils/value';
 import {
   validateAndParseAmount,
@@ -54,7 +51,7 @@ export async function applyContext({
     permissionDetails,
     tokenMetadata: { decimals },
   } = context;
-  const expiry = convertReadableDateToTimestamp(context.expiry.timestamp);
+  const expiry = context.expiry.timestamp;
 
   let isExpiryRuleFound = false;
 
@@ -93,7 +90,7 @@ export async function applyContext({
         decimals,
       }) / TIME_PERIOD_TO_SECONDS[permissionDetails.timePeriod],
     ),
-    startTime: convertReadableDateToTimestamp(permissionDetails.startTime),
+    startTime: permissionDetails.startTime,
     justification: originalRequest.permission.data.justification,
     tokenAddress: originalRequest.permission.data.tokenAddress,
   };
@@ -187,7 +184,7 @@ export async function buildContext({
   }
 
   const expiry = {
-    timestamp: expiryRule.data.timestamp.toString(),
+    timestamp: expiryRule.data.timestamp,
     isAdjustmentAllowed: expiryRule.isAdjustmentAllowed ?? true,
   };
 
@@ -214,8 +211,7 @@ export async function buildContext({
     decimals,
   });
 
-  const startTime =
-    data.startTime?.toString() ?? Math.floor(Date.now() / 1000).toString();
+  const startTime = data.startTime ?? Math.floor(Date.now() / 1000);
 
   const tokenAddressCaip19 = toCaipAssetType(
     CHAIN_NAMESPACE,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/rules.ts
@@ -73,7 +73,7 @@ export const startTimeRule: Erc20TokenStreamRuleDefinition = {
   label: 'Start Time',
   type: 'datetime',
   getRuleData: ({ context, metadata }) => ({
-    value: context.permissionDetails.startTime,
+    value: context.permissionDetails.startTime.toString(),
     isAdjustmentAllowed: context.isAdjustmentAllowed,
     isVisible: true,
     tooltip: 'The start time of the stream(mm/dd/yyyy hh:mm:ss).',
@@ -145,7 +145,7 @@ export const expiryRule: Erc20TokenStreamRuleDefinition = {
   label: 'Expiry',
   type: 'datetime',
   getRuleData: ({ context, metadata }) => ({
-    value: context.expiry.timestamp,
+    value: context.expiry.timestamp.toString(),
     isAdjustmentAllowed: context.expiry.isAdjustmentAllowed,
     isVisible: true,
     tooltip: 'The expiry date of the permission(mm/dd/yyyy hh:mm:ss).',

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
@@ -31,7 +31,7 @@ export type Erc20TokenStreamContext = BaseContext & {
     initialAmount: string | undefined;
     maxAmount: string | undefined;
     timePeriod: TimePeriod;
-    startTime: string;
+    startTime: number;
     amountPerPeriod: string;
   };
 };

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -8,10 +8,7 @@ import {
 
 import { TimePeriod } from '../../core/types';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
-import {
-  convertReadableDateToTimestamp,
-  TIME_PERIOD_TO_SECONDS,
-} from '../../utils/time';
+import { TIME_PERIOD_TO_SECONDS } from '../../utils/time';
 import { parseUnits, formatUnitsFromHex } from '../../utils/value';
 import {
   validateAndParseAmount,
@@ -52,7 +49,7 @@ export async function applyContext({
     tokenMetadata: { decimals },
   } = context;
 
-  const expiry = convertReadableDateToTimestamp(context.expiry.timestamp);
+  const expiry = context.expiry.timestamp;
 
   let isExpiryRuleFound = false;
 
@@ -79,7 +76,7 @@ export async function applyContext({
       parseUnits({ formatted: permissionDetails.periodAmount, decimals }),
     ),
     periodDuration: parseInt(permissionDetails.periodDuration, 10),
-    startTime: convertReadableDateToTimestamp(permissionDetails.startTime),
+    startTime: permissionDetails.startTime,
     justification: originalRequest.permission.data.justification,
   };
 
@@ -169,7 +166,7 @@ export async function buildContext({
   }
 
   const expiry = {
-    timestamp: expiryRule.data.timestamp.toString(),
+    timestamp: expiryRule.data.timestamp,
     isAdjustmentAllowed: expiryRule.isAdjustmentAllowed ?? true,
   };
 
@@ -193,8 +190,7 @@ export async function buildContext({
     periodType = 'Other';
   }
 
-  const startTime =
-    data.startTime?.toString() ?? Math.floor(Date.now() / 1000).toString();
+  const startTime = data.startTime ?? Math.floor(Date.now() / 1000);
 
   const tokenAddressCaip19 = toCaipAssetType(
     CHAIN_NAMESPACE,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/rules.ts
@@ -101,7 +101,7 @@ export const startTimeRule: RuleDefinition<
   label: 'Start Time',
   type: 'datetime',
   getRuleData: ({ context, metadata }) => ({
-    value: context.permissionDetails.startTime,
+    value: context.permissionDetails.startTime.toString(),
     isAdjustmentAllowed: context.isAdjustmentAllowed,
     isVisible: true,
     tooltip: 'The time at which the first period begins(mm/dd/yyyy hh:mm:ss).',
@@ -135,7 +135,7 @@ export const expiryRule: RuleDefinition<
   label: 'Expiry',
   type: 'datetime',
   getRuleData: ({ context, metadata }) => ({
-    value: context.expiry.timestamp,
+    value: context.expiry.timestamp.toString(),
     isAdjustmentAllowed: context.expiry.isAdjustmentAllowed,
     isVisible: true,
     tooltip: 'The expiry date of the permission(mm/dd/yyyy hh:mm:ss).',

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
@@ -29,7 +29,7 @@ export type NativeTokenPeriodicContext = BaseContext & {
     periodAmount: string;
     periodType: TimePeriod | 'Other';
     periodDuration: string;
-    startTime: string;
+    startTime: number;
   };
 };
 

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -8,10 +8,7 @@ import {
 
 import { TimePeriod } from '../../core/types';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
-import {
-  convertReadableDateToTimestamp,
-  TIME_PERIOD_TO_SECONDS,
-} from '../../utils/time';
+import { TIME_PERIOD_TO_SECONDS } from '../../utils/time';
 import { parseUnits, formatUnits, formatUnitsFromHex } from '../../utils/value';
 import {
   validateAndParseAmount,
@@ -55,7 +52,7 @@ export async function applyContext({
     permissionDetails,
     tokenMetadata: { decimals },
   } = context;
-  const expiry = convertReadableDateToTimestamp(context.expiry.timestamp);
+  const expiry = context.expiry.timestamp;
 
   let isExpiryRuleFound = false;
 
@@ -92,7 +89,7 @@ export async function applyContext({
       parseUnits({ formatted: permissionDetails.amountPerPeriod, decimals }) /
         TIME_PERIOD_TO_SECONDS[permissionDetails.timePeriod],
     ),
-    startTime: convertReadableDateToTimestamp(permissionDetails.startTime),
+    startTime: permissionDetails.startTime,
     justification: originalRequest.permission.data.justification,
   };
 
@@ -184,7 +181,7 @@ export async function buildContext({
   }
 
   const expiry = {
-    timestamp: expiryRule.data.timestamp.toString(),
+    timestamp: expiryRule.data.timestamp,
     isAdjustmentAllowed: expiryRule?.isAdjustmentAllowed ?? true,
   };
 
@@ -211,8 +208,7 @@ export async function buildContext({
     decimals,
   });
 
-  const startTime =
-    data.startTime?.toString() ?? Math.floor(Date.now() / 1000).toString();
+  const startTime = data.startTime ?? Math.floor(Date.now() / 1000);
 
   const tokenAddressCaip19 = toCaipAssetType(
     CHAIN_NAMESPACE,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/rules.ts
@@ -74,7 +74,7 @@ export const startTimeRule: NativeTokenStreamRuleDefinition = {
   label: 'Start Time',
   type: 'datetime',
   getRuleData: ({ context, metadata }) => ({
-    value: context.permissionDetails.startTime,
+    value: context.permissionDetails.startTime.toString(),
     isAdjustmentAllowed: context.isAdjustmentAllowed,
     isVisible: true,
     tooltip: 'The start time of the stream(mm/dd/yyyy hh:mm:ss).',
@@ -146,7 +146,7 @@ export const expiryRule: NativeTokenStreamRuleDefinition = {
   label: 'Expiry',
   type: 'datetime',
   getRuleData: ({ context, metadata }) => ({
-    value: context.expiry.timestamp,
+    value: context.expiry.timestamp.toLocaleString(),
     isAdjustmentAllowed: context.expiry.isAdjustmentAllowed,
     isVisible: true,
     tooltip: 'The expiry date of the permission(mm/dd/yyyy hh:mm:ss).',

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
@@ -30,7 +30,7 @@ export type NativeTokenStreamContext = BaseContext & {
     initialAmount: string | undefined;
     maxAmount: string | undefined;
     timePeriod: TimePeriod;
-    startTime: string;
+    startTime: number;
     amountPerPeriod: string;
   };
 };

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenPeriodic/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenPeriodic/content.test.ts
@@ -11,7 +11,10 @@ import { TIME_PERIOD_TO_SECONDS } from '../../../src/utils/time';
 const tokenDecimals = 6;
 
 const mockContext: Erc20TokenPeriodicContext = {
-  expiry: '05/01/2024',
+  expiry: {
+    timestamp: 1714521600, // 05/01/2024
+    isAdjustmentAllowed: true,
+  },
   isAdjustmentAllowed: true,
   justification: 'Permission to do periodic ERC20 token transfers',
   accountAddressCaip10: `eip155:1:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`,
@@ -26,7 +29,7 @@ const mockContext: Erc20TokenPeriodicContext = {
     periodAmount: '100',
     periodType: TimePeriod.DAILY,
     periodDuration: Number(TIME_PERIOD_TO_SECONDS[TimePeriod.DAILY]).toString(),
-    startTime: '10/26/1985',
+    startTime: 499161600, // 10/26/1985
   },
 };
 
@@ -134,7 +137,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -144,7 +147,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -396,7 +399,6 @@ describe('erc20TokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -441,8 +443,77 @@ describe('erc20TokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -452,20 +523,13 @@ describe('erc20TokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -592,7 +656,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -602,7 +666,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -855,7 +919,6 @@ describe('erc20TokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -900,8 +963,77 @@ describe('erc20TokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -911,20 +1043,13 @@ describe('erc20TokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -1048,7 +1173,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -1058,7 +1183,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -1310,7 +1435,6 @@ describe('erc20TokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -1355,8 +1479,77 @@ describe('erc20TokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -1366,20 +1559,13 @@ describe('erc20TokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -1501,7 +1687,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -1511,7 +1697,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -1851,7 +2037,6 @@ describe('erc20TokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -1896,8 +2081,77 @@ describe('erc20TokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -1907,20 +2161,13 @@ describe('erc20TokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -2041,7 +2288,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -2051,7 +2298,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -2294,7 +2541,6 @@ describe('erc20TokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -2339,8 +2585,77 @@ describe('erc20TokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -2350,20 +2665,13 @@ describe('erc20TokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -2476,7 +2784,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -2486,7 +2794,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -2738,7 +3046,6 @@ describe('erc20TokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -2783,8 +3090,77 @@ describe('erc20TokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -2794,20 +3170,13 @@ describe('erc20TokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -2929,7 +3298,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -2939,7 +3308,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -3200,7 +3569,6 @@ describe('erc20TokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -3245,8 +3613,77 @@ describe('erc20TokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -3259,17 +3696,18 @@ describe('erc20TokenPeriodic:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": "undefined undefined UTC",
+                            "children": "Invalid expiry",
+                            "color": "error",
+                            "size": "sm",
                           },
                           "type": "Text",
                         },
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -3382,7 +3820,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -3392,7 +3830,7 @@ describe('erc20TokenPeriodic:content', () => {
                                 "name": "erc20-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -3644,7 +4082,6 @@ describe('erc20TokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -3689,8 +4126,77 @@ describe('erc20TokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -3700,20 +4206,13 @@ describe('erc20TokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenPeriodic/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenPeriodic/context.test.ts
@@ -15,7 +15,6 @@ import type {
 } from '../../../src/permissions/erc20TokenPeriodic/types';
 import type { TokenMetadataService } from '../../../src/services/tokenMetadataService';
 import {
-  convertTimestampToReadableDate,
   convertReadableDateToTimestamp,
   TIME_PERIOD_TO_SECONDS,
 } from '../../../src/utils/time';
@@ -76,7 +75,7 @@ const alreadyPopulatedPermissionRequest: Erc20TokenPeriodicPermissionRequest = {
 
 const alreadyPopulatedContext: Erc20TokenPeriodicContext = {
   expiry: {
-    timestamp: '1714521600',
+    timestamp: 1714521600,
     isAdjustmentAllowed: true,
   },
   isAdjustmentAllowed: true,
@@ -92,7 +91,7 @@ const alreadyPopulatedContext: Erc20TokenPeriodicContext = {
     periodAmount: '100',
     periodType: TimePeriod.DAILY,
     periodDuration: Number(TIME_PERIOD_TO_SECONDS[TimePeriod.DAILY]).toString(),
-    startTime: '1729900800',
+    startTime: 1729900800,
   },
 } as const;
 
@@ -236,11 +235,8 @@ describe('erc20TokenPeriodic:context', () => {
   });
 
   describe('deriveMetadata()', () => {
-    const dateInTheFuture = (
-      Math.floor(Date.now() / 1000) +
-      24 * 60 * 60
-    ).toString(); // 24 hours from now
-    const startTime = (Math.floor(Date.now() / 1000) + 12 * 60 * 60).toString(); // 12 hours from now
+    const dateInTheFuture = Math.floor(Date.now() / 1000) + 24 * 60 * 60; // 24 hours from now
+    const startTime = Math.floor(Date.now() / 1000) + 12 * 60 * 60; // 12 hours from now
 
     const context = {
       ...alreadyPopulatedContext,
@@ -349,7 +345,7 @@ describe('erc20TokenPeriodic:context', () => {
           ...context,
           permissionDetails: {
             ...context.permissionDetails,
-            startTime: 'invalid',
+            startTime: -1, // Special case for invalid format
           },
         };
 
@@ -367,7 +363,7 @@ describe('erc20TokenPeriodic:context', () => {
           ...context,
           permissionDetails: {
             ...context.permissionDetails,
-            startTime: '01/01/2020',
+            startTime: 1577836800, // 01/01/2020
           },
         };
 
@@ -386,7 +382,7 @@ describe('erc20TokenPeriodic:context', () => {
         const contextWithExpiryInThePast = {
           ...context,
           expiry: {
-            timestamp: '10/26/1985',
+            timestamp: 499161600, // 10/26/1985
             isAdjustmentAllowed: true,
           },
           permissionDetails: {
@@ -403,7 +399,28 @@ describe('erc20TokenPeriodic:context', () => {
         });
       });
 
-      it.each([['12345678'], ['0x1234'], ['Steve']])(
+      it('should return a validation error for invalid expiry -1', async () => {
+        const contextWithInvalidExpiry = {
+          ...context,
+          expiry: {
+            timestamp: -1,
+            isAdjustmentAllowed: true,
+          },
+          permissionDetails: {
+            ...context.permissionDetails,
+          },
+        };
+
+        const metadata = await deriveMetadata({
+          context: contextWithInvalidExpiry,
+        });
+
+        expect(metadata.validationErrors).toStrictEqual({
+          expiryError: 'Invalid expiry',
+        });
+      });
+
+      it.each([[12345678], [0x1234], [999999999]])(
         'should return a validation error for invalid expiry %s',
         async (expiry) => {
           const contextWithInvalidExpiry = {
@@ -422,7 +439,7 @@ describe('erc20TokenPeriodic:context', () => {
           });
 
           expect(metadata.validationErrors).toStrictEqual({
-            expiryError: 'Invalid expiry',
+            expiryError: 'Expiry must be in the future',
           });
         },
       );
@@ -437,12 +454,10 @@ describe('erc20TokenPeriodic:context', () => {
           ...alreadyPopulatedContext.permissionDetails,
           periodAmount: '200',
           periodDuration: '604800', // 1 week
-          startTime: convertTimestampToReadableDate(Date.now() / 1000),
+          startTime: Math.floor(Date.now() / 1000),
         },
         expiry: {
-          timestamp: convertTimestampToReadableDate(
-            Date.now() / 1000 + 30 * 24 * 60 * 60,
-          ), // 30 days from now
+          timestamp: Math.floor(Date.now() / 1000 + 30 * 24 * 60 * 60), // 30 days from now
           isAdjustmentAllowed: true,
         },
       };

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/content.test.ts
@@ -10,22 +10,25 @@ import type {
 const tokenDecimals = 10;
 
 const mockContext: Erc20TokenStreamContext = {
-  expiry: '05/01/2024',
+  expiry: {
+    timestamp: 1714521600, // 05/01/2024
+    isAdjustmentAllowed: true,
+  },
   isAdjustmentAllowed: true,
   justification: 'Permission to stream ERC20 tokens',
   accountAddressCaip10: `eip155:1:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`,
   tokenAddressCaip19: `eip155:1/erc20:0xA0b86a33E6417efb4e0Ba2b1e4E6FE87bbEf2B0F`,
   tokenMetadata: {
-    decimals: tokenDecimals,
     symbol: 'USDC',
+    decimals: tokenDecimals,
     iconDataBase64:
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
   },
   permissionDetails: {
     initialAmount: '1',
     maxAmount: '10',
     timePeriod: TimePeriod.WEEKLY,
-    startTime: '10/26/1985',
+    startTime: 499161600, // 10/26/1985
     amountPerPeriod: '302400',
   },
 };
@@ -118,7 +121,7 @@ describe('erc20TokenStream:content', () => {
                                 "props": {
                                   "alt": "USDC",
                                   "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" width="24" height="24" />
   </svg>",
                                 },
                                 "type": "Image",
@@ -312,7 +315,7 @@ describe('erc20TokenStream:content', () => {
                               "props": {
                                 "alt": "USDC",
                                 "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" width="24" height="24" />
   </svg>",
                               },
                               "type": "Image",
@@ -439,7 +442,7 @@ describe('erc20TokenStream:content', () => {
                               "props": {
                                 "alt": "USDC",
                                 "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" width="24" height="24" />
   </svg>",
                               },
                               "type": "Image",
@@ -564,7 +567,7 @@ describe('erc20TokenStream:content', () => {
                               "props": {
                                 "alt": "USDC",
                                 "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" width="24" height="24" />
   </svg>",
                               },
                               "type": "Image",
@@ -680,7 +683,7 @@ describe('erc20TokenStream:content', () => {
                                 "name": "erc20-token-stream-start-time_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -690,7 +693,7 @@ describe('erc20TokenStream:content', () => {
                                 "name": "erc20-token-stream-start-time_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -737,7 +740,6 @@ describe('erc20TokenStream:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -782,8 +784,77 @@ describe('erc20TokenStream:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-stream-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-stream-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -793,20 +864,13 @@ describe('erc20TokenStream:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -911,7 +975,7 @@ describe('erc20TokenStream:content', () => {
                                 "props": {
                                   "alt": "USDC",
                                   "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" width="24" height="24" />
   </svg>",
                                 },
                                 "type": "Image",
@@ -1106,7 +1170,7 @@ describe('erc20TokenStream:content', () => {
                               "props": {
                                 "alt": "USDC",
                                 "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" width="24" height="24" />
   </svg>",
                               },
                               "type": "Image",
@@ -1233,7 +1297,7 @@ describe('erc20TokenStream:content', () => {
                               "props": {
                                 "alt": "USDC",
                                 "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" width="24" height="24" />
   </svg>",
                               },
                               "type": "Image",
@@ -1359,7 +1423,7 @@ describe('erc20TokenStream:content', () => {
                               "props": {
                                 "alt": "USDC",
                                 "src": "<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="24" height="24" />
+    <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" width="24" height="24" />
   </svg>",
                               },
                               "type": "Image",
@@ -1476,7 +1540,7 @@ describe('erc20TokenStream:content', () => {
                                 "name": "erc20-token-stream-start-time_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -1486,7 +1550,7 @@ describe('erc20TokenStream:content', () => {
                                 "name": "erc20-token-stream-start-time_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -1541,7 +1605,6 @@ describe('erc20TokenStream:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -1586,8 +1649,77 @@ describe('erc20TokenStream:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-stream-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "erc20-token-stream-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -1600,17 +1732,18 @@ describe('erc20TokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": "undefined undefined UTC",
+                            "children": "Invalid expiry",
+                            "color": "error",
+                            "size": "sm",
                           },
                           "type": "Text",
                         },
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/content.test.ts
@@ -9,7 +9,10 @@ import type {
 import { TIME_PERIOD_TO_SECONDS } from '../../../src/utils/time';
 
 const mockContext: NativeTokenPeriodicContext = {
-  expiry: '05/01/2024',
+  expiry: {
+    timestamp: 1714521600, // 05/01/2024
+    isAdjustmentAllowed: true,
+  },
   isAdjustmentAllowed: true,
   justification: 'Permission to do periodic native token transfers',
   accountAddressCaip10: 'eip155:1:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -24,7 +27,7 @@ const mockContext: NativeTokenPeriodicContext = {
     periodAmount: '1',
     periodType: TimePeriod.DAILY,
     periodDuration: Number(TIME_PERIOD_TO_SECONDS[TimePeriod.DAILY]).toString(),
-    startTime: '10/26/1985',
+    startTime: 499161600, // 10/26/1985
   },
 };
 
@@ -132,7 +135,7 @@ describe('nativeTokenPeriodic:content', () => {
                                 "name": "native-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -142,7 +145,7 @@ describe('nativeTokenPeriodic:content', () => {
                                 "name": "native-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -385,7 +388,6 @@ describe('nativeTokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -430,8 +432,77 @@ describe('nativeTokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -441,20 +512,13 @@ describe('nativeTokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -574,7 +638,7 @@ describe('nativeTokenPeriodic:content', () => {
                                 "name": "native-token-periodic-start-date_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -584,7 +648,7 @@ describe('nativeTokenPeriodic:content', () => {
                                 "name": "native-token-periodic-start-date_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -915,7 +979,6 @@ describe('nativeTokenPeriodic:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -960,8 +1023,77 @@ describe('nativeTokenPeriodic:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-periodic-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-periodic-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -971,20 +1103,13 @@ describe('nativeTokenPeriodic:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/content.test.ts
@@ -8,7 +8,10 @@ import type {
 } from '../../../src/permissions/nativeTokenStream/types';
 
 const mockContext: NativeTokenStreamContext = {
-  expiry: '05/01/2024',
+  expiry: {
+    timestamp: 1714521600, // 05/01/2024
+    isAdjustmentAllowed: true,
+  },
   isAdjustmentAllowed: true,
   justification: 'Permission to stream native tokens',
   accountAddressCaip10: `eip155:1:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`,
@@ -22,7 +25,7 @@ const mockContext: NativeTokenStreamContext = {
     initialAmount: '1',
     maxAmount: '10',
     timePeriod: TimePeriod.WEEKLY,
-    startTime: '10/26/1985',
+    startTime: 499161600, // 10/26/1985
     amountPerPeriod: '302400',
   },
 };
@@ -647,7 +650,7 @@ describe('nativeTokenStream:content', () => {
                                 "name": "native-token-stream-start-time_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -657,7 +660,7 @@ describe('nativeTokenStream:content', () => {
                                 "name": "native-token-stream-start-time_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -704,7 +707,6 @@ describe('nativeTokenStream:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -749,8 +751,77 @@ describe('nativeTokenStream:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -760,20 +831,13 @@ describe('nativeTokenStream:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -1409,7 +1473,7 @@ describe('nativeTokenStream:content', () => {
                                 "name": "native-token-stream-start-time_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -1419,7 +1483,7 @@ describe('nativeTokenStream:content', () => {
                                 "name": "native-token-stream-start-time_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -1466,7 +1530,6 @@ describe('nativeTokenStream:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -1511,8 +1574,77 @@ describe('nativeTokenStream:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -1522,20 +1654,13 @@ describe('nativeTokenStream:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -2030,7 +2155,7 @@ describe('nativeTokenStream:content', () => {
                         {
                           "key": null,
                           "props": {
-                            "children": "01/01/1970 00:00:10 UTC",
+                            "children": "10/26/1985 08:00:00 UTC",
                           },
                           "type": "Text",
                         },
@@ -2047,7 +2172,6 @@ describe('nativeTokenStream:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -2092,8 +2216,77 @@ describe('nativeTokenStream:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -2103,20 +2296,13 @@ describe('nativeTokenStream:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -2685,7 +2871,7 @@ describe('nativeTokenStream:content', () => {
                                 "name": "native-token-stream-start-time_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -2695,7 +2881,7 @@ describe('nativeTokenStream:content', () => {
                                 "name": "native-token-stream-start-time_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -2742,7 +2928,6 @@ describe('nativeTokenStream:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -2787,8 +2972,77 @@ describe('nativeTokenStream:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -2798,20 +3052,13 @@ describe('nativeTokenStream:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },
@@ -3445,7 +3692,7 @@ describe('nativeTokenStream:content', () => {
                                 "name": "native-token-stream-start-time_date",
                                 "placeholder": "mm/dd/yyyy",
                                 "type": "text",
-                                "value": "01/01/1970",
+                                "value": "10/26/1985",
                               },
                               "type": "Input",
                             },
@@ -3455,7 +3702,7 @@ describe('nativeTokenStream:content', () => {
                                 "name": "native-token-stream-start-time_time",
                                 "placeholder": "HH:MM:SS",
                                 "type": "text",
-                                "value": "00:00:10",
+                                "value": "08:00:00",
                               },
                               "type": "Input",
                             },
@@ -3502,7 +3749,6 @@ describe('nativeTokenStream:content', () => {
             {
               "key": null,
               "props": {
-                "alignment": "space-between",
                 "children": [
                   {
                     "key": null,
@@ -3547,8 +3793,77 @@ describe('nativeTokenStream:content', () => {
                           },
                           "type": "Box",
                         },
-                        null,
+                        {
+                          "key": null,
+                          "props": {
+                            "alignment": "end",
+                            "children": {
+                              "key": null,
+                              "props": {
+                                "children": "mm/dd/yyyy hh:mm:ss",
+                                "color": "muted",
+                                "size": "sm",
+                              },
+                              "type": "Text",
+                            },
+                            "direction": "horizontal",
+                          },
+                          "type": "Box",
+                        },
                       ],
+                      "direction": "horizontal",
+                    },
+                    "type": "Box",
+                  },
+                  {
+                    "key": null,
+                    "props": {
+                      "alignment": "space-between",
+                      "children": {
+                        "key": null,
+                        "props": {
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_date",
+                                "placeholder": "mm/dd/yyyy",
+                                "type": "text",
+                                "value": "05/01/2024",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "name": "native-token-stream-expiry_time",
+                                "placeholder": "HH:MM:SS",
+                                "type": "text",
+                                "value": "00:00:00",
+                              },
+                              "type": "Input",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "center",
+                                "children": {
+                                  "key": null,
+                                  "props": {
+                                    "alignment": "center",
+                                    "children": "UTC",
+                                  },
+                                  "type": "Text",
+                                },
+                                "direction": "vertical",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
                       "direction": "horizontal",
                     },
                     "type": "Box",
@@ -3558,20 +3873,13 @@ describe('nativeTokenStream:content', () => {
                     "props": {
                       "children": [
                         null,
-                        {
-                          "key": null,
-                          "props": {
-                            "children": "undefined undefined UTC",
-                          },
-                          "type": "Text",
-                        },
+                        null,
                       ],
-                      "direction": "horizontal",
                     },
                     "type": "Box",
                   },
                 ],
-                "direction": "horizontal",
+                "direction": "vertical",
               },
               "type": "Box",
             },


### PR DESCRIPTION

## **Description**

`expiry` and `startTime` are expected to be unix timestamp in seconds. Because of that we are switching their types from `string` to `number`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.