### PR TITLE
Resolve path-to-regexp vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
       "@lavamoat/preinstall-always-fail": false,
       "sharp": true
     }
+  },
+  "resolutions": {
+    "gatsby/path-to-regexp": "0.1.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16547,13 +16547,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.10":
-  version: 0.1.10
-  resolution: "path-to-regexp@npm:0.1.10"
-  checksum: ab7a3b7a0b914476d44030340b0a65d69851af2a0f33427df1476100ccb87d409c39e2182837a96b98fb38c4ef2ba6b87bdad62bb70a2c153876b8061760583c
-  languageName: node
-  linkType: hard
-
 "path-to-regexp@npm:0.1.12":
   version: 0.1.12
   resolution: "path-to-regexp@npm:0.1.12"


### PR DESCRIPTION
## **Description**

https://github.com/MetaMask/snap-7715-permissions/security/dependabot/21 describes a vulnerability impacting path-to-regexp < 0.1.12.

This change uses selective resolutions to specify path-to-regexp@0.1.12 for transitive dependency via gatsby.

## **Related issues**

Fixes: https://github.com/MetaMask/snap-7715-permissions/security/dependabot/21

When gatsby is updated to depend on path-to-regexp >= 0.1.12, we will need to remember to remove this resolution.