### PR TITLE
fix(gator-permissions-snap): fix return type for account addresses

### DIFF
--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "tY03cqLVieaPqJQu1vDTjsSXIO3OcDSnuEbckENtG1E=",
+    "shasum": "90vtziwpCk98xWhVDndfokRhlvV6as9rwHt/DpvqDEo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "90vtziwpCk98xWhVDndfokRhlvV6as9rwHt/DpvqDEo=",
+    "shasum": "tY03cqLVieaPqJQu1vDTjsSXIO3OcDSnuEbckENtG1E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/core/accountController.ts
+++ b/packages/gator-permissions-snap/src/core/accountController.ts
@@ -82,7 +82,7 @@ export class AccountController implements AccountControllerInterface {
    * Retrieves the account addresses available for this current account.
    * @returns The account addresses in CAIP-10 format.
    */
-  public async getAccountAddresses(): Promise<Hex[]> {
+  public async getAccountAddresses(): Promise<[Hex, ...Hex[]]> {
     logger.debug('AccountController:getAccountAddresses()');
 
     const accounts = await this.#ethereumProvider.request<Hex[]>({
@@ -97,7 +97,7 @@ export class AccountController implements AccountControllerInterface {
       throw new Error('No accounts found');
     }
 
-    return accounts as Hex[];
+    return accounts as [Hex, ...Hex[]];
   }
 
   /**

--- a/packages/gator-permissions-snap/src/core/accountController.ts
+++ b/packages/gator-permissions-snap/src/core/accountController.ts
@@ -4,15 +4,12 @@ import type { SnapsEthereumProvider, SnapsProvider } from '@metamask/snaps-sdk';
 import { bigIntToHex, hexToNumber, numberToHex } from '@metamask/utils';
 
 import { getChainMetadata } from './chainMetadata';
-import type {
-  AccountControllerInterface,
-  SignDelegationOptions,
-} from './types';
+import type { SignDelegationOptions } from './types';
 
 /**
  * Controls EOA account operations including address retrieval, delegation signing, and balance queries.
  */
-export class AccountController implements AccountControllerInterface {
+export class AccountController {
   #ethereumProvider: SnapsEthereumProvider;
 
   protected supportedChains: readonly number[];

--- a/packages/gator-permissions-snap/src/core/permissionHandler.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandler.ts
@@ -12,6 +12,7 @@ import { getIconData } from '../permissions/iconUtil';
 import type { TokenMetadataService } from '../services/tokenMetadataService';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { UserEventDispatcher } from '../userEventDispatcher';
+import type { AccountController } from './accountController';
 import { getChainMetadata } from './chainMetadata';
 import {
   ACCOUNT_SELECTOR_NAME,
@@ -29,7 +30,6 @@ import type {
   PermissionHandlerType,
   PermissionHandlerDependencies,
   PermissionHandlerParams,
-  AccountControllerInterface,
 } from './types';
 import { logger } from '../../../shared/src/utils/logger';
 import { ZERO_ADDRESS } from '../constants';
@@ -49,7 +49,7 @@ export class PermissionHandler<
   TPopulatedPermission extends DeepRequired<TPermission>,
 > implements PermissionHandlerType
 {
-  readonly #accountController: AccountControllerInterface;
+  readonly #accountController: AccountController;
 
   readonly #userEventDispatcher: UserEventDispatcher;
 
@@ -153,7 +153,7 @@ export class PermissionHandler<
       const allAvailableAddresses =
         await this.#accountController.getAccountAddresses();
 
-      let address: Hex | undefined;
+      let address: Hex;
 
       if (requestedAddressLowercase) {
         // validate that the requested address is one of the addresses available for the account

--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -1,6 +1,7 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { extractPermissionName } from '@metamask/7715-permissions-shared/utils';
 
+import type { AccountController } from './accountController';
 import { erc20TokenPeriodicPermissionDefinition } from '../permissions/erc20TokenPeriodic';
 import { erc20TokenStreamPermissionDefinition } from '../permissions/erc20TokenStream';
 import { nativeTokenPeriodicPermissionDefinition } from '../permissions/nativeTokenPeriodic';
@@ -11,7 +12,6 @@ import type { UserEventDispatcher } from '../userEventDispatcher';
 import { PermissionHandler } from './permissionHandler';
 import type { PermissionRequestLifecycleOrchestrator } from './permissionRequestLifecycleOrchestrator';
 import type {
-  AccountControllerInterface,
   BaseContext,
   DeepRequired,
   PermissionDefinition,
@@ -23,7 +23,7 @@ import type {
  * Each permission type has its own orchestrator that handles the specific logic for that permission.
  */
 export class PermissionHandlerFactory {
-  readonly #accountController: AccountControllerInterface;
+  readonly #accountController: AccountController;
 
   readonly #tokenPricesService: TokenPricesService;
 
@@ -40,7 +40,7 @@ export class PermissionHandlerFactory {
     userEventDispatcher,
     orchestrator,
   }: {
-    accountController: AccountControllerInterface;
+    accountController: AccountController;
     tokenPricesService: TokenPricesService;
     tokenMetadataService: TokenMetadataService;
     userEventDispatcher: UserEventDispatcher;

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -19,10 +19,10 @@ import {
 import type { NonceCaveatService } from 'src/services/nonceCaveatService';
 
 import type { UserEventDispatcher } from '../userEventDispatcher';
+import type { AccountController } from './accountController';
 import { getChainMetadata } from './chainMetadata';
 import type { ConfirmationDialogFactory } from './confirmationFactory';
 import type {
-  AccountControllerInterface,
   BaseContext,
   BaseMetadata,
   DeepRequired,
@@ -35,7 +35,7 @@ import type {
  * Orchestrates the lifecycle of permission requests, confirmation dialogs, and delegation creation.
  */
 export class PermissionRequestLifecycleOrchestrator {
-  readonly #accountController: AccountControllerInterface;
+  readonly #accountController: AccountController;
 
   readonly #confirmationDialogFactory: ConfirmationDialogFactory;
 
@@ -49,7 +49,7 @@ export class PermissionRequestLifecycleOrchestrator {
     userEventDispatcher,
     nonceCaveatService,
   }: {
-    accountController: AccountControllerInterface;
+    accountController: AccountController;
     confirmationDialogFactory: ConfirmationDialogFactory;
     userEventDispatcher: UserEventDispatcher;
     nonceCaveatService: NonceCaveatService;

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -13,6 +13,7 @@ import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 
 import type { TokenMetadataService } from '../services/tokenMetadataService';
 import type { UserEventDispatcher } from '../userEventDispatcher';
+import type { AccountController } from './accountController';
 import type { DelegationContracts } from './chainMetadata';
 import type { PermissionRequestLifecycleOrchestrator } from './permissionRequestLifecycleOrchestrator';
 import type { TokenPricesService } from '../services/tokenPricesService';
@@ -273,7 +274,7 @@ export type PermissionHandlerParams<
   TPermission extends TRequest['permission'],
   TPopulatedPermission extends DeepRequired<TPermission>,
 > = {
-  accountController: AccountControllerInterface;
+  accountController: AccountController;
   userEventDispatcher: UserEventDispatcher;
   orchestrator: PermissionRequestLifecycleOrchestrator;
   permissionRequest: PermissionRequest;
@@ -343,19 +344,4 @@ export type SignDelegationOptions = {
 export type FactoryArgs = {
   factory: Hex | undefined;
   factoryData: Hex | undefined;
-};
-
-/**
- * Interface for account controller implementations.
- */
-export type AccountControllerInterface = {
-  /**
-   * Signs a delegation using the smart account.
-   */
-  signDelegation(options: SignDelegationOptions): Promise<Delegation>;
-
-  /**
-   * Retrieves the account addresses available for this current account.
-   */
-  getAccountAddresses(): Promise<Hex[]>;
 };

--- a/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
@@ -3,10 +3,10 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { UserInputEventType } from '@metamask/snaps-sdk';
 import type { TokenBalanceAndMetadata } from 'src/clients/types';
 
+import type { AccountController } from '../../src/core/accountController';
 import { PermissionHandler } from '../../src/core/permissionHandler';
 import type { PermissionRequestLifecycleOrchestrator } from '../../src/core/permissionRequestLifecycleOrchestrator';
 import type {
-  AccountControllerInterface,
   BaseContext,
   DeepRequired,
   LifecycleOrchestrationHandlers,
@@ -56,6 +56,7 @@ const mockPermissionRequest: PermissionRequest = {
       startTime: 1234567890,
       justification: 'test',
     },
+    isAdjustmentAllowed: false,
   },
 };
 
@@ -134,7 +135,7 @@ const setupTest = () => {
   const accountController = {
     signDelegation: jest.fn(),
     getAccountAddresses: jest.fn(),
-  } as unknown as jest.Mocked<AccountControllerInterface>;
+  } as unknown as jest.Mocked<AccountController>;
 
   userEventDispatcher = {
     on: jest.fn(bindEvent),

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "3PALS/KgcPwwnrUweCi4M45cukomk8SLbACDbQuli5M=",
+    "shasum": "kv9aSU1HpGqXgCJoesdx70RBTtKEMzqvj/HvLwkqhcs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "kv9aSU1HpGqXgCJoesdx70RBTtKEMzqvj/HvLwkqhcs=",
+    "shasum": "3PALS/KgcPwwnrUweCi4M45cukomk8SLbACDbQuli5M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `getAccountAddresses` method’s return type has been updated from `Promise<Hex[]>` to `Promise<[Hex, ...Hex[]]>`.  
This change ensures that the returned value always includes at least one `Hex` address, improving type safety and better reflecting the method’s actual behavior.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.