### PR TITLE
feat(ui): add TokenBalanceField component for displaying token balances

### DIFF
--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "90vtziwpCk98xWhVDndfokRhlvV6as9rwHt/DpvqDEo=",
+    "shasum": "Fpkdkj5J+y47zzuO+WD0T+AHuagsGFhnJhKPXcXy8pY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "H2ef1K+7qxv8PJbX/6No5BkiJTa+Ww2dhiB3hhLL5z4=",
+    "shasum": "o8PDKoNn4OGC2/HtjKZmmr61R+i3xGaVOHoyHM91xuw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "ggdsvzO3/UXNneyoWFjsed1gBArLr3Twxzeh/5jsoiw=",
+    "shasum": "2vOYwTM30DDpYzGG2NRfWFDCJ+jxKa36N5T9C1BnyWk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "o8PDKoNn4OGC2/HtjKZmmr61R+i3xGaVOHoyHM91xuw=",
+    "shasum": "CkAT14KmlPc9Xgu8Ac51jQ2EnLzj05XOxXcK+fu3C0A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "7AGsCG0C/LTZiUJp0g+Og77YDa1YQ3VI+qYfSLG2hNc=",
+    "shasum": "H2ef1K+7qxv8PJbX/6No5BkiJTa+Ww2dhiB3hhLL5z4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "Fpkdkj5J+y47zzuO+WD0T+AHuagsGFhnJhKPXcXy8pY=",
+    "shasum": "YtKCcRmZ7vrYFgFlyhgz3oQbDd1MNZlzu7tn4kL1BLg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "CkAT14KmlPc9Xgu8Ac51jQ2EnLzj05XOxXcK+fu3C0A=",
+    "shasum": "ggdsvzO3/UXNneyoWFjsed1gBArLr3Twxzeh/5jsoiw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
@@ -17,6 +17,7 @@ import {
   TextField,
   TooltipIcon,
   TokenField,
+  TokenBalanceField,
 } from '../ui/components';
 
 export const ACCOUNT_SELECTOR_NAME = 'account-selector';
@@ -81,11 +82,7 @@ export const PermissionHandlerContent = ({
   chainId,
   explorerUrl,
 }: PermissionHandlerContentProps): SnapElement => {
-  const tokenBalanceComponent = tokenBalance ? (
-    <Text>{tokenBalance} available</Text>
-  ) : (
-    <Skeleton />
-  );
+  const tokenBalanceComponent = TokenBalanceField({ tokenBalance });
 
   const fiatBalanceComponent = tokenBalanceFiat ? (
     <Text>{tokenBalanceFiat}</Text>

--- a/packages/gator-permissions-snap/src/ui/components/TokenBalanceField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenBalanceField.tsx
@@ -16,7 +16,7 @@ export const TokenBalanceField = ({ tokenBalance }: TokenBalanceFieldProps) => {
   if (!tokenBalance) {
     return <Skeleton />;
   }
-  const truncatedTokenBalance = truncateDecimalPlaces(tokenBalance);
+  const truncatedTokenBalance = truncateDecimalPlaces(tokenBalance, 5);
   if (truncatedTokenBalance === tokenBalance) {
     return <Text>{truncatedTokenBalance} available</Text>;
   }

--- a/packages/gator-permissions-snap/src/ui/components/TokenBalanceField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenBalanceField.tsx
@@ -16,7 +16,7 @@ export const TokenBalanceField = ({ tokenBalance }: TokenBalanceFieldProps) => {
   if (!tokenBalance) {
     return <Skeleton />;
   }
-  const truncatedTokenBalance = truncateDecimalPlaces(tokenBalance ?? '');
+  const truncatedTokenBalance = truncateDecimalPlaces(tokenBalance);
   if (truncatedTokenBalance === tokenBalance) {
     return <Text>{truncatedTokenBalance} available</Text>;
   }

--- a/packages/gator-permissions-snap/src/ui/components/TokenBalanceField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenBalanceField.tsx
@@ -1,0 +1,28 @@
+import { Skeleton, Text, Tooltip } from '@metamask/snaps-sdk/jsx';
+
+import { truncateDecimalPlaces } from '../../utils/string';
+
+type TokenBalanceFieldProps = {
+  tokenBalance: string | undefined;
+};
+
+/**
+ * A component that displays the token balance.
+ * @param props - The component props.
+ * @param props.tokenBalance - The token balance to display.
+ * @returns A JSX element containing the token balance or a skeleton if not available.
+ */
+export const TokenBalanceField = ({ tokenBalance }: TokenBalanceFieldProps) => {
+  if (!tokenBalance) {
+    return <Skeleton />;
+  }
+  const truncatedTokenBalance = truncateDecimalPlaces(tokenBalance ?? '');
+  if (truncatedTokenBalance === tokenBalance) {
+    return <Text>{truncatedTokenBalance} available</Text>;
+  }
+  return (
+    <Tooltip content={<Text>{tokenBalance}</Text>}>
+      <Text>{truncatedTokenBalance} available</Text>
+    </Tooltip>
+  );
+};

--- a/packages/gator-permissions-snap/src/ui/components/TokenBalanceField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenBalanceField.tsx
@@ -16,7 +16,7 @@ export const TokenBalanceField = ({ tokenBalance }: TokenBalanceFieldProps) => {
   if (!tokenBalance) {
     return <Skeleton />;
   }
-  const truncatedTokenBalance = truncateDecimalPlaces(tokenBalance, 5);
+  const truncatedTokenBalance = truncateDecimalPlaces(tokenBalance);
   if (truncatedTokenBalance === tokenBalance) {
     return <Text>{truncatedTokenBalance} available</Text>;
   }

--- a/packages/gator-permissions-snap/src/ui/components/index.ts
+++ b/packages/gator-permissions-snap/src/ui/components/index.ts
@@ -7,3 +7,4 @@ export { TextField } from './TextField';
 export { TokenIcon } from './TokenIcon';
 export { TooltipIcon } from './TooltipIcon';
 export { TokenField } from './TokenField';
+export { TokenBalanceField } from './TokenBalanceField';

--- a/packages/gator-permissions-snap/src/utils/string.ts
+++ b/packages/gator-permissions-snap/src/utils/string.ts
@@ -58,3 +58,32 @@ export function shortenAddress(address = '') {
     skipCharacterInEnd: false,
   });
 }
+
+/**
+ * Truncates the decimal part of a numeric string to a specified number of digits.
+ * If the input is not a valid number, returns the original value.
+ *
+ * @param value - The numeric string to truncate (e.g., "123.456789").
+ * @param decimalPlaces - The maximum number of decimal places to keep. Defaults to 8.
+ * @returns The truncated numeric string, or the original value if not a valid number.
+ *
+ * @example
+ * truncateDecimalPlaces("123.456789123", 4); // "123.4567"
+ * truncateDecimalPlaces("100", 4); // "100"
+ * truncateDecimalPlaces("abc", 4); // "abc"
+ */
+export function truncateDecimalPlaces(
+  value: string,
+  decimalPlaces = 8,
+): string {
+  const trimmedValue = value.trim();
+  // Only allow optional minus, digits, optional decimal and digits
+  if (!/^[-+]?\d+(\.\d+)?$/u.test(trimmedValue)) {
+    return value;
+  }
+  const [whole = '', decimals = ''] = trimmedValue.split('.');
+  if (!decimals) {
+    return whole;
+  }
+  return `${whole}.${decimals.slice(0, decimalPlaces)}`;
+}

--- a/packages/gator-permissions-snap/src/utils/string.ts
+++ b/packages/gator-permissions-snap/src/utils/string.ts
@@ -60,35 +60,32 @@ export function shortenAddress(address = '') {
 }
 
 /**
- * Truncates the decimal places of a numeric string to a specified number of digits.
+ * Truncates the decimal part of a numeric string to a specified number of digits.
+ * If the input is not a valid number, returns the original value.
  *
- * Converts the input string to a number, handling scientific notation, and returns
- * a string representation with at most `decimalPlaces` digits after the decimal point.
- * If the input is not a valid number, an error is thrown.
- *
- * @param value - The numeric string to truncate.
- * @param decimalPlaces - The maximum number of decimal places to retain (default: 8).
+ * @param value - The numeric string to truncate (e.g., "123.456789").
+ * @param decimalPlaces - The maximum number of decimal places to keep. Defaults to 8.
  * @returns The truncated numeric string.
  * @throws {Error} If the input value is not a valid number.
+ *
+ * @example
+ * truncateDecimalPlaces("123.456789123", 4); // "123.4567"
+ * truncateDecimalPlaces("100", 4); // "100"
+ * truncateDecimalPlaces("abc", 4); // "abc"
  */
 export function truncateDecimalPlaces(
   value: string,
   decimalPlaces = 8,
 ): string {
   const trimmedValue = value.trim();
-  const numValue = Number(trimmedValue);
-
-  if (isNaN(numValue)) {
+  // Only allow optional minus, digits, optional decimal and digits
+  if (!/^[-+]?\d+(\.\d+)?$/u.test(trimmedValue)) {
     throw new Error(`Invalid number: ${value}`);
   }
 
-  // Convert to fixed notation if in scientific notation
-  const stringValue = numValue.toFixed(20); // Use high precision
-  const [whole = '', decimals = ''] = stringValue.split('.');
-
-  if (!decimals || decimals.length <= decimalPlaces) {
-    return trimmedValue; // Return original if no truncation needed
+  const [whole = '', decimals = ''] = trimmedValue.split('.');
+  if (!decimals) {
+    return whole;
   }
-
   return `${whole}.${decimals.slice(0, decimalPlaces)}`;
 }

--- a/packages/gator-permissions-snap/src/utils/string.ts
+++ b/packages/gator-permissions-snap/src/utils/string.ts
@@ -63,8 +63,8 @@ export function shortenAddress(address = '') {
  * Truncates the decimal part of a numeric string to a specified number of digits.
  * If the input is not a valid number, returns the original value.
  *
- * @param value - The numeric string to truncate (e.g., "123.456789").
- * @param decimalPlaces - The maximum number of decimal places to keep. Defaults to 8.
+ * @param value - The numeric string to truncate (e.g., "123.45678").
+ * @param decimalPlaces - The maximum number of decimal places to keep. Defaults to 5.
  * @returns The truncated numeric string.
  * @throws {Error} If the input value is not a valid number.
  *
@@ -75,7 +75,7 @@ export function shortenAddress(address = '') {
  */
 export function truncateDecimalPlaces(
   value: string,
-  decimalPlaces = 8,
+  decimalPlaces = 5,
 ): string {
   const trimmedValue = value.trim();
   // Only allow optional minus, digits, optional decimal and digits

--- a/packages/gator-permissions-snap/test/utils/string.test.ts
+++ b/packages/gator-permissions-snap/test/utils/string.test.ts
@@ -27,7 +27,7 @@ describe('truncateDecimalPlaces', () => {
   });
 
   it('handles positive sign', () => {
-    expect(truncateDecimalPlaces('+123.456789', 2)).toBe('123.45');
+    expect(truncateDecimalPlaces('+123.456789', 2)).toBe('+123.45');
   });
 
   it('throws error for invalid input', () => {
@@ -39,8 +39,10 @@ describe('truncateDecimalPlaces', () => {
   });
 
   it('handles scientific notation', () => {
-    expect(truncateDecimalPlaces('1e-8')).toBe('0.00000001');
-    expect(truncateDecimalPlaces('1.23e2')).toBe('123.00000000');
+    expect(() => truncateDecimalPlaces('1e-8')).toThrow('Invalid number: 1e-8');
+    expect(() => truncateDecimalPlaces('1.23e2')).toThrow(
+      'Invalid number: 1.23e2',
+    );
   });
 
   it('throws error for more than one dot', () => {

--- a/packages/gator-permissions-snap/test/utils/string.test.ts
+++ b/packages/gator-permissions-snap/test/utils/string.test.ts
@@ -1,8 +1,8 @@
 import { truncateDecimalPlaces } from '../../src/utils/string';
 
 describe('truncateDecimalPlaces', () => {
-  it('truncates decimals to default 8 places', () => {
-    expect(truncateDecimalPlaces('123.456789123')).toBe('123.45678912');
+  it('truncates decimals to default 5 places', () => {
+    expect(truncateDecimalPlaces('123.456789123')).toBe('123.45678');
   });
 
   it('truncates decimals to specified places', () => {

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "3PALS/KgcPwwnrUweCi4M45cukomk8SLbACDbQuli5M=",
+    "shasum": "kv9aSU1HpGqXgCJoesdx70RBTtKEMzqvj/HvLwkqhcs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "kv9aSU1HpGqXgCJoesdx70RBTtKEMzqvj/HvLwkqhcs=",
+    "shasum": "3PALS/KgcPwwnrUweCi4M45cukomk8SLbACDbQuli5M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Long token balances (e.g., with many decimal places) were previously rendered **verbatim**, making them difficult to read and potentially misleading in the UI.  
This PR addresses it by introducing a **reusable `TokenBalance` component** that:
- Displays a shortened version of the token balance with a fixed decimal precision.
- Shows the full, exact balance in a tooltip on hover for accuracy.
- Centralizes the balance rendering logic to improve maintainability.

A new utility function `truncateDecimals` is also introduced for consistent decimal truncation across the app.

## **Related issues**

Fixes: #328

## **Manual testing steps**

1. Navigate to a view where token balances are rendered in `permissionHandlerContent`.
2. Confirm that:
   - Long balances are truncated for display (e.g., `0.123456789` → `0.12345678`).
   - Hovering over the balance shows the full value in a tooltip.
3. Verify that all token balances now use the `TokenBalanceField` component.
4. Check that formatting is consistent across different pages.

## **Screenshots/Recordings**

### **Before**
<!-- Add screenshot or recording showing full long balance rendered verbatim -->
<img width="622" height="934" alt="before" src="https://github.com/user-attachments/assets/f2f8f235-836c-4f4e-9be2-20dd350bc5e1" />

### **After**
<!-- Add screenshot or recording showing truncated balance with tooltip -->
<img width="1023" height="224" alt="image" src="https://github.com/user-attachments/assets/701dfc96-ac81-4845-b589-9fb3eec29f3e" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests for the new component and utility function.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format where applicable.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and/or screenshots.