### PR TITLE
Process permission requests sequentially

### DIFF
--- a/packages/gator-permissions-snap/src/rpc/rpcHandler.ts
+++ b/packages/gator-permissions-snap/src/rpc/rpcHandler.ts
@@ -61,12 +61,10 @@ export function createRpcHandler(config: {
     const responses: Json[] = [];
 
     for (const request of permissionsRequest) {
-      const handler =
-        permissionHandlerFactory.createPermissionHandler(request);
+      const handler = permissionHandlerFactory.createPermissionHandler(request);
 
-      const permissionResponse = await handler.handlePermissionRequest(
-        siteOrigin,
-      );
+      const permissionResponse =
+        await handler.handlePermissionRequest(siteOrigin);
 
       if (!permissionResponse.approved) {
         throw new InvalidInputError(permissionResponse.reason);
@@ -82,7 +80,7 @@ export function createRpcHandler(config: {
       responses.push(permissionResponse.response as Json);
     }
 
-    return responses as Json[];
+    return responses;
   };
 
   /**

--- a/packages/gator-permissions-snap/src/rpc/rpcHandler.ts
+++ b/packages/gator-permissions-snap/src/rpc/rpcHandler.ts
@@ -75,12 +75,10 @@ export function createRpcHandler(config: {
         throw new InvalidInputError(permissionResponse.reason);
       }
 
-      if (permissionResponse.response) {
-        permissionsToStore.push({
-          permissionResponse: permissionResponse.response,
-          siteOrigin,
-        });
-      }
+      permissionsToStore.push({
+        permissionResponse: permissionResponse.response,
+        siteOrigin,
+      });
     }
 
     // Only after all permissions have been successfully processed, store them all in batch

--- a/packages/permissions-kernel-snap/src/index.ts
+++ b/packages/permissions-kernel-snap/src/index.ts
@@ -1,5 +1,6 @@
 import { logger } from '@metamask/7715-permissions-shared/utils';
 import {
+  LimitExceededError,
   MethodNotFoundError,
   type Json,
   type JsonRpcParams,
@@ -27,6 +28,9 @@ const boundRpcHandlers: {
     rpcHandler.requestExecutionPermissions.bind(rpcHandler),
 };
 
+// Processing lock to ensure only one RPC request is processed at a time
+let isProcessing = false;
+
 /**
  * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
  *
@@ -41,26 +45,40 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
   origin,
   request,
 }) => {
-  logger.info(
-    `Custom request (origin="${origin}"):`,
-    JSON.stringify(request, undefined, 2),
-  );
-
-  // Use Object.prototype.hasOwnProperty.call() to prevent prototype pollution attacks
-  // This ensures we only access methods that exist on boundRpcHandlers itself
-  if (!Object.prototype.hasOwnProperty.call(boundRpcHandlers, request.method)) {
-    throw new MethodNotFoundError(`Method ${request.method} not found.`);
+  // Check if another request is already being processed
+  if (isProcessing) {
+    logger.warn(`RPC request rejected (origin="${origin}"): another request is already being processed`);
+    throw new LimitExceededError('Another request is already being processed.');
   }
 
-  // We know that the method exists, so we can cast to NonNullable
-  const handler = boundRpcHandlers[request.method] as NonNullable<
-    (typeof boundRpcHandlers)[string]
-  >;
+  // Acquire the processing lock
+  isProcessing = true;
+  
+  try {
+    logger.info(
+      `Custom request (origin="${origin}"):`,
+      JSON.stringify(request, undefined, 2),
+    );
 
-  const result = await handler({
-    siteOrigin: origin,
-    params: request.params as JsonRpcParams,
-  });
+    // Use Object.prototype.hasOwnProperty.call() to prevent prototype pollution attacks
+    // This ensures we only access methods that exist on boundRpcHandlers itself
+    if (!Object.prototype.hasOwnProperty.call(boundRpcHandlers, request.method)) {
+      throw new MethodNotFoundError(`Method ${request.method} not found.`);
+    }
 
-  return result;
+    // We know that the method exists, so we can cast to NonNullable
+    const handler = boundRpcHandlers[request.method] as NonNullable<
+      (typeof boundRpcHandlers)[string]
+    >;
+
+    const result = await handler({
+      siteOrigin: origin,
+      params: request.params as JsonRpcParams,
+    });
+
+    return result;
+  } finally {
+    // Always release the processing lock, regardless of success or failure
+    isProcessing = false;
+  }
 };

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -135,7 +135,7 @@ const Index = () => {
   const [data, setData] = useState<Hex>('0x');
   const [value, setValue] = useState<bigint>(0n);
   const [receipt, setReceipt] = useState<UserOperationReceipt | null>(null);
-  const [isWorking, setIsWorking] = useState(false);
+  const [pendingPermissionRequests, setPendingPermissionRequests] = useState<Set<string>>(new Set());
 
   const handleChainChange = ({
     target: { value: inputValue },
@@ -175,7 +175,13 @@ const Index = () => {
     if (!delegateAccount) {
       throw new Error('Delegate account not found');
     }
-    setIsWorking(true);
+    
+    // Generate a unique identifier for this redemption request
+    const requestId = `redeem-${Date.now()}-${Math.random()}`;
+    
+    // Add this request to pending requests
+    setPendingPermissionRequests(prev => new Set(prev).add(requestId));
+    
     setReceipt(null);
     setPermissionResponseError(undefined);
 
@@ -214,8 +220,14 @@ const Index = () => {
       setReceipt(operationReceipt);
     } catch (error) {
       setPermissionResponseError(error as Error);
+    } finally {
+      // Remove this request from pending requests
+      setPendingPermissionRequests(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(requestId);
+        return newSet;
+      });
     }
-    setIsWorking(false);
   };
 
   const handleGrantPermissions = async () => {
@@ -253,7 +265,12 @@ const Index = () => {
       } as const,
     ];
 
-    setIsWorking(true);
+    // Generate a unique identifier for this permission request
+    const requestId = `${type}-${Date.now()}-${Math.random()}`;
+    
+    // Add this request to pending requests
+    setPendingPermissionRequests(prev => new Set(prev).add(requestId));
+    
     setPermissionResponse(null);
     setReceipt(null);
     setPermissionResponseError(null);
@@ -265,8 +282,14 @@ const Index = () => {
     } catch (error) {
       setPermissionResponse(null);
       setPermissionResponseError(error as Error);
+    } finally {
+      // Remove this request from pending requests
+      setPendingPermissionRequests(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(requestId);
+        return newSet;
+      });
     }
-    setIsWorking(false);
   };
 
   const handleCopyToClipboard = () => {
@@ -304,7 +327,6 @@ const Index = () => {
       <Subtitle>
         Get started by installing snaps and sending permissions requests.
       </Subtitle>
-      {isWorking && <p>Loading...</p>}
       <CardContainer>
         {errors.map((error, idx) => (
           <ErrorMessage key={idx}>
@@ -372,7 +394,7 @@ const Index = () => {
             <CustomMessageButton
               $text="Redeem Permission"
               onClick={handleRedeemPermission}
-              disabled={isWorking}
+              disabled={pendingPermissionRequests.size > 0}
             />
           </Box>
         )}
@@ -459,7 +481,6 @@ const Index = () => {
             <CustomMessageButton
               $text="Grant Permission"
               onClick={handleGrantPermissions}
-              disabled={isWorking}
             />
           </Box>
         )}


### PR DESCRIPTION
## **Description**

Make sure that permission requests are processed sequentially also updated how permissions are stored ensuring storage occurs only if all permissions got processed successfully. 

## **Manual testing**

1. Open localhost:8000
2. Click grant permission
3. While permission is being processed in extension click grant permission again - it should get rejected.

## **After video**

https://github.com/user-attachments/assets/1413dd13-077a-4910-ad23-394741a7ec92

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.