### PR TITLE
chore: remove unused 'viem' dependency from package.json and related files

### DIFF
--- a/packages/gator-permissions-snap/package.json
+++ b/packages/gator-permissions-snap/package.json
@@ -53,7 +53,6 @@
     "@metamask/profile-sync-controller": "21.0.0",
     "@metamask/snaps-sdk": "8.1.0",
     "@metamask/utils": "11.4.2",
-    "viem": "2.31.7",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "LC/2zCP+93w0bFP4+jOLk4KyND/wrxlcPJZpl7oUcMw=",
+    "shasum": "Vs9lYGeC2uo7E6/p4eYFQG8i5gv0RJFqGEeuAxbV980=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -8,8 +8,8 @@ import {
 import { InvalidParamsError } from '@metamask/snaps-sdk';
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 import { bigIntToHex, bytesToHex } from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
 import type { NonceCaveatService } from 'src/services/nonceCaveatService';
-import type { Hex } from 'viem';
 
 import type { AccountController } from '../../src/core/accountController';
 import { getChainMetadata } from '../../src/core/chainMetadata';

--- a/packages/permissions-kernel-snap/package.json
+++ b/packages/permissions-kernel-snap/package.json
@@ -47,8 +47,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@metamask/snaps-sdk": "8.1.0",
-    "viem": "2.31.7"
+    "@metamask/snaps-sdk": "8.1.0"
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "9o0JEkh8Z4zpPLTu16OgskMaiVUqb4Ied6i1QL7xfqg=",
+    "shasum": "BbJKtMNO27QngXRYsexD21RKiiRxDrtS+/XoFXjBEjA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3589,7 +3589,6 @@ __metadata:
     rimraf: 6.0.1
     ts-jest: 29.4.0
     typescript: 5.8.3
-    viem: 2.31.7
     zod: 3.25.76
   languageName: unknown
   linkType: soft
@@ -3734,7 +3733,6 @@ __metadata:
     rimraf: 6.0.1
     ts-jest: 29.4.0
     typescript: 5.8.3
-    viem: 2.31.7
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes the unused `viem@2.31.7` dependency from the project.  


## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run `yarn install` confirm that `viem` is no longer present in the lockfile.
2. Build and run the project to ensure there are no runtime errors.
3. Run all tests to confirm they pass without regression.

## **Screenshots/Recordings**

### **Before**

`package.json` contained `viem@2.31.7` as a dependency.

### **After**

`viem` dependency removed from `package.json`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
