### PR TITLE
fix: TokenIcon runtime type enforcement

### DIFF
--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "ul+BnB8SWZbltFcsK47kzYs+bRNQO0+3aoBg0Grd6I0=",
+    "shasum": "Bk2dRfwbzcBvVceu+sAm2+4CdOxrDdtgLBtmlDduQn8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "LC/2zCP+93w0bFP4+jOLk4KyND/wrxlcPJZpl7oUcMw=",
+    "shasum": "ul+BnB8SWZbltFcsK47kzYs+bRNQO0+3aoBg0Grd6I0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "Bk2dRfwbzcBvVceu+sAm2+4CdOxrDdtgLBtmlDduQn8=",
+    "shasum": "FexQ6e6eEnmbH8X2W+csCg2uoUUAEOOiYQ/iVLSytxQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
@@ -15,96 +15,14 @@ export type TokenIconParams = {
 
 const MAX_ICON_SIZE = 512;
 
-// Dangerous SVG elements and attributes that could execute scripts
-const DANGEROUS_SVG_ELEMENTS = [
-  'script',
-  'foreignObject',
-  'iframe',
-  'object',
-  'embed',
-  'link',
-  'style',
-];
-
-const DANGEROUS_SVG_ATTRIBUTES = [
-  'onload',
-  'onerror',
-  'onclick',
-  'onmouseover',
-  'onmouseout',
-  'onmousedown',
-  'onmouseup',
-  'onfocus',
-  'onblur',
-  'onchange',
-  'onsubmit',
-  'onreset',
-  'onselect',
-  'onkeydown',
-  'onkeypress',
-  'onkeyup',
-  'onabort',
-  'oncanplay',
-  'oncanplaythrough',
-  'ondurationchange',
-  'onemptied',
-  'onended',
-  'onloadeddata',
-  'onloadedmetadata',
-  'onloadstart',
-  'onpause',
-  'onplay',
-  'onplaying',
-  'onprogress',
-  'onratechange',
-  'onseeked',
-  'onseeking',
-  'onstalled',
-  'onsuspend',
-  'ontimeupdate',
-  'onvolumechange',
-  'onwaiting',
-  'href',
-  'xlink:href',
-];
-
 // zod schema for runtime validation
 const TokenIconParamsSchema = z.object({
   imageDataBase64: z
     .string()
     .regex(
-      /^data:image\/(svg\+xml|png|jpeg|jpg);base64,[A-Za-z0-9+/=]+$/u,
-      'Must be a valid base64 data URI',
-    )
-    .refine((dataUri) => {
-      // Only validate SVG content for security
-      if (!dataUri.startsWith('data:image/svg+xml;base64,')) {
-        return true; // PNG/JPEG don't need content validation
-      }
-
-      try {
-        const base64Content = dataUri.replace('data:image/svg+xml;base64,', '');
-        const decodedContent = atob(base64Content);
-        const lowercaseContent = decodedContent.toLowerCase();
-
-        // Check for dangerous elements
-        for (const element of DANGEROUS_SVG_ELEMENTS) {
-          if (lowercaseContent.includes(`<${element}`)) {
-            return false;
-          }
-        }
-
-        // Check for dangerous attributes
-        for (const attribute of DANGEROUS_SVG_ATTRIBUTES) {
-          if (lowercaseContent.includes(`${attribute}=`)) {
-            return false;
-          }
-        }
-        return true;
-      } catch {
-        return false; // Invalid base64 or decoding error
-      }
-    }, 'SVG content contains dangerous elements or attributes'),
+      /^data:image\/png;base64,[A-Za-z0-9+/=]+$/u,
+      'Must be a valid PNG base64 data URI',
+    ),
   altText: z.string().default(''),
   width: z.number().int().positive().max(MAX_ICON_SIZE).default(24),
   height: z.number().int().positive().max(MAX_ICON_SIZE).default(24),

--- a/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
@@ -15,6 +15,59 @@ export type TokenIconParams = {
 
 const MAX_ICON_SIZE = 512;
 
+// Dangerous SVG elements and attributes that could execute scripts
+const DANGEROUS_SVG_ELEMENTS = [
+  'script',
+  'foreignObject',
+  'iframe',
+  'object',
+  'embed',
+  'link',
+  'style',
+];
+
+const DANGEROUS_SVG_ATTRIBUTES = [
+  'onload',
+  'onerror',
+  'onclick',
+  'onmouseover',
+  'onmouseout',
+  'onmousedown',
+  'onmouseup',
+  'onfocus',
+  'onblur',
+  'onchange',
+  'onsubmit',
+  'onreset',
+  'onselect',
+  'onkeydown',
+  'onkeypress',
+  'onkeyup',
+  'onabort',
+  'oncanplay',
+  'oncanplaythrough',
+  'ondurationchange',
+  'onemptied',
+  'onended',
+  'onloadeddata',
+  'onloadedmetadata',
+  'onloadstart',
+  'onpause',
+  'onplay',
+  'onplaying',
+  'onprogress',
+  'onratechange',
+  'onseeked',
+  'onseeking',
+  'onstalled',
+  'onsuspend',
+  'ontimeupdate',
+  'onvolumechange',
+  'onwaiting',
+  'href',
+  'xlink:href',
+];
+
 // zod schema for runtime validation
 const TokenIconParamsSchema = z.object({
   imageDataBase64: z
@@ -22,7 +75,36 @@ const TokenIconParamsSchema = z.object({
     .regex(
       /^data:image\/(svg\+xml|png|jpeg|jpg);base64,[A-Za-z0-9+/=]+$/u,
       'Must be a valid base64 data URI',
-    ),
+    )
+    .refine((dataUri) => {
+      // Only validate SVG content for security
+      if (!dataUri.startsWith('data:image/svg+xml;base64,')) {
+        return true; // PNG/JPEG don't need content validation
+      }
+
+      try {
+        const base64Content = dataUri.replace('data:image/svg+xml;base64,', '');
+        const decodedContent = atob(base64Content);
+        const lowercaseContent = decodedContent.toLowerCase();
+
+        // Check for dangerous elements
+        for (const element of DANGEROUS_SVG_ELEMENTS) {
+          if (lowercaseContent.includes(`<${element}`)) {
+            return false;
+          }
+        }
+
+        // Check for dangerous attributes
+        for (const attribute of DANGEROUS_SVG_ATTRIBUTES) {
+          if (lowercaseContent.includes(`${attribute}=`)) {
+            return false;
+          }
+        }
+        return true;
+      } catch {
+        return false; // Invalid base64 or decoding error
+      }
+    }, 'SVG content contains dangerous elements or attributes'),
   altText: z.string().default(''),
   width: z.number().int().positive().max(MAX_ICON_SIZE).default(24),
   height: z.number().int().positive().max(MAX_ICON_SIZE).default(24),

--- a/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TokenIcon.tsx
@@ -1,5 +1,10 @@
+import {
+  extractZodError,
+  logger,
+} from '@metamask/7715-permissions-shared/utils';
 import type { SnapComponent } from '@metamask/snaps-sdk/jsx';
 import { Image, Text } from '@metamask/snaps-sdk/jsx';
+import { z } from 'zod';
 
 export type TokenIconParams = {
   imageDataBase64: string | null;
@@ -8,17 +13,39 @@ export type TokenIconParams = {
   height?: number;
 };
 
-export const TokenIcon: SnapComponent<TokenIconParams> = ({
-  imageDataBase64,
-  altText,
-  width = 24,
-  height = 24,
-}) => {
-  if (!imageDataBase64) {
+const MAX_ICON_SIZE = 512;
+
+// zod schema for runtime validation
+const TokenIconParamsSchema = z.object({
+  imageDataBase64: z
+    .string()
+    .regex(
+      /^data:image\/(svg\+xml|png|jpeg|jpg);base64,[A-Za-z0-9+/=]+$/u,
+      'Must be a valid base64 data URI',
+    ),
+  altText: z.string().default(''),
+  width: z.number().int().positive().max(MAX_ICON_SIZE).default(24),
+  height: z.number().int().positive().max(MAX_ICON_SIZE).default(24),
+});
+
+export const TokenIcon: SnapComponent<TokenIconParams> = (props) => {
+  if (!props.imageDataBase64) {
     return <Text> </Text>;
   }
 
-  const imageSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  const parseResult = TokenIconParamsSchema.safeParse(props);
+
+  if (!parseResult.success) {
+    logger.warn(
+      'TokenIcon: Invalid parameters',
+      extractZodError(parseResult.error.errors),
+    );
+    return <Text> </Text>;
+  }
+
+  const { imageDataBase64, altText, width, height } = parseResult.data;
+
+  const imageSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
     <image href="${imageDataBase64}" width="${width}" height="${height}" />
   </svg>`;
 

--- a/packages/gator-permissions-snap/test/ui/components/TokenIcon.test.ts
+++ b/packages/gator-permissions-snap/test/ui/components/TokenIcon.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { TokenIcon } from '../../../src/ui/components/TokenIcon';
+
+// Mock the logger and extractZodError utilities
+jest.mock('@metamask/7715-permissions-shared/utils', () => ({
+  logger: {
+    warn: jest.fn(),
+  },
+  extractZodError: jest.fn((errors) => errors),
+}));
+
+describe('TokenIcon', () => {
+  const validBase64Image =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+  it('should return empty Text when imageDataBase64 is null', () => {
+    const result = TokenIcon({
+      imageDataBase64: null,
+      altText: 'Test Alt Text',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text when imageDataBase64 is empty string', () => {
+    const result = TokenIcon({
+      imageDataBase64: '',
+      altText: 'Test Alt Text',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should render Image with valid base64 PNG data URI', () => {
+    const result = TokenIcon({
+      imageDataBase64: validBase64Image,
+      altText: 'Test PNG',
+    });
+
+    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="${validBase64Image}" width="24" height="24" />
+  </svg>`;
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Image',
+        props: { src: expectedSvg, alt: 'Test PNG' },
+      }),
+    );
+  });
+
+  it('should render Image with valid base64 JPEG data URI', () => {
+    const jpegImage =
+      'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8A8A';
+
+    const result = TokenIcon({
+      imageDataBase64: jpegImage,
+      altText: 'Test JPEG',
+    });
+
+    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="${jpegImage}" width="24" height="24" />
+  </svg>`;
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Image',
+        props: { src: expectedSvg, alt: 'Test JPEG' },
+      }),
+    );
+  });
+
+  it('should render Image with valid base64 SVG data URI', () => {
+    const svgImage =
+      'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIHZpZXdCb3g9IjAgMCAxMCAxMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjMDA3M0U2Ii8+Cjwvc3ZnPgo=';
+
+    const result = TokenIcon({
+      imageDataBase64: svgImage,
+      altText: 'Test SVG',
+    });
+
+    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="${svgImage}" width="24" height="24" />
+  </svg>`;
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Image',
+        props: { src: expectedSvg, alt: 'Test SVG' },
+      }),
+    );
+  });
+
+  it('should use custom width and height when provided', () => {
+    const result = TokenIcon({
+      imageDataBase64: validBase64Image,
+      altText: 'Custom Size',
+      width: 48,
+      height: 32,
+    });
+
+    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="32" viewBox="0 0 48 32">
+    <image href="${validBase64Image}" width="48" height="32" />
+  </svg>`;
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Image',
+        props: { src: expectedSvg, alt: 'Custom Size' },
+      }),
+    );
+  });
+
+  it('should return empty Text for invalid data URI format', () => {
+    const result = TokenIcon({
+      imageDataBase64: 'invalid-data-uri',
+      altText: 'Invalid URI',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text for non-base64 data URI', () => {
+    const result = TokenIcon({
+      imageDataBase64: 'data:image/png;base64,not-valid-base64!@#',
+      altText: 'Invalid Base64',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text for unsupported image type', () => {
+    const result = TokenIcon({
+      imageDataBase64:
+        'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+      altText: 'Unsupported GIF',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text when width exceeds maximum', () => {
+    const result = TokenIcon({
+      imageDataBase64: validBase64Image,
+      altText: 'Too Wide',
+      width: 600,
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text when height exceeds maximum', () => {
+    const result = TokenIcon({
+      imageDataBase64: validBase64Image,
+      altText: 'Too Tall',
+      height: 600,
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text for zero or negative width', () => {
+    const result = TokenIcon({
+      imageDataBase64: validBase64Image,
+      altText: 'Zero Width',
+      width: 0,
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text for zero or negative height', () => {
+    const result = TokenIcon({
+      imageDataBase64: validBase64Image,
+      altText: 'Zero Height',
+      height: -1,
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text for non-integer width', () => {
+    const result = TokenIcon({
+      imageDataBase64: validBase64Image,
+      altText: 'Float Width',
+      width: 24.5,
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should use default altText when empty string provided', () => {
+    const result = TokenIcon({
+      imageDataBase64: validBase64Image,
+      altText: '',
+    });
+
+    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="${validBase64Image}" width="24" height="24" />
+  </svg>`;
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Image',
+        props: { src: expectedSvg, alt: '' },
+      }),
+    );
+  });
+
+  it('should reject malicious SVG content with XSS protection', () => {
+    const maliciousSvgContent =
+      '<svg onload="alert(\'XSS\')" xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+    const maliciousInput = `data:image/svg+xml;base64,${btoa(
+      maliciousSvgContent,
+    )}`;
+
+    const result = TokenIcon({
+      imageDataBase64: maliciousInput,
+      altText: 'XSS Test',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text for non-data URI schemes', () => {
+    const maliciousInput = 'http://example.com/malicious.svg';
+
+    const result = TokenIcon({
+      imageDataBase64: maliciousInput,
+      altText: 'Non-data URI Test',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should return empty Text for data URI with script content', () => {
+    const maliciousInput = 'data:text/html,<script>alert("XSS")</script>';
+
+    const result = TokenIcon({
+      imageDataBase64: maliciousInput,
+      altText: 'Script Content Test',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should reject SVG with script element', () => {
+    const maliciousSvgContent =
+      '<svg xmlns="http://www.w3.org/2000/svg"><script>alert("XSS")</script><rect width="10" height="10"/></svg>';
+    const maliciousInput = `data:image/svg+xml;base64,${btoa(
+      maliciousSvgContent,
+    )}`;
+
+    const result = TokenIcon({
+      imageDataBase64: maliciousInput,
+      altText: 'Script Element Test',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should reject SVG with foreignObject element', () => {
+    const maliciousSvgContent =
+      '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><script>alert("XSS")</script></foreignObject><rect width="10" height="10"/></svg>';
+    const maliciousInput = `data:image/svg+xml;base64,${btoa(
+      maliciousSvgContent,
+    )}`;
+
+    const result = TokenIcon({
+      imageDataBase64: maliciousInput,
+      altText: 'ForeignObject Test',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should reject SVG with onclick attribute', () => {
+    const maliciousSvgContent =
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect onclick="alert(\'XSS\')" width="10" height="10"/></svg>';
+    const maliciousInput = `data:image/svg+xml;base64,${btoa(
+      maliciousSvgContent,
+    )}`;
+
+    const result = TokenIcon({
+      imageDataBase64: maliciousInput,
+      altText: 'OnClick Test',
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Text',
+        props: { children: ' ' },
+      }),
+    );
+  });
+
+  it('should accept safe SVG content', () => {
+    const safeSvgContent =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect x="0" y="0" width="10" height="10" fill="blue"/></svg>';
+    const safeInput = `data:image/svg+xml;base64,${btoa(safeSvgContent)}`;
+
+    const result = TokenIcon({
+      imageDataBase64: safeInput,
+      altText: 'Safe SVG',
+    });
+
+    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <image href="${safeInput}" width="24" height="24" />
+  </svg>`;
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        type: 'Image',
+        props: { src: expectedSvg, alt: 'Safe SVG' },
+      }),
+    );
+  });
+});

--- a/packages/gator-permissions-snap/test/ui/components/TokenIcon.test.ts
+++ b/packages/gator-permissions-snap/test/ui/components/TokenIcon.test.ts
@@ -28,20 +28,6 @@ describe('TokenIcon', () => {
     );
   });
 
-  it('should return empty Text when imageDataBase64 is empty string', () => {
-    const result = TokenIcon({
-      imageDataBase64: '',
-      altText: 'Test Alt Text',
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
   it('should render Image with valid base64 PNG data URI', () => {
     const result = TokenIcon({
       imageDataBase64: validBase64Image,
@@ -60,58 +46,16 @@ describe('TokenIcon', () => {
     );
   });
 
-  it('should render Image with valid base64 JPEG data URI', () => {
-    const jpegImage =
-      'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8A8A';
-
-    const result = TokenIcon({
-      imageDataBase64: jpegImage,
-      altText: 'Test JPEG',
-    });
-
-    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="${jpegImage}" width="24" height="24" />
-  </svg>`;
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Image',
-        props: { src: expectedSvg, alt: 'Test JPEG' },
-      }),
-    );
-  });
-
-  it('should render Image with valid base64 SVG data URI', () => {
-    const svgImage =
-      'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIHZpZXdCb3g9IjAgMCAxMCAxMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjMDA3M0U2Ii8+Cjwvc3ZnPgo=';
-
-    const result = TokenIcon({
-      imageDataBase64: svgImage,
-      altText: 'Test SVG',
-    });
-
-    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="${svgImage}" width="24" height="24" />
-  </svg>`;
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Image',
-        props: { src: expectedSvg, alt: 'Test SVG' },
-      }),
-    );
-  });
-
   it('should use custom width and height when provided', () => {
     const result = TokenIcon({
       imageDataBase64: validBase64Image,
       altText: 'Custom Size',
       width: 48,
-      height: 32,
+      height: 48,
     });
 
-    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="32" viewBox="0 0 48 32">
-    <image href="${validBase64Image}" width="48" height="32" />
+    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+    <image href="${validBase64Image}" width="48" height="48" />
   </svg>`;
 
     expect(result).toStrictEqual(
@@ -125,7 +69,7 @@ describe('TokenIcon', () => {
   it('should return empty Text for invalid data URI format', () => {
     const result = TokenIcon({
       imageDataBase64: 'invalid-data-uri',
-      altText: 'Invalid URI',
+      altText: 'Invalid',
     });
 
     expect(result).toStrictEqual(
@@ -136,10 +80,13 @@ describe('TokenIcon', () => {
     );
   });
 
-  it('should return empty Text for non-base64 data URI', () => {
+  it('should return empty Text for non-PNG image types', () => {
+    const jpegImage =
+      'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8A8A';
+
     const result = TokenIcon({
-      imageDataBase64: 'data:image/png;base64,not-valid-base64!@#',
-      altText: 'Invalid Base64',
+      imageDataBase64: jpegImage,
+      altText: 'JPEG',
     });
 
     expect(result).toStrictEqual(
@@ -150,244 +97,18 @@ describe('TokenIcon', () => {
     );
   });
 
-  it('should return empty Text for unsupported image type', () => {
-    const result = TokenIcon({
-      imageDataBase64:
-        'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
-      altText: 'Unsupported GIF',
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should return empty Text when width exceeds maximum', () => {
+  it('should return empty Text when dimensions exceed maximum', () => {
     const result = TokenIcon({
       imageDataBase64: validBase64Image,
-      altText: 'Too Wide',
-      width: 600,
+      altText: 'Too Large',
+      width: 1000,
+      height: 1000,
     });
 
     expect(result).toStrictEqual(
       expect.objectContaining({
         type: 'Text',
         props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should return empty Text when height exceeds maximum', () => {
-    const result = TokenIcon({
-      imageDataBase64: validBase64Image,
-      altText: 'Too Tall',
-      height: 600,
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should return empty Text for zero or negative width', () => {
-    const result = TokenIcon({
-      imageDataBase64: validBase64Image,
-      altText: 'Zero Width',
-      width: 0,
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should return empty Text for zero or negative height', () => {
-    const result = TokenIcon({
-      imageDataBase64: validBase64Image,
-      altText: 'Zero Height',
-      height: -1,
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should return empty Text for non-integer width', () => {
-    const result = TokenIcon({
-      imageDataBase64: validBase64Image,
-      altText: 'Float Width',
-      width: 24.5,
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should use default altText when empty string provided', () => {
-    const result = TokenIcon({
-      imageDataBase64: validBase64Image,
-      altText: '',
-    });
-
-    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="${validBase64Image}" width="24" height="24" />
-  </svg>`;
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Image',
-        props: { src: expectedSvg, alt: '' },
-      }),
-    );
-  });
-
-  it('should reject malicious SVG content with XSS protection', () => {
-    const maliciousSvgContent =
-      '<svg onload="alert(\'XSS\')" xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
-    const maliciousInput = `data:image/svg+xml;base64,${btoa(
-      maliciousSvgContent,
-    )}`;
-
-    const result = TokenIcon({
-      imageDataBase64: maliciousInput,
-      altText: 'XSS Test',
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should return empty Text for non-data URI schemes', () => {
-    const maliciousInput = 'http://example.com/malicious.svg';
-
-    const result = TokenIcon({
-      imageDataBase64: maliciousInput,
-      altText: 'Non-data URI Test',
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should return empty Text for data URI with script content', () => {
-    const maliciousInput = 'data:text/html,<script>alert("XSS")</script>';
-
-    const result = TokenIcon({
-      imageDataBase64: maliciousInput,
-      altText: 'Script Content Test',
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should reject SVG with script element', () => {
-    const maliciousSvgContent =
-      '<svg xmlns="http://www.w3.org/2000/svg"><script>alert("XSS")</script><rect width="10" height="10"/></svg>';
-    const maliciousInput = `data:image/svg+xml;base64,${btoa(
-      maliciousSvgContent,
-    )}`;
-
-    const result = TokenIcon({
-      imageDataBase64: maliciousInput,
-      altText: 'Script Element Test',
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should reject SVG with foreignObject element', () => {
-    const maliciousSvgContent =
-      '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><script>alert("XSS")</script></foreignObject><rect width="10" height="10"/></svg>';
-    const maliciousInput = `data:image/svg+xml;base64,${btoa(
-      maliciousSvgContent,
-    )}`;
-
-    const result = TokenIcon({
-      imageDataBase64: maliciousInput,
-      altText: 'ForeignObject Test',
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should reject SVG with onclick attribute', () => {
-    const maliciousSvgContent =
-      '<svg xmlns="http://www.w3.org/2000/svg"><rect onclick="alert(\'XSS\')" width="10" height="10"/></svg>';
-    const maliciousInput = `data:image/svg+xml;base64,${btoa(
-      maliciousSvgContent,
-    )}`;
-
-    const result = TokenIcon({
-      imageDataBase64: maliciousInput,
-      altText: 'OnClick Test',
-    });
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Text',
-        props: { children: ' ' },
-      }),
-    );
-  });
-
-  it('should accept safe SVG content', () => {
-    const safeSvgContent =
-      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect x="0" y="0" width="10" height="10" fill="blue"/></svg>';
-    const safeInput = `data:image/svg+xml;base64,${btoa(safeSvgContent)}`;
-
-    const result = TokenIcon({
-      imageDataBase64: safeInput,
-      altText: 'Safe SVG',
-    });
-
-    const expectedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <image href="${safeInput}" width="24" height="24" />
-  </svg>`;
-
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        type: 'Image',
-        props: { src: expectedSvg, alt: 'Safe SVG' },
       }),
     );
   });

--- a/packages/permissions-kernel-snap/snap.manifest.json
+++ b/packages/permissions-kernel-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "9o0JEkh8Z4zpPLTu16OgskMaiVUqb4Ied6i1QL7xfqg=",
+    "shasum": "BbJKtMNO27QngXRYsexD21RKiiRxDrtS+/XoFXjBEjA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `TokenIcon` component previously generated its SVG markup using raw string concatenation, without enforcing runtime type validation on its inputs.
This approach posed potential risks:

* `imageDataBase64` was assumed to always be a valid base64 data URI, but was never validated.
* Any image type (e.g., SVG, JPEG) could be passed in, which introduced unnecessary complexity and risk.
* `width` and `height` defaulted to `24`, but invalid values could still be passed in without checks.
* Concatenated strings introduced unnecessary HTML injection surface.

This PR introduces runtime validation using **zod** to strictly enforce:

* **Only `data:image/png;base64` strings are accepted.** Other formats are rejected.
* `width` and `height` must be integers within a safe range (1–512).
* Invalid or missing inputs fall back to a safe placeholder instead of rendering arbitrary content.
* SVG content is now sanitized to filter out unsafe attributes and elements, further reducing injection risk.

By enforcing **png-only input**, strict type validation, and sanitization, this update reduces the attack surface and improves robustness.

## **Related issues**

Fixes: 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

<!-- Example: unsafe string concatenation without validation -->

### **After**

<!-- Example: png-only validation with safe SVG string generation and sanitized content -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

* [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
* [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.