### PR TITLE
Missing runtime schema verification for profile sync store/retrieve

### DIFF
--- a/packages/gator-permissions-snap/snap.manifest.json
+++ b/packages/gator-permissions-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-7715-permissions.git"
   },
   "source": {
-    "shasum": "Vs9lYGeC2uo7E6/p4eYFQG8i5gv0RJFqGEeuAxbV980=",
+    "shasum": "DK0xWacmpY2VdHt48Tn5iw8Rpivla7dufa88PvDvPCw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/gator-permissions-snap/src/profileSync/profileSync.ts
+++ b/packages/gator-permissions-snap/src/profileSync/profileSync.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable no-restricted-globals */
 import type { PermissionResponse } from '@metamask/7715-permissions-shared/types';
+import { zPermissionResponse } from '@metamask/7715-permissions-shared/types';
 import { logger } from '@metamask/7715-permissions-shared/utils';
 import {
   hashDelegation,
@@ -12,7 +13,82 @@ import type {
   JwtBearerAuth,
   UserStorage,
 } from '@metamask/profile-sync-controller/sdk';
-import { UnsupportedMethodError } from '@metamask/snaps-sdk';
+import {
+  InvalidInputError,
+  LimitExceededError,
+  ParseError,
+  UnsupportedMethodError,
+} from '@metamask/snaps-sdk';
+import { z } from 'zod';
+
+// Constants for validation
+const MAX_STORAGE_SIZE_BYTES = 400 * 1024; // 400kb limit as documented
+
+// Zod schema for runtime validation of StoredGrantedPermission
+const zStoredGrantedPermission = z.object({
+  permissionResponse: zPermissionResponse,
+  siteOrigin: z.string().min(1, 'Site origin cannot be empty'),
+});
+
+/**
+ * Safely deserializes and validates a JSON string as StoredGrantedPermission.
+ * @param jsonString - The JSON string to deserialize.
+ * @returns The validated StoredGrantedPermission object.
+ * @throws InvalidInputError if validation fails.
+ * @throws ParseError if parsing fails.
+ */
+function safeDeserializeStoredGrantedPermission(
+  jsonString: string,
+): StoredGrantedPermission {
+  try {
+    const parsed = JSON.parse(jsonString);
+    const validated = zStoredGrantedPermission.parse(parsed);
+    return validated;
+  } catch (error) {
+    logger.error('Error deserializing stored granted permission:', error);
+    if (error instanceof z.ZodError) {
+      throw new InvalidInputError(
+        `Invalid permission data structure: ${error.errors.map((zodError) => `${zodError.path.join('.')}: ${zodError.message}`).join(', ')}`,
+      );
+    }
+    throw new ParseError(`Failed to parse JSON`);
+  }
+}
+
+/**
+ * Safely serializes a StoredGrantedPermission object with size validation.
+ * @param permission - The permission object to serialize.
+ * @returns The JSON string.
+ * @throws LimitExceededError if size limit exceeded.
+ */
+function safeSerializeStoredGrantedPermission(
+  permission: StoredGrantedPermission,
+): string {
+  try {
+    // Validate the object structure first
+    const validated = zStoredGrantedPermission.parse(permission);
+
+    // Serialize to JSON
+    const jsonString = JSON.stringify(validated);
+
+    // Check size limit
+    const sizeBytes = new TextEncoder().encode(jsonString).length;
+    if (sizeBytes > MAX_STORAGE_SIZE_BYTES) {
+      throw new LimitExceededError(
+        `Permission data exceeds size limit: ${sizeBytes} bytes > ${MAX_STORAGE_SIZE_BYTES} bytes`,
+      );
+    }
+
+    return jsonString;
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new InvalidInputError(
+        `Invalid permission data structure: ${error.errors.map((zodError) => `${zodError.path.join('.')}: ${zodError.message}`).join(', ')}`,
+      );
+    }
+    throw error;
+  }
+}
 
 export type ProfileSyncManager = {
   getAllGrantedPermissions: () => Promise<StoredGrantedPermission[]>;
@@ -109,9 +185,22 @@ export function createProfileSyncManager(
       await authenticate();
 
       const items = await userStorage.getAllFeatureItems(FEATURE);
-      return (
-        items?.map((item) => JSON.parse(item) as StoredGrantedPermission) ?? []
-      );
+      if (!items) {
+        return [];
+      }
+
+      const validPermissions: StoredGrantedPermission[] = [];
+
+      for (const item of items) {
+        try {
+          const permission = safeDeserializeStoredGrantedPermission(item);
+          validPermissions.push(permission);
+        } catch (error) {
+          logger.warn('Skipping invalid permission data:', error);
+        }
+      }
+
+      return validPermissions;
     } catch (error) {
       logger.error('Error fetching all granted permissions:', error);
       throw error;
@@ -133,9 +222,11 @@ export function createProfileSyncManager(
       const path: UserStorageGenericPathWithFeatureAndKey = `${FEATURE}.${generateObjectKey(permissionContext)}`;
       const permission = await userStorage.getItem(path);
 
-      return permission
-        ? (JSON.parse(permission) as StoredGrantedPermission)
-        : null;
+      if (!permission) {
+        return null;
+      }
+
+      return safeDeserializeStoredGrantedPermission(permission);
     } catch (error) {
       logger.error('Error fetching granted permissions:', error);
       throw error;
@@ -147,7 +238,7 @@ export function createProfileSyncManager(
    *
    * Persisting "<permissionContext>" key under "gator_7715_permissions" feature
    * value has to be serialized to string and does not exceed 400kb
-   * it is up to the SDK consumer to enforce proper schema management
+   * Runtime schema validation is enforced to prevent corrupted data storage
    * will result in PUT /api/v1/userstorage/gator_7715_permissions/Hash(<storage_key+<permissionContext>">)
    * VALUE: encrypted("JSONstringifyPermission", storage_key).
    * @param storedGrantedPermission - The permission response to store.
@@ -158,8 +249,13 @@ export function createProfileSyncManager(
     try {
       await authenticate();
 
+      // Validate and serialize with size check
+      const serializedPermission = safeSerializeStoredGrantedPermission(
+        storedGrantedPermission,
+      );
+
       const path: UserStorageGenericPathWithFeatureAndKey = `${FEATURE}.${generateObjectKey(storedGrantedPermission.permissionResponse.context)}`;
-      await userStorage.setItem(path, JSON.stringify(storedGrantedPermission));
+      await userStorage.setItem(path, serializedPermission);
     } catch (error) {
       logger.error('Error storing granted permission:', error);
       throw error;
@@ -171,7 +267,7 @@ export function createProfileSyncManager(
    *
    * Batch set multiple items under the "gator_7715_permissions" feature
    * values have to be serialized to string and does not exceed 400kb
-   * it is up to the SDK consumer to enforce proper schema management
+   * Runtime schema validation is enforced to prevent corrupted data storage
    * will result in PUT /api/v1/userstorage/gator_7715_permissions/
    * VALUES: encrypted("JSONstringifyPermission1", storage_key), encrypted("JSONstringifyPermission2", storage_key).
    * @param storedGrantedPermissions - The permission responses to store.
@@ -182,15 +278,31 @@ export function createProfileSyncManager(
     try {
       await authenticate();
 
-      await userStorage.batchSetItems(
-        FEATURE,
-        storedGrantedPermissions.map((storedGrantedPermission) => [
-          generateObjectKey(storedGrantedPermission.permissionResponse.context), // key
-          JSON.stringify(storedGrantedPermission), // value
-        ]),
-      );
+      // Validate and serialize all permissions with size checks
+      const validatedItems: [string, string][] = [];
+
+      for (const permission of storedGrantedPermissions) {
+        try {
+          const serializedPermission =
+            safeSerializeStoredGrantedPermission(permission);
+          validatedItems.push([
+            generateObjectKey(permission.permissionResponse.context), // key
+            serializedPermission, // value
+          ]);
+        } catch (error) {
+          logger.warn('Skipping invalid permission in batch:', error);
+        }
+      }
+
+      if (validatedItems.length === 0) {
+        throw new InvalidInputError(
+          'No valid permissions to store in batch operation',
+        );
+      }
+
+      await userStorage.batchSetItems(FEATURE, validatedItems);
     } catch (error) {
-      logger.error('Error storing granted permission:', error);
+      logger.error('Error storing granted permission batch:', error);
       throw error;
     }
   }

--- a/packages/gator-permissions-snap/src/profileSync/profileSync.ts
+++ b/packages/gator-permissions-snap/src/profileSync/profileSync.ts
@@ -2,7 +2,10 @@
 /* eslint-disable no-restricted-globals */
 import type { PermissionResponse } from '@metamask/7715-permissions-shared/types';
 import { zPermissionResponse } from '@metamask/7715-permissions-shared/types';
-import { logger } from '@metamask/7715-permissions-shared/utils';
+import {
+  logger,
+  extractZodError,
+} from '@metamask/7715-permissions-shared/utils';
 import {
   hashDelegation,
   decodeDelegations,
@@ -47,9 +50,7 @@ function safeDeserializeStoredGrantedPermission(
   } catch (error) {
     logger.error('Error deserializing stored granted permission:', error);
     if (error instanceof z.ZodError) {
-      throw new InvalidInputError(
-        `Invalid permission data structure: ${error.errors.map((zodError) => `${zodError.path.join('.')}: ${zodError.message}`).join(', ')}`,
-      );
+      throw new InvalidInputError(extractZodError(error.errors));
     }
     throw new ParseError(`Failed to parse JSON`);
   }
@@ -82,9 +83,7 @@ function safeSerializeStoredGrantedPermission(
     return jsonString;
   } catch (error) {
     if (error instanceof z.ZodError) {
-      throw new InvalidInputError(
-        `Invalid permission data structure: ${error.errors.map((zodError) => `${zodError.path.join('.')}: ${zodError.message}`).join(', ')}`,
-      );
+      throw new InvalidInputError(extractZodError(error.errors));
     }
     throw error;
   }

--- a/packages/gator-permissions-snap/test/profileSync/profileSync.test.ts
+++ b/packages/gator-permissions-snap/test/profileSync/profileSync.test.ts
@@ -204,8 +204,19 @@ describe('profileSync', () => {
 
         expect(userStorageMock.setItem).toHaveBeenCalledWith(
           `gator_7715_permissions.${mockDelegationHash}`,
-          expect.stringContaining('"permissionResponse"'),
+          expect.stringMatching(
+            /^\{"permissionResponse":\{.*\},"siteOrigin":"https:\/\/example\.com"\}$/u,
+          ),
         );
+        // Verify the stored data can be parsed and contains expected fields
+        const storedData = userStorageMock.setItem.mock.calls[0]?.[1];
+        expect(storedData).toBeDefined();
+        const parsed = JSON.parse(storedData as string);
+        expect(parsed.permissionResponse.chainId).toBe('0xaa36a7');
+        expect(parsed.permissionResponse.address).toBe(
+          '0x1234567890123456789012345678901234567890',
+        );
+        expect(parsed.siteOrigin).toBe('https://example.com');
       });
 
       it('should concatenate all delegation hashes together when store granted permission that has multiple delegations in profile sync', async () => {
@@ -223,8 +234,19 @@ describe('profileSync', () => {
 
         expect(userStorageMock.setItem).toHaveBeenCalledWith(
           `gator_7715_permissions.${mockDelegationHash}${mockDelegationHashTwo.slice(2)}`,
-          expect.stringContaining('"permissionResponse"'),
+          expect.stringMatching(
+            /^\{"permissionResponse":\{.*\},"siteOrigin":"https:\/\/example\.com"\}$/u,
+          ),
         );
+        // Verify the stored data can be parsed and contains expected fields
+        const storedData = userStorageMock.setItem.mock.calls[0]?.[1];
+        expect(storedData).toBeDefined();
+        const parsed = JSON.parse(storedData as string);
+        expect(parsed.permissionResponse.chainId).toBe('0xaa36a7');
+        expect(parsed.permissionResponse.address).toBe(
+          '0x1234567890123456789012345678901234567890',
+        );
+        expect(parsed.siteOrigin).toBe('https://example.com');
       });
 
       it('should throw error when profile sync storage throws error', async () => {
@@ -290,13 +312,31 @@ describe('profileSync', () => {
           [
             [
               mockDelegationHash,
-              expect.stringContaining('"permissionResponse"'),
+              expect.stringMatching(
+                /^\{"permissionResponse":\{.*\},"siteOrigin":"https:\/\/example\.com"\}$/u,
+              ),
             ],
             [
               mockDelegationHashTwo,
-              expect.stringContaining('"permissionResponse"'),
+              expect.stringMatching(
+                /^\{"permissionResponse":\{.*\},"siteOrigin":"https:\/\/example\.com"\}$/u,
+              ),
             ],
           ],
+        );
+        // Verify the stored data can be parsed and contains expected fields
+        const batchCalls = userStorageMock.batchSetItems.mock.calls[0]?.[1];
+        expect(batchCalls).toBeDefined();
+        expect(batchCalls).toHaveLength(2);
+        const firstStored = JSON.parse((batchCalls as any)[0]?.[1] as string);
+        const secondStored = JSON.parse((batchCalls as any)[1]?.[1] as string);
+        expect(firstStored.permissionResponse.chainId).toBe('0xaa36a7');
+        expect(firstStored.permissionResponse.address).toBe(
+          '0x1234567890123456789012345678901234567890',
+        );
+        expect(secondStored.permissionResponse.chainId).toBe('0xaa36a7');
+        expect(secondStored.permissionResponse.address).toBe(
+          '0x1234567890123456789012345678901234567891',
         );
       });
 
@@ -402,8 +442,25 @@ describe('profileSync', () => {
 
       expect(userStorageMock.batchSetItems).toHaveBeenCalledWith(
         'gator_7715_permissions',
-        [[mockDelegationHash, expect.stringContaining('"permissionResponse"')]],
+        [
+          [
+            mockDelegationHash,
+            expect.stringMatching(
+              /^\{"permissionResponse":\{.*\},"siteOrigin":"https:\/\/example\.com"\}$/u,
+            ),
+          ],
+        ],
       );
+      // Verify the stored data can be parsed and contains expected fields
+      const batchCalls = userStorageMock.batchSetItems.mock.calls[0]?.[1];
+      expect(batchCalls).toBeDefined();
+      expect(batchCalls).toHaveLength(1);
+      const storedData = JSON.parse((batchCalls as any)[0]?.[1] as string);
+      expect(storedData.permissionResponse.chainId).toBe('0xaa36a7');
+      expect(storedData.permissionResponse.address).toBe(
+        '0x1234567890123456789012345678901234567890',
+      );
+      expect(storedData.siteOrigin).toBe('https://example.com');
     });
   });
 

--- a/packages/gator-permissions-snap/test/profileSync/profileSync.test.ts
+++ b/packages/gator-permissions-snap/test/profileSync/profileSync.test.ts
@@ -197,10 +197,10 @@ describe('profileSync', () => {
 
     describe('storeGrantedPermission', () => {
       it('should store granted permission successfully in profile sync', async () => {
+        mockPassAuth();
         await profileSyncManager.storeGrantedPermission(
           mockStoredGrantedPermission,
         );
-        mockPassAuth();
 
         expect(userStorageMock.setItem).toHaveBeenCalledWith(
           `gator_7715_permissions.${mockDelegationHash}`,
@@ -227,10 +227,11 @@ describe('profileSync', () => {
             context: encodeDelegations([mockDelegation, mockDelegationTwo]),
           },
         };
+
+        mockPassAuth();
         await profileSyncManager.storeGrantedPermission(
           mockStoredGrantedPermissionWithMultipleDelegations,
         );
-        mockPassAuth();
 
         expect(userStorageMock.setItem).toHaveBeenCalledWith(
           `gator_7715_permissions.${mockDelegationHash}${mockDelegationHashTwo.slice(2)}`,

--- a/packages/gator-permissions-snap/test/profileSync/profileSync.test.ts
+++ b/packages/gator-permissions-snap/test/profileSync/profileSync.test.ts
@@ -375,7 +375,7 @@ describe('profileSync', () => {
         profileSyncManager.getGrantedPermission(
           mockStoredGrantedPermission.permissionResponse.context,
         ),
-      ).rejects.toThrow('Invalid permission data structure');
+      ).rejects.toThrow('Failed type validation');
     });
 
     it('should enforce 400kb size limit and reject oversized data', async () => {


### PR DESCRIPTION
## **Description**

The Profile Sync performs unsafe deserialization of permission data without runtime schema validation.

JSON.parse only validates JSON syntax, not data structure
The type assertion as StoredGrantedPermission is a compile-time hint only
At runtime, there’s no guarantee the parsed object matches the expected structure
The code comments explicitly state that “it is up to the SDK consumer to enforce proper schema management” (lines 147–149). However, no such validation is implemented. Because profile sync data is shared across devices, erroneous or malicious data could propagate and impact all connected devices.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.