### PR TITLE
getRegisteredPermissionOffers array optimization

### DIFF
--- a/packages/permissions-kernel-snap/src/registryManager.ts
+++ b/packages/permissions-kernel-snap/src/registryManager.ts
@@ -135,10 +135,7 @@ export const createPermissionOfferRegistryManager = (
       return [];
     }
 
-    return Object.values(permissionOfferRegistry).reduce(
-      (acc, offers) => [...acc, ...offers],
-      [],
-    );
+    return Object.values(permissionOfferRegistry).flat();
   }
 
   /**


### PR DESCRIPTION
## **Description**

The getRegisteredPermissionOffers function uses an inefficient O(n²) array concatenation pattern. It is using spread operators inside a reduce, which recreates the entire array on every iteration. While the current registry is hardcoded to the gator snap, and even considering numerous permissions offers, the risk of causing significant performance degradation or denial of service is reduced, however, it still should be addressed.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.