### PR TITLE
Validate kernel rpc request

### DIFF
--- a/packages/permissions-kernel-snap/package.json
+++ b/packages/permissions-kernel-snap/package.json
@@ -47,7 +47,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@metamask/snaps-sdk": "8.1.0"
+    "@metamask/snaps-sdk": "8.1.0",
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",

--- a/packages/permissions-kernel-snap/src/index.ts
+++ b/packages/permissions-kernel-snap/src/index.ts
@@ -39,7 +39,7 @@ let activeProcessingLock: symbol | null = null;
  * @param args.origin - The origin of the request, e.g., the website that
  * invoked the snap.
  * @param args.request - A JSON-RPC request object that will be validated.
- * @returns The result of the RPC method execution.
+ * @returns The result of the RPC method execution (The 7715 permissions response from the permissions provider).
  * @throws If the request is invalid, method is not found, or processing fails.
  */
 export const onRpcRequest: OnRpcRequestHandler = async ({

--- a/packages/permissions-kernel-snap/src/index.ts
+++ b/packages/permissions-kernel-snap/src/index.ts
@@ -2,6 +2,7 @@ import { logger } from '@metamask/7715-permissions-shared/utils';
 import {
   InvalidParamsError,
   LimitExceededError,
+  MethodNotFoundError,
   type Json,
   type JsonRpcParams,
   type OnRpcRequestHandler,
@@ -80,7 +81,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
       !Object.prototype.hasOwnProperty.call(boundRpcHandlers, request.method)
     ) {
       logger.warn('Method not found in bound handlers:', request.method);
-      throw new InvalidParamsError(`Method ${request.method} not found`);
+      throw new MethodNotFoundError(`Method ${request.method} not found.`);
     }
 
     // Now validate the full JSON-RPC structure

--- a/packages/permissions-kernel-snap/src/utils/validate.ts
+++ b/packages/permissions-kernel-snap/src/utils/validate.ts
@@ -155,19 +155,14 @@ export function validateJsonRpcRequest(
   const validationResult = zJsonRpcRequest.safeParse(request);
 
   if (!validationResult.success) {
-    const errorMessages = validationResult.error.errors.map((error) => {
-      const path = error.path.length > 0 ? error.path.join('.') : 'root';
-      return `${path}: ${error.message}`;
-    });
+    const errorMessage = extractZodError(validationResult.error.errors);
 
     logger.warn('Invalid JSON-RPC request structure:', {
-      errors: errorMessages,
+      errors: errorMessage,
       request: JSON.stringify(request, null, 2),
     });
 
-    throw new InvalidParamsError(
-      `Invalid JSON-RPC request: ${errorMessages.join(', ')}`,
-    );
+    throw new InvalidParamsError(`Invalid JSON-RPC request: ${errorMessage}`);
   }
 
   return validationResult.data;

--- a/packages/permissions-kernel-snap/src/utils/validate.ts
+++ b/packages/permissions-kernel-snap/src/utils/validate.ts
@@ -5,8 +5,13 @@ import {
   zPermissionsRequest,
   zPermissionsResponse,
 } from '@metamask/7715-permissions-shared/types';
-import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+import {
+  extractZodError,
+  logger,
+} from '@metamask/7715-permissions-shared/utils';
 import { InvalidParamsError } from '@metamask/snaps-sdk';
+import { z } from 'zod';
+import { RpcMethod } from '../rpc/rpcMethod';
 
 /**
  * Safely parses the grant permissions request parameters, validating them using Zod schema.
@@ -55,3 +60,99 @@ export const parsePermissionsResponseParam = (
 
   return validatePermissionsResponse.data;
 };
+
+/**
+ * Zod schema for validating JSON-RPC request structure
+ */
+export const zJsonRpcRequest = z.object({
+  /**
+   * The JSON-RPC version, must be "2.0"
+   */
+  jsonrpc: z.literal('2.0'),
+
+  /**
+   * The method name - must be a valid RPC method
+   */
+  method: z.nativeEnum(RpcMethod),
+
+  /**
+   * The parameters for the method - must be valid JsonRpcParams
+   */
+  params: z
+    .union([
+      z.string(),
+      z.number(),
+      z.boolean(),
+      z.null(),
+      z.array(z.unknown()),
+      z.record(z.unknown()),
+    ])
+    .optional(),
+
+  /**
+   * The request ID - must be a string or number
+   */
+  id: z.union([z.string(), z.number()]).optional(),
+});
+
+/**
+ * Type for a validated JSON-RPC request
+ */
+export type ValidatedJsonRpcRequest = z.infer<typeof zJsonRpcRequest>;
+
+/**
+ * Validates that the request object is a proper JSON-RPC request
+ * and that the method is supported by this snap.
+ *
+ * @param request - The request object to validate.
+ * @returns The validated request object.
+ * @throws InvalidParamsError if validation fails.
+ */
+export function validateJsonRpcRequest(
+  request: unknown,
+): ValidatedJsonRpcRequest {
+  // First, ensure the request is an object
+  if (typeof request !== 'object' || request === null) {
+    throw new InvalidParamsError('Request must be a valid JSON-RPC object');
+  }
+
+  // Validate the JSON-RPC structure using Zod
+  const validationResult = zJsonRpcRequest.safeParse(request);
+
+  if (!validationResult.success) {
+    const errorMessages = validationResult.error.errors.map((error) => {
+      const path = error.path.length > 0 ? error.path.join('.') : 'root';
+      return `${path}: ${error.message}`;
+    });
+
+    logger.warn('Invalid JSON-RPC request structure:', {
+      errors: errorMessages,
+      request: JSON.stringify(request, null, 2),
+    });
+
+    throw new InvalidParamsError(
+      `Invalid JSON-RPC request: ${errorMessages.join(', ')}`,
+    );
+  }
+
+  return validationResult.data;
+}
+
+/**
+ * Validates that the request method exists in the bound handlers.
+ * This provides an additional layer of security beyond the Zod schema.
+ *
+ * @param method - The method name to validate.
+ * @param boundHandlers - The object containing bound RPC handlers.
+ * @throws InvalidParamsError if method is not found.
+ */
+export function validateMethodExists(
+  method: string,
+  boundHandlers: Record<string, unknown>,
+): void {
+  // Use Object.prototype.hasOwnProperty.call() to prevent prototype pollution attacks
+  if (!Object.prototype.hasOwnProperty.call(boundHandlers, method)) {
+    logger.warn('Method not found in bound handlers:', { method });
+    throw new InvalidParamsError(`Method ${method} not found`);
+  }
+}

--- a/packages/permissions-kernel-snap/src/utils/validate.ts
+++ b/packages/permissions-kernel-snap/src/utils/validate.ts
@@ -29,10 +29,10 @@ function isSafeObject(obj: unknown): boolean {
 
   // Check for exact dangerous keys (not substrings)
   const dangerousKeys = ['__proto__', 'constructor', 'prototype'];
-  
+
   // Check if any dangerous keys exist as own properties
-  const hasDangerousKey = dangerousKeys.some((dangerousKey) => 
-    Object.prototype.hasOwnProperty.call(obj, dangerousKey)
+  const hasDangerousKey = dangerousKeys.some((dangerousKey) =>
+    Object.prototype.hasOwnProperty.call(obj, dangerousKey),
   );
 
   if (hasDangerousKey) {

--- a/packages/permissions-kernel-snap/test/end-to-end/index.test.tsx
+++ b/packages/permissions-kernel-snap/test/end-to-end/index.test.tsx
@@ -56,7 +56,7 @@ describe('Kernel Snap', () => {
 
         expect(response1).toRespondWithError({
           code: -32602,
-          message: expect.stringContaining('Invalid JSON-RPC request'),
+          message: expect.stringContaining('Failed type validation'),
           stack: expect.any(String),
         });
 
@@ -68,7 +68,21 @@ describe('Kernel Snap', () => {
 
         expect(response2).toRespondWithError({
           code: -32602,
-          message: expect.stringContaining('Invalid JSON-RPC request'),
+          data: expect.objectContaining({
+            cause: null,
+            method: 'snapRpc',
+            params: expect.arrayContaining([
+              expect.stringMatching(/^local:http:\/\/localhost:\d+$/),
+              'onRpcRequest',
+              'https://metamask.io',
+              expect.objectContaining({
+                id: 1,
+                jsonrpc: '1.0',
+                method: 'wallet_requestExecutionPermissions',
+              }),
+            ]),
+          }),
+          message: expect.stringContaining('Invalid parameters for method "snapRpc": At path: 3.jsonrpc -- Expected the literal `"2.0"`, but received: "1.0"'),
           stack: expect.any(String),
         });
       });
@@ -80,8 +94,8 @@ describe('Kernel Snap', () => {
         } as any);
 
         expect(response).toRespondWithError({
-          code: -32602,
-          message: expect.stringContaining('Invalid JSON-RPC request'),
+          code: -32601,
+          message: 'Method invalid_method not found.',
           stack: expect.any(String),
         });
       });
@@ -98,7 +112,7 @@ describe('Kernel Snap', () => {
 
         expect(response).toRespondWithError({
           code: -32602,
-          message: expect.stringContaining('Invalid JSON-RPC request'),
+          message: expect.stringContaining('Failed type validation'),
           stack: expect.any(String),
         });
       });
@@ -116,7 +130,7 @@ describe('Kernel Snap', () => {
 
         expect(response).toRespondWithError({
           code: -32602,
-          message: expect.stringContaining('Invalid JSON-RPC request'),
+          message: expect.stringContaining('Failed type validation'),
           stack: expect.any(String),
         });
       });
@@ -134,7 +148,7 @@ describe('Kernel Snap', () => {
         // The request should be processed (may fail later due to test setup, but not due to validation)
         expect(response).not.toRespondWithError({
           code: -32602,
-          message: expect.stringContaining('Invalid JSON-RPC request'),
+          message: expect.stringContaining('Failed type validation'),
         });
       });
     });

--- a/packages/permissions-kernel-snap/test/end-to-end/index.test.tsx
+++ b/packages/permissions-kernel-snap/test/end-to-end/index.test.tsx
@@ -47,6 +47,96 @@ describe('Kernel Snap', () => {
           });
         }
       });
+
+      it('validates JSON-RPC request structure', async () => {
+        // Test missing jsonrpc field
+        const response1 = await snapRequest({
+          method: 'wallet_requestExecutionPermissions',
+        });
+
+        expect(response1).toRespondWithError({
+          code: -32602,
+          message: expect.stringContaining('Invalid JSON-RPC request'),
+          stack: expect.any(String),
+        });
+
+        // Test invalid jsonrpc version
+        const response2 = await snapRequest({
+          jsonrpc: '1.0',
+          method: 'wallet_requestExecutionPermissions',
+        } as any);
+
+        expect(response2).toRespondWithError({
+          code: -32602,
+          message: expect.stringContaining('Invalid JSON-RPC request'),
+          stack: expect.any(String),
+        });
+      });
+
+      it('validates request method against allowed methods', async () => {
+        const response = await snapRequest({
+          jsonrpc: '2.0',
+          method: 'invalid_method',
+        } as any);
+
+        expect(response).toRespondWithError({
+          code: -32602,
+          message: expect.stringContaining('Invalid JSON-RPC request'),
+          stack: expect.any(String),
+        });
+      });
+
+      it('prevents prototype pollution in request params', async () => {
+        const response = await snapRequest({
+          jsonrpc: '2.0',
+          method: 'wallet_requestExecutionPermissions',
+          params: {
+            '__proto__': 'malicious',
+            normalKey: 'value',
+          },
+        } as any);
+
+        expect(response).toRespondWithError({
+          code: -32602,
+          message: expect.stringContaining('Invalid JSON-RPC request'),
+          stack: expect.any(String),
+        });
+      });
+
+      it('prevents prototype pollution in nested request params', async () => {
+        const response = await snapRequest({
+          jsonrpc: '2.0',
+          method: 'wallet_requestExecutionPermissions',
+          params: {
+            normalKey: {
+              '__proto__': 'malicious',
+            },
+          },
+        } as any);
+
+        expect(response).toRespondWithError({
+          code: -32602,
+          message: expect.stringContaining('Invalid JSON-RPC request'),
+          stack: expect.any(String),
+        });
+      });
+
+      it('allows valid JSON-RPC request structure', async () => {
+        const response = await snapRequest({
+          jsonrpc: '2.0',
+          method: 'wallet_requestExecutionPermissions',
+          params: {
+            test: 'value',
+          },
+          id: 1,
+        } as any);
+
+        // The request should be processed (may fail later due to test setup, but not due to validation)
+        expect(response).not.toRespondWithError({
+          code: -32602,
+          message: expect.stringContaining('Invalid JSON-RPC request'),
+        });
+      });
     });
 
     describe('processing lock', () => {

--- a/packages/permissions-kernel-snap/test/utils/validate.test.ts
+++ b/packages/permissions-kernel-snap/test/utils/validate.test.ts
@@ -6,7 +6,6 @@ import {
   parsePermissionRequestParam,
   parsePermissionsResponseParam,
   validateJsonRpcRequest,
-  validateMethodExists,
 } from '../../src/utils/validate';
 import { MOCK_PERMISSIONS_REQUEST_SINGLE } from '../constants';
 
@@ -42,7 +41,7 @@ describe('validate utils', () => {
             },
           },
         ]),
-      ).toThrow('Failed type validation: 0.permission: Required');
+      ).toThrow('Invalid method parameter(s).');
     });
 
     it('throw error if params is empty', async () => {
@@ -51,7 +50,7 @@ describe('validate utils', () => {
 
     it('throw error if params is invalid type', async () => {
       expect(() => parsePermissionRequestParam('invalid')).toThrow(
-        'Failed type validation',
+        'Invalid method parameter(s).',
       );
     });
   });
@@ -99,7 +98,7 @@ describe('validate utils', () => {
             // Missing permission object
           },
         ]),
-      ).toThrow('Failed type validation');
+      ).toThrow('Invalid method parameter(s).');
     });
 
     it('throw error if params is empty', async () => {
@@ -110,7 +109,7 @@ describe('validate utils', () => {
 
     it('throw error if params is invalid type', async () => {
       expect(() => parsePermissionsResponseParam('invalid')).toThrow(
-        'Failed type validation',
+        'Invalid method parameter(s).',
       );
     });
   });
@@ -246,43 +245,6 @@ describe('validate utils', () => {
     });
   });
 
-  describe('validateMethodExists', () => {
-    const mockBoundHandlers = {
-      [RpcMethod.WalletRequestExecutionPermissions]: jest.fn(),
-    };
-
-    it('should not throw for existing method', () => {
-      expect(() =>
-        validateMethodExists(
-          RpcMethod.WalletRequestExecutionPermissions,
-          mockBoundHandlers,
-        ),
-      ).not.toThrow();
-    });
-
-    it('should throw InvalidParamsError for non-existing method', () => {
-      expect(() =>
-        validateMethodExists('non_existing_method', mockBoundHandlers),
-      ).toThrow(InvalidParamsError);
-    });
-
-    it('should not be vulnerable to prototype pollution', () => {
-      // Test that the function uses Object.prototype.hasOwnProperty.call correctly
-      // by ensuring it doesn't find methods that don't actually exist on the object
-      expect(() =>
-        validateMethodExists('nonExistentMethod', mockBoundHandlers),
-      ).toThrow(InvalidParamsError);
-
-      // Test that it correctly finds existing methods
-      expect(() =>
-        validateMethodExists(
-          RpcMethod.WalletRequestExecutionPermissions,
-          mockBoundHandlers,
-        ),
-      ).not.toThrow();
-    });
-  });
-
   describe('Integration tests', () => {
     it('should handle complete valid request flow', () => {
       const validRequest = {
@@ -292,15 +254,8 @@ describe('validate utils', () => {
         id: 1,
       };
 
-      const mockBoundHandlers = {
-        [RpcMethod.WalletRequestExecutionPermissions]: jest.fn(),
-      };
-
       // Validate request
       const validatedRequest = validateJsonRpcRequest(validRequest);
-
-      // Validate method exists
-      validateMethodExists(validatedRequest.method, mockBoundHandlers);
 
       expect(validatedRequest).toStrictEqual(validRequest);
     });

--- a/packages/permissions-kernel-snap/test/utils/validate.test.ts
+++ b/packages/permissions-kernel-snap/test/utils/validate.test.ts
@@ -1,10 +1,25 @@
-import { expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
+import { InvalidParamsError } from '@metamask/snaps-sdk';
 
+import { RpcMethod } from '../../src/rpc/rpcMethod';
 import {
   parsePermissionRequestParam,
   parsePermissionsResponseParam,
+  validateJsonRpcRequest,
+  validateMethodExists,
 } from '../../src/utils/validate';
 import { MOCK_PERMISSIONS_REQUEST_SINGLE } from '../constants';
+
+// Mock the logger to avoid console output during tests
+jest.mock('@metamask/7715-permissions-shared/utils', () => ({
+  logger: {
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  extractZodError: jest.fn((errors: unknown[]) =>
+    errors.map((error: any) => error.message).join(', '),
+  ),
+}));
 
 describe('validate utils', () => {
   describe('parsePermissionRequestParam', () => {
@@ -97,6 +112,219 @@ describe('validate utils', () => {
       expect(() => parsePermissionsResponseParam('invalid')).toThrow(
         'Failed type validation',
       );
+    });
+  });
+
+  describe('validateJsonRpcRequest', () => {
+    it('should validate a correct JSON-RPC request', () => {
+      const validRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        params: { test: 'value' },
+        id: 1,
+      };
+
+      const result = validateJsonRpcRequest(validRequest);
+      expect(result).toStrictEqual(validRequest);
+    });
+
+    it('should validate a request without params', () => {
+      const validRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        id: 'test-id',
+      };
+
+      const result = validateJsonRpcRequest(validRequest);
+      expect(result).toStrictEqual(validRequest);
+    });
+
+    it('should validate a request without id', () => {
+      const validRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        params: { test: 'value' },
+      };
+
+      const result = validateJsonRpcRequest(validRequest);
+      expect(result).toStrictEqual(validRequest);
+    });
+
+    it('should throw InvalidParamsError for non-object request', () => {
+      expect(() => validateJsonRpcRequest('invalid')).toThrow(
+        InvalidParamsError,
+      );
+      expect(() => validateJsonRpcRequest(null)).toThrow(InvalidParamsError);
+      expect(() => validateJsonRpcRequest(123)).toThrow(InvalidParamsError);
+    });
+
+    it('should throw InvalidParamsError for invalid jsonrpc version', () => {
+      const invalidRequest = {
+        jsonrpc: '1.0',
+        method: RpcMethod.WalletRequestExecutionPermissions,
+      };
+
+      expect(() => validateJsonRpcRequest(invalidRequest)).toThrow(
+        InvalidParamsError,
+      );
+    });
+
+    it('should throw InvalidParamsError for missing jsonrpc field', () => {
+      const invalidRequest = {
+        method: RpcMethod.WalletRequestExecutionPermissions,
+      };
+
+      expect(() => validateJsonRpcRequest(invalidRequest)).toThrow(
+        InvalidParamsError,
+      );
+    });
+
+    it('should throw InvalidParamsError for invalid method', () => {
+      const invalidRequest = {
+        jsonrpc: '2.0' as const,
+        method: 'invalid_method',
+      };
+
+      expect(() => validateJsonRpcRequest(invalidRequest)).toThrow(
+        InvalidParamsError,
+      );
+    });
+
+    it('should throw InvalidParamsError for missing method', () => {
+      const invalidRequest = {
+        jsonrpc: '2.0' as const,
+      };
+
+      expect(() => validateJsonRpcRequest(invalidRequest)).toThrow(
+        InvalidParamsError,
+      );
+    });
+
+    it('should throw InvalidParamsError for invalid id type', () => {
+      const invalidRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        id: { invalid: 'id' },
+      };
+
+      expect(() => validateJsonRpcRequest(invalidRequest)).toThrow(
+        InvalidParamsError,
+      );
+    });
+
+    it('should allow valid primitive params', () => {
+      const validRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        params: 'string param',
+      };
+
+      const result = validateJsonRpcRequest(validRequest);
+      expect(result.params).toBe('string param');
+    });
+
+    it('should allow valid number params', () => {
+      const validRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        params: 123,
+      };
+
+      const result = validateJsonRpcRequest(validRequest);
+      expect(result.params).toBe(123);
+    });
+
+    it('should allow valid boolean params', () => {
+      const validRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        params: true,
+      };
+
+      const result = validateJsonRpcRequest(validRequest);
+      expect(result.params).toBe(true);
+    });
+  });
+
+  describe('validateMethodExists', () => {
+    const mockBoundHandlers = {
+      [RpcMethod.WalletRequestExecutionPermissions]: jest.fn(),
+    };
+
+    it('should not throw for existing method', () => {
+      expect(() =>
+        validateMethodExists(
+          RpcMethod.WalletRequestExecutionPermissions,
+          mockBoundHandlers,
+        ),
+      ).not.toThrow();
+    });
+
+    it('should throw InvalidParamsError for non-existing method', () => {
+      expect(() =>
+        validateMethodExists('non_existing_method', mockBoundHandlers),
+      ).toThrow(InvalidParamsError);
+    });
+
+    it('should not be vulnerable to prototype pollution', () => {
+      // Test that the function uses Object.prototype.hasOwnProperty.call correctly
+      // by ensuring it doesn't find methods that don't actually exist on the object
+      expect(() =>
+        validateMethodExists('nonExistentMethod', mockBoundHandlers),
+      ).toThrow(InvalidParamsError);
+
+      // Test that it correctly finds existing methods
+      expect(() =>
+        validateMethodExists(
+          RpcMethod.WalletRequestExecutionPermissions,
+          mockBoundHandlers,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe('Integration tests', () => {
+    it('should handle complete valid request flow', () => {
+      const validRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        params: { test: 'value' },
+        id: 1,
+      };
+
+      const mockBoundHandlers = {
+        [RpcMethod.WalletRequestExecutionPermissions]: jest.fn(),
+      };
+
+      // Validate request
+      const validatedRequest = validateJsonRpcRequest(validRequest);
+
+      // Validate method exists
+      validateMethodExists(validatedRequest.method, mockBoundHandlers);
+
+      expect(validatedRequest).toStrictEqual(validRequest);
+    });
+
+    it('should handle request with complex nested params', () => {
+      const complexParams = {
+        level1: {
+          level2: {
+            level3: 'deep value',
+            array: [1, 2, 3],
+          },
+          simple: 'value',
+        },
+        primitive: 42,
+      };
+
+      const validRequest = {
+        jsonrpc: '2.0' as const,
+        method: RpcMethod.WalletRequestExecutionPermissions,
+        params: complexParams,
+      };
+
+      const result = validateJsonRpcRequest(validRequest);
+      expect(result.params).toStrictEqual(complexParams);
     });
   });
 });

--- a/packages/permissions-kernel-snap/test/utils/validate.test.ts
+++ b/packages/permissions-kernel-snap/test/utils/validate.test.ts
@@ -252,11 +252,20 @@ describe('validate utils', () => {
       const dangerousParams2 = { prototype: 'pollution' };
       // Create an object with __proto__ as an actual property (not the special __proto__ property)
       const dangerousParams3 = Object.create(null);
-      dangerousParams3['__proto__'] = 'pollution';
+      // eslint-disable-next-line no-proto
+      dangerousParams3.__proto__ = 'pollution';
 
       const dangerousRequests = [
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: dangerousParams1 },
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: dangerousParams2 },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: dangerousParams1,
+        },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: dangerousParams2,
+        },
         // Note: dangerousParams3 won't work with z.record as it converts Object.create(null) to {}
         // This is actually correct behavior - Object.create(null) objects are safe from prototype pollution
       ];
@@ -270,11 +279,34 @@ describe('validate utils', () => {
 
     it('should allow objects with keys that contain dangerous substrings', () => {
       const safeRequests = [
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: { my__proto__field: 'safe' } },
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: { constructorHelper: 'safe' } },
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: { prototypeData: 'safe' } },
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: { __proto__test: 'safe' } },
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: { test__proto__: 'safe' } },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          params: { my__proto__field: 'safe' },
+        },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: { constructorHelper: 'safe' },
+        },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: { prototypeData: 'safe' },
+        },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          params: { __proto__test: 'safe' },
+        },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          params: { test__proto__: 'safe' },
+        },
       ];
 
       safeRequests.forEach((request) => {
@@ -286,39 +318,40 @@ describe('validate utils', () => {
     it('should reject nested objects with dangerous keys', () => {
       // Create nested objects with dangerous keys that will actually be detected
       const nestedProto = Object.create(null);
-      nestedProto['__proto__'] = 'pollution';
-      
+      // eslint-disable-next-line no-proto
+      nestedProto.__proto__ = 'pollution';
+
       const dangerousNestedRequests = [
-        { 
-          jsonrpc: '2.0' as const, 
-          method: RpcMethod.WalletRequestExecutionPermissions, 
-          params: { 
-            level1: nestedProto
-          } 
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: {
+            level1: nestedProto,
+          },
         },
-        { 
-          jsonrpc: '2.0' as const, 
-          method: RpcMethod.WalletRequestExecutionPermissions, 
-          params: { 
-            level1: { 
-              level2: { 
-                constructor: 'pollution' 
-              }
-            } 
-          } 
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: {
+            level1: {
+              level2: {
+                constructor: 'pollution',
+              },
+            },
+          },
         },
-        { 
-          jsonrpc: '2.0' as const, 
-          method: RpcMethod.WalletRequestExecutionPermissions, 
-          params: { 
-            level1: { 
-              level2: { 
-                level3: { 
-                  prototype: 'pollution' 
-                }
-              } 
-            } 
-          } 
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: {
+            level1: {
+              level2: {
+                level3: {
+                  prototype: 'pollution',
+                },
+              },
+            },
+          },
         },
       ];
 
@@ -356,10 +389,7 @@ describe('validate utils', () => {
                 level4: {
                   level5: {
                     safe: 'deep value',
-                    array: [
-                      { nested: 'safe' },
-                      { another: 'safe' },
-                    ],
+                    array: [{ nested: 'safe' }, { another: 'safe' }],
                   },
                 },
               },
@@ -389,10 +419,26 @@ describe('validate utils', () => {
 
     it('should handle primitive values safely', () => {
       const primitiveRequests = [
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: 'string' },
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: 123 },
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: true },
-        { jsonrpc: '2.0' as const, method: RpcMethod.WalletRequestExecutionPermissions, params: null },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: 'string',
+        },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: 123,
+        },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: true,
+        },
+        {
+          jsonrpc: '2.0' as const,
+          method: RpcMethod.WalletRequestExecutionPermissions,
+          params: null,
+        },
       ];
 
       primitiveRequests.forEach((request) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3733,6 +3733,7 @@ __metadata:
     rimraf: 6.0.1
     ts-jest: 29.4.0
     typescript: 5.8.3
+    zod: 3.25.76
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## **Description**

The onRpcRequest handler does not validate incoming requests before processing them. The JSDoc mentions it expects a “validated JSON-RPC request object”, but the code should verify if that’s actually happening, rather than directly accessing request.method and request.params without any checks.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.