### PR TITLE
Remove superfluous permissions

### DIFF
--- a/packages/permissions-kernel-snap/snap.manifest.ts
+++ b/packages/permissions-kernel-snap/snap.manifest.ts
@@ -1,8 +1,6 @@
 /* eslint-disable no-restricted-globals */
 import type { SnapManifest } from '@metamask/7715-permissions-shared/types';
 
-const gatorSnapId = process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
-
 const manifest: SnapManifest = {
   version: '0.2.0',
   description: 'Manage onchain 7715 permissions',
@@ -25,16 +23,11 @@ const manifest: SnapManifest = {
   initialPermissions: {
     'endowment:rpc': {
       dapps: true,
-      snaps: true,
+      snaps: false,
     },
   },
   platformVersion: '8.1.0',
   manifestVersion: '0.1',
 };
 
-if (gatorSnapId) {
-  manifest.initialConnections = {
-    [gatorSnapId]: {},
-  };
-}
 export default manifest;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes superfluous permissions from the Kernel snap manifest to comply with the principle of least privilege and reduce the attack surface. The manifest previously included three categories of unnecessary permissions:

1. **initialConnections**:  
   - The manifest declares `npm:@metamask/gator-permissions-snap`, but the Kernel snap never initiates communication with the Gator snap. The Kernel only processes responses when invoking other snaps.

2. **endowment:rpc**:  
   - Grants `"snaps": true` access, but no other snaps initiate communication with the Kernel snap. The Kernel handles request-response communications unidirectionally (DApp → Kernel → Gator).


**Recommendation applied in this PR**:  
- Remove `npm:@metamask/gator-permissions-snap` from `initialConnections`  
- Set `"snaps": false` in the RPC endowment configuration  

This reduces unnecessary permissions and potential security risks.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Pull the branch and build the extension.  
2. Inspect `packages/permissions-kernel-snap/snap.manifest.json` to confirm the unnecessary permissions are removed.  
3. Run the Kernel snap and ensure all functionality continues to work as expected.

## **Screenshots/Recordings**

### **Before**

<!-- Screenshot or snippet showing the manifest with the superfluous permissions -->

### **After**

<!-- Screenshot or snippet showing the cleaned manifest -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

