### PR TITLE
Rename RCP Urls To Be Consistent

### DIFF
--- a/packages/gator-permissions-snap/docs/architecture.md
+++ b/packages/gator-permissions-snap/docs/architecture.md
@@ -203,7 +203,7 @@ The EntryPoint serves as the main initialization and configuration point for the
 
 2. Configuring RPC method bindings:
    - Maps RPC methods to their corresponding handlers
-   - Supports `permissionProvider_grantPermissions`, `permissionProvider_getPermissionOffers`, and `permissionProvider_getGrantedPermissions`
+   - Supports `permissionsProvider_grantPermissions`, `permissionsProvider_getPermissionOffers`, and `permissionsProvider_getGrantedPermissions`
 
 3. Handling lifecycle events:
    - `onRpcRequest`: Processes incoming JSON-RPC requests with origin validation

--- a/packages/gator-permissions-snap/src/index.ts
+++ b/packages/gator-permissions-snap/src/index.ts
@@ -174,11 +174,11 @@ const rpcHandler = createRpcHandler({
 const boundRpcHandlers: {
   [RpcMethod: string]: (params?: JsonRpcParams) => Promise<Json>;
 } = {
-  [RpcMethod.PermissionProviderGrantPermissions]:
+  [RpcMethod.PermissionsProviderGrantPermissions]:
     rpcHandler.grantPermission.bind(rpcHandler),
-  [RpcMethod.PermissionProviderGetPermissionOffers]:
+  [RpcMethod.PermissionsProviderGetPermissionOffers]:
     rpcHandler.getPermissionOffers.bind(rpcHandler),
-  [RpcMethod.PermissionProviderGetGrantedPermissions]:
+  [RpcMethod.PermissionsProviderGetGrantedPermissions]:
     rpcHandler.getGrantedPermissions.bind(rpcHandler),
 };
 

--- a/packages/gator-permissions-snap/src/rpc/permissions.ts
+++ b/packages/gator-permissions-snap/src/rpc/permissions.ts
@@ -5,11 +5,11 @@ const allowedPermissionsByOrigin: { [origin: string]: string[] } = {
   ...(process.env.KERNEL_SNAP_ID && {
     // eslint-disable-next-line no-restricted-globals
     [process.env.KERNEL_SNAP_ID]: [
-      RpcMethod.PermissionProviderGrantPermissions,
-      RpcMethod.PermissionProviderGetPermissionOffers,
+      RpcMethod.PermissionsProviderGrantPermissions,
+      RpcMethod.PermissionsProviderGetPermissionOffers,
     ],
   }),
-  metamask: [RpcMethod.PermissionProviderGetGrantedPermissions],
+  metamask: [RpcMethod.PermissionsProviderGetGrantedPermissions],
 };
 
 /**

--- a/packages/gator-permissions-snap/src/rpc/rpcMethod.ts
+++ b/packages/gator-permissions-snap/src/rpc/rpcMethod.ts
@@ -5,15 +5,15 @@ export enum RpcMethod {
   /**
    * This method is used by the kernel to request a permissions provider to get its permission offers.
    */
-  PermissionProviderGetPermissionOffers = 'permissionProvider_getPermissionOffers',
+  PermissionsProviderGetPermissionOffers = 'permissionsProvider_getPermissionOffers',
 
   /**
    * This method is used by the kernel to request a permissions provider to grant attenuated permissions to a site.
    */
-  PermissionProviderGrantPermissions = 'permissionProvider_grantPermissions',
+  PermissionsProviderGrantPermissions = 'permissionsProvider_grantPermissions',
 
   /**
    * This method is used by Metamask clients to retrieve granted permissions for all sites.
    */
-  PermissionProviderGetGrantedPermissions = 'permissionProvider_getGrantedPermissions',
+  PermissionsProviderGetGrantedPermissions = 'permissionsProvider_getGrantedPermissions',
 }

--- a/packages/gator-permissions-snap/test/end-to-end/index.test.tsx
+++ b/packages/gator-permissions-snap/test/end-to-end/index.test.tsx
@@ -32,13 +32,13 @@ describe('Kernel Snap', () => {
 
       it('throws an error if the origin is not metamask for getGrantedPermissions', async () => {
         const response = await snapRequest({
-          method: 'permissionProvider_getGrantedPermissions',
+          method: 'permissionsProvider_getGrantedPermissions',
           origin: 'npm:@metamask/not-metamask',
         });
 
         expect(response).toRespondWithError({
           code: -32600,
-          message: `Origin 'npm:@metamask/not-metamask' is not allowed to call 'permissionProvider_getGrantedPermissions'`,
+          message: `Origin 'npm:@metamask/not-metamask' is not allowed to call 'permissionsProvider_getGrantedPermissions'`,
           stack: expect.any(String),
         });
       });

--- a/packages/permissions-kernel-snap/docs/ephemeralPermissionsOfferRegistry.md
+++ b/packages/permissions-kernel-snap/docs/ephemeralPermissionsOfferRegistry.md
@@ -16,17 +16,17 @@ sequenceDiagram
   participant DApp
   participant KernelSnap
   participant List of permission provider snapIds
-  participant PermissionProviderSnap
+  participant PermissionsProviderSnap
 
   DApp->>KernelSnap: wallet_requestExecutionPermissions(request)
   KernelSnap->>List of permission provider snapIds: Fetch list of all permission provider snaps
 
   loop For each snap
-    KernelSnap->>PermissionProviderSnap: permissions_offerPermissions()
+    KernelSnap->>PermissionsProviderSnap: permissions_offerPermissions()
     alt Snap supports RPC
-      PermissionProviderSnap-->>KernelSnap: Valid permission offers
+      PermissionsProviderSnap-->>KernelSnap: Valid permission offers
     else RPC unsupported or invalid
-      PermissionProviderSnap-->>KernelSnap: Error or invalid response
+      PermissionsProviderSnap-->>KernelSnap: Error or invalid response
     end
   end
 
@@ -35,8 +35,8 @@ sequenceDiagram
   KernelSnap->>KernelSnap: Filter offers matching requested permissions
 
   loop For each matched permission
-    KernelSnap->>PermissionProviderSnap: Forward permission request
-    PermissionProviderSnap-->>KernelSnap: Attenuated permission response
+    KernelSnap->>PermissionsProviderSnap: Forward permission request
+    PermissionsProviderSnap-->>KernelSnap: Attenuated permission response
   end
 
   KernelSnap-->>DApp: Return aggregated granted permissions
@@ -45,8 +45,8 @@ sequenceDiagram
 **Steps**
 
 1. DApp calls `wallet_requestExecutionPermissions` on the Kernel Snap.
-2. Kernel makes async RPC calls to all registered permission provider snaps using `permissionProvider_getPermissionOffers` to fetch permission offers.
-   1. A standard `permissionProvider_getPermissionOffers` rpc must be implemented by the permission provider snap to participate in the permission system.
+2. Kernel makes async RPC calls to all registered permission provider snaps using `permissionsProvider_getPermissionOffers` to fetch permission offers.
+   1. A standard `permissionsProvider_getPermissionOffers` rpc must be implemented by the permission provider snap to participate in the permission system.
       1. If the permission provider snap returns with an error, it does not support the RPC and will not participate in the permission system.
       2. If the permission provider snap returns an invalid result, it will not participate in the permission system.
 3. The kernel will aggregate all valid responses from the permission provider snap as an in-memory registry.
@@ -59,12 +59,12 @@ sequenceDiagram
 
 ### **The requirement for permission provider snaps to opt into the permission system**
 
-1. Support `permissionProvider_getPermissionOffers` RPC
-2. Support `permissionProvider_grantPermissions` RPC to allow the kernel to forward `wallet_grantPermission` payload.
+1. Support `permissionsProvider_getPermissionOffers` RPC
+2. Support `permissionsProvider_grantPermissions` RPC to allow the kernel to forward `wallet_grantPermission` payload.
 
 ### **The requirement to leave the permission system**
 
-1. The permission provider snap will no longer return a valid response for the `permissionProvider_getPermissionOffers` RPC.
+1. The permission provider snap will no longer return a valid response for the `permissionsProvider_getPermissionOffers` RPC.
    1. Opt-out can be implemented as an update to the developer's permission provider snap or through more dynamic solutions that support HTTPS network calls to toggle support.
 
 ### **Known Bottlenecks**

--- a/packages/permissions-kernel-snap/src/registryManager.ts
+++ b/packages/permissions-kernel-snap/src/registryManager.ts
@@ -61,11 +61,11 @@ export const createPermissionOfferRegistryManager = (
   }
 
   /**
-   * Discovers and builds the permission provider registry by querying all permission provider snaps
+   * Discovers and builds the permissions provider registry by querying all permissions provider snaps
    * for their permission offers.
    *
    * @param snapId - The snap id to query for permission offers.
-   * @returns The permission provider registry.
+   * @returns The permissions provider registry.
    */
   async function buildPermissionOffersRegistry(
     snapId: string,
@@ -80,7 +80,7 @@ export const createPermissionOfferRegistryManager = (
           params: {
             snapId,
             request: {
-              method: ExternalMethod.PermissionProviderGetPermissionOffers,
+              method: ExternalMethod.PermissionsProviderGetPermissionOffers,
             },
           },
         });
@@ -102,12 +102,12 @@ export const createPermissionOfferRegistryManager = (
           };
 
           logger.debug(
-            `Snap ${snapId} supports ${ExternalMethod.PermissionProviderGetPermissionOffers}, adding to registry...`,
+            `Snap ${snapId} supports ${ExternalMethod.PermissionsProviderGetPermissionOffers}, adding to registry...`,
           );
         }
       } catch (error) {
         logger.error(
-          `Snap ${snapId} does not support ${ExternalMethod.PermissionProviderGetPermissionOffers}, or returned an invalid response, skipping...`,
+          `Snap ${snapId} does not support ${ExternalMethod.PermissionsProviderGetPermissionOffers}, or returned an invalid response, skipping...`,
         );
       }
 
@@ -172,7 +172,7 @@ export const createPermissionOfferRegistryManager = (
       return {
         permissionsToGrant: [],
         missingPermissions,
-        errorMessage: `The following permissions can not be granted by the permission provider: ${missingPermissions.map((permission) => permission.permission.type).join(', ')}`,
+        errorMessage: `The following permissions can not be granted by the permissions provider: ${missingPermissions.map((permission) => permission.permission.type).join(', ')}`,
       };
     }
 

--- a/packages/permissions-kernel-snap/src/rpc/rpcHandler.ts
+++ b/packages/permissions-kernel-snap/src/rpc/rpcHandler.ts
@@ -97,7 +97,7 @@ export function createRpcHandler(config: {
       params: {
         snapId: gatorPermissionsProviderSnapId, // We only want gator-permissions-snap for now but we will use more snaps in the future
         request: {
-          method: ExternalMethod.PermissionProviderGrantPermissions,
+          method: ExternalMethod.PermissionsProviderGrantPermissions,
           params: {
             permissionsRequest: permissionsToGrant,
             siteOrigin: options.siteOrigin,

--- a/packages/permissions-kernel-snap/src/rpc/rpcMethod.ts
+++ b/packages/permissions-kernel-snap/src/rpc/rpcMethod.ts
@@ -12,10 +12,10 @@ export enum ExternalMethod {
   /**
    * This method is used by the kernel to request a permissions provider to get its permission offers.
    */
-  PermissionProviderGetPermissionOffers = 'permissionProvider_getPermissionOffers',
+  PermissionsProviderGetPermissionOffers = 'permissionsProvider_getPermissionOffers',
 
   /**
    * This method is used by the kernel to request a permissions provider to grant attenuated permissions to a site.
    */
-  PermissionProviderGrantPermissions = 'permissionProvider_grantPermissions',
+  PermissionsProviderGrantPermissions = 'permissionsProvider_grantPermissions',
 }

--- a/packages/permissions-kernel-snap/test/registryManager.test.ts
+++ b/packages/permissions-kernel-snap/test/registryManager.test.ts
@@ -43,7 +43,7 @@ describe('PermissionOfferRegistryManager', () => {
         params: {
           snapId: mockSnapId,
           request: {
-            method: ExternalMethod.PermissionProviderGetPermissionOffers,
+            method: ExternalMethod.PermissionsProviderGetPermissionOffers,
           },
         },
       });
@@ -209,7 +209,7 @@ describe('PermissionOfferRegistryManager', () => {
       expect(result.permissionsToGrant).toStrictEqual([]);
       expect(result.missingPermissions).toStrictEqual(mockPermissionsToGrant);
       expect(result.errorMessage).toBe(
-        'The following permissions can not be granted by the permission provider: native-token-transfer, native-token-stream',
+        'The following permissions can not be granted by the permissions provider: native-token-transfer, native-token-stream',
       );
     });
 

--- a/packages/permissions-kernel-snap/test/rpc/rpc.test.ts
+++ b/packages/permissions-kernel-snap/test/rpc/rpc.test.ts
@@ -48,7 +48,7 @@ describe('RpcHandler', () => {
       },
     ];
 
-    it('should throw error when permission provider does not support all requested permissions', async () => {
+    it('should throw error when permissions provider does not support all requested permissions', async () => {
       const mockPartialPermissions: PermissionsRequest = [
         {
           chainId: '0x1',
@@ -87,7 +87,7 @@ describe('RpcHandler', () => {
             mockPartialPermissions[1],
           ] as unknown as PermissionsRequest,
           errorMessage:
-            'The following permissions can not be granted by the permission provider: native-token-stream',
+            'The following permissions can not be granted by the permissions provider: native-token-stream',
         },
       );
 
@@ -97,7 +97,7 @@ describe('RpcHandler', () => {
           params: mockPartialPermissions as unknown as Json,
         }),
       ).rejects.toThrow(
-        'The following permissions can not be granted by the permission provider: native-token-stream',
+        'The following permissions can not be granted by the permissions provider: native-token-stream',
       );
     });
 
@@ -161,7 +161,7 @@ describe('RpcHandler', () => {
           // eslint-disable-next-line no-restricted-globals
           snapId: process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID,
           request: {
-            method: ExternalMethod.PermissionProviderGrantPermissions,
+            method: ExternalMethod.PermissionsProviderGrantPermissions,
             params: {
               permissionsRequest: mockPermissions,
               siteOrigin,
@@ -172,7 +172,7 @@ describe('RpcHandler', () => {
       expect(result).toStrictEqual(mockGrantedPermissions);
     });
 
-    it('should handle errors thrown during call to permission provider when granting permissions', async () => {
+    it('should handle errors thrown during call to permissions provider when granting permissions', async () => {
       mockPermissionOfferRegistryManager.buildPermissionOffersRegistry.mockResolvedValue(
         {
           'test-provider': [],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixed inconsistent naming convention for RPC method names across the codebase. Changed all instances of `permissionProvider` to `permissionsProvider` to maintain consistency.

The codebase had mixed naming where some methods used `permissionProvider_` (singular) while others used `permissionsProvider_` (plural). This standardizes all RPC method names to use the plural `permissionsProvider_` prefix.

## **Related issues**

Fixes: https://app.zenhub.com/workspaces/readable-permissions-67982ce51eb4360029b2c1a1/issues/gh/metamask/delegator-readable-permissions/388

## **Manual testing steps**
1. Run the test suite: `yarn test`
2. Build the project: `yarn build`
3. Verify all RPC methods work correctly with the updated naming

## **Pre-merge author checklist**

- [x] I've followed MetaMask 7715 Permissions Snaps Contributor Docs and Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (updated existing test references)
- [x] I've documented my code using JSDoc format if applicable

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.