### PR TITLE
Remove npx from site

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -8,7 +8,7 @@
     "build": "GATSBY_TELEMETRY_DISABLED=1 gatsby build",
     "clean": "rimraf public",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
-    "lint:eslint": "npx eslint . --cache --ext js,ts",
+    "lint:eslint": "yarn eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
     "start": "GATSBY_TELEMETRY_DISABLED=1 gatsby develop"


### PR DESCRIPTION
## **Description**

Removes usage of npx which introduces supply chain risk, by downloading and executing npm packages.

## **Related issues**

https://github.com/MetaMask/snap-7715-permissions/security/code-scanning/3

## **Manual testing steps**

Run `yarn lint:eslint` in the site package. No change should be observed.