### PR TITLE
feat: Add the wallet connect button to the site

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -146,6 +146,7 @@ const Index = () => {
   const [value, setValue] = useState<bigint>(0n);
   const [receipt, setReceipt] = useState<UserOperationReceipt | null>(null);
   const [pendingPermissionRequests, setPendingPermissionRequests] = useState<Set<string>>(new Set());
+  const [isWalletConnected, setIsWalletConnected] = useState(false);
 
   const handleChainChange = ({
     target: { value: inputValue },
@@ -328,6 +329,18 @@ const Index = () => {
     },
     [],
   );
+
+  const connectWallet = async () => {
+    await provider?.request({
+      method: 'wallet_requestPermissions',
+      params: [
+        {
+          eth_accounts: {},
+        },
+      ],
+    });
+    setIsWalletConnected(true);
+  };
 
   return (
     <Container>
@@ -550,6 +563,21 @@ const Index = () => {
                 onClick={requestPermissionSnap}
                 disabled={!isMetaMaskReady}
                 $isReconnect={isGatorSnapReady}
+              />
+            ),
+          }}
+          disabled={!isMetaMaskReady}
+        />
+
+        <Card
+          content={{
+            title: `${isWalletConnected ? 'Reconnect' : 'Connect'}(wallet)`,
+            description: 'Connect to your wallet to the site',
+            button: (
+              <ConnectButton
+                onClick={connectWallet}
+                disabled={!isMetaMaskReady}
+                $isReconnect={isWalletConnected}
               />
             ),
           }}

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -331,15 +331,20 @@ const Index = () => {
   );
 
   const connectWallet = async () => {
-    await provider?.request({
-      method: 'wallet_requestPermissions',
-      params: [
-        {
-          eth_accounts: {},
-        },
-      ],
-    });
-    setIsWalletConnected(true);
+    try {
+      await provider?.request({
+        method: 'wallet_requestPermissions',
+        params: [
+          {
+            eth_accounts: {},
+          },
+        ],
+      });
+      setIsWalletConnected(true);
+    } catch (error) {
+      console.error('Failed to connect wallet: ', error);
+      setIsWalletConnected(false);
+    }
   };
 
   return (
@@ -572,7 +577,7 @@ const Index = () => {
         <Card
           content={{
             title: `${isWalletConnected ? 'Reconnect' : 'Connect'}(wallet)`,
-            description: 'Connect to your wallet to the site',
+            description: 'Connect your wallet to the site.',
             button: (
               <ConnectButton
                 onClick={connectWallet}

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -321,7 +321,10 @@ const Index = () => {
 
   const connectWallet = async () => {
     try {
-      await provider?.request({
+      if (!provider) {
+        throw new Error('Provider not found');
+      }
+      await provider.request({
         method: 'wallet_requestPermissions',
         params: [
           {


### PR DESCRIPTION
## **Description**

The demo site does not allow connecting to MM extension via the legacy `wallet_requestPermissions` connection flow. 

This PR adds a wallet connection button to the site as needed to test the rendering of gator permissions(see Related issues) on exiting the MM extension's `all permission` site connection page.

## **Related issues**

Required by: [feat: Show gator permissions on existing review permissions page](https://github.com/MetaMask/metamask-extension/pull/35846) to complete e2e recording of feature.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c3b631a8d707505bc380d9eb6f044dede7446e43. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->