### PR TITLE
Add chain metadata for supported testnets

### DIFF
--- a/packages/gator-permissions-snap/src/core/chainMetadata.ts
+++ b/packages/gator-permissions-snap/src/core/chainMetadata.ts
@@ -52,10 +52,15 @@ const metadataByChainId: Record<number, ChainMetadata> = {
     explorerUrl: 'https://etherscan.io',
   },
   // Testnets:
-  11155111: {
+  97: {
     contracts: CONTRACTS_1_3_0,
-    name: 'Sepolia Testnet',
-    explorerUrl: 'https://sepolia.etherscan.io',
+    name: 'BNB Smart Chain Testnet',
+    explorerUrl: 'https://testnet.bscscan.com',
+  },
+  1301: {
+    contracts: CONTRACTS_1_3_0,
+    name: 'Unichain Sepolia Testnet',
+    explorerUrl: 'https://sepolia.uniscan.xyz',
   },
   5115: {
     contracts: CONTRACTS_1_3_0,
@@ -72,25 +77,15 @@ const metadataByChainId: Record<number, ChainMetadata> = {
     name: 'Gnosis Chiado Testnet',
     explorerUrl: 'https://gnosis-chiado.blockscout.com',
   },
+  80002: {
+    contracts: CONTRACTS_1_3_0,
+    name: 'Polygon Amoy Testnet',
+    explorerUrl: 'https://amoy.polygonscan.com/',
+  },
   80069: {
     contracts: CONTRACTS_1_3_0,
     name: 'Berachain Bepolia Testnet',
     explorerUrl: 'https://bepolia.beratrail.io',
-  },
-  11155420: {
-    contracts: CONTRACTS_1_3_0,
-    name: 'OP Sepolia Testnet',
-    explorerUrl: 'https://sepolia-optimism.etherscan.io',
-  },
-  763373: {
-    contracts: CONTRACTS_1_3_0,
-    name: 'Ink Sepolia Testnet',
-    explorerUrl: 'https://explorer-sepolia.inkonchain.com',
-  },
-  97: {
-    contracts: CONTRACTS_1_3_0,
-    name: 'BNB Smart Chain Testnet',
-    explorerUrl: 'https://testnet.bscscan.com',
   },
   84532: {
     contracts: CONTRACTS_1_3_0,
@@ -102,15 +97,20 @@ const metadataByChainId: Record<number, ChainMetadata> = {
     name: 'Arbitrum Sepolia Testnet',
     explorerUrl: 'https://sepolia.arbiscan.io',
   },
-  1301: {
+  763373: {
     contracts: CONTRACTS_1_3_0,
-    name: 'Unichain Sepolia Testnet',
-    explorerUrl: 'https://sepolia.uniscan.xyz',
+    name: 'Ink Sepolia Testnet',
+    explorerUrl: 'https://explorer-sepolia.inkonchain.com',
   },
-  80002: {
+  11155111: {
     contracts: CONTRACTS_1_3_0,
-    name: 'Polygon Amoy Testnet',
-    explorerUrl: 'https://amoy.polygonscan.com/',
+    name: 'Sepolia Testnet',
+    explorerUrl: 'https://sepolia.etherscan.io',
+  },
+  11155420: {
+    contracts: CONTRACTS_1_3_0,
+    name: 'OP Sepolia Testnet',
+    explorerUrl: 'https://sepolia-optimism.etherscan.io',
   },
 };
 


### PR DESCRIPTION
## **Description**

Adds metadata for supported testnets. Expected chains:

- bscTestnet
- citreaTestnet
- megaEthTestnet
- chiado
- berachainBepolia
- baseSepolia
- arbitrumSepolia
- sepolia
- optimismSepolia
- unichainSepolia
- polygonAmoy
- inkSepolia

Updated build configuration here https://github.com/MetaMask/snap-7715-permissions/settings/variables/actions/SUPPORTED_CHAINS

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.