### PR TITLE
Add hideSnapBranding flag to preinstalled snap manifest

### DIFF
--- a/packages/gator-permissions-snap/scripts/build-preinstalled-snap.js
+++ b/packages/gator-permissions-snap/scripts/build-preinstalled-snap.js
@@ -55,6 +55,7 @@ const preinstalledSnap = {
     },
   ],
   removable: false,
+  hideSnapBranding: true,
 };
 
 // Write preinstalled-snap file

--- a/packages/permissions-kernel-snap/scripts/build-preinstalled-snap.js
+++ b/packages/permissions-kernel-snap/scripts/build-preinstalled-snap.js
@@ -55,6 +55,7 @@ const preinstalledSnap = {
     },
   ],
   removable: false,
+  hideSnapBranding: true,
 };
 
 // Write preinstalled-snap file


### PR DESCRIPTION
## **Description**

Adds the `hideSnapBranding: true` flag to preinstalled snap manifest for both snaps.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.