### PR TITLE
Fix profile sync unauthorized issue

### DIFF
--- a/packages/gator-permissions-snap/snap.manifest.ts
+++ b/packages/gator-permissions-snap/snap.manifest.ts
@@ -7,7 +7,7 @@ const kernelSnapId = process.env.KERNEL_SNAP_ID;
 const messageSnapId = process.env.MESSAGE_SIGNING_SNAP_ID;
 const snapEnv = process.env.SNAP_ENV;
 const manifest: SnapManifest = {
-  version: '0.2.1',
+  version: '0.3.0',
   description: 'Grants 7715 permissions from a DeleGator smart account',
   proposedName: 'Gator Permissions',
   repository: {

--- a/packages/gator-permissions-snap/snap.manifest.ts
+++ b/packages/gator-permissions-snap/snap.manifest.ts
@@ -5,7 +5,7 @@ import type { SnapManifest } from '@metamask/7715-permissions-shared/types';
 
 const kernelSnapId = process.env.KERNEL_SNAP_ID;
 const messageSnapId = process.env.MESSAGE_SIGNING_SNAP_ID;
-
+const snapEnv = process.env.SNAP_ENV;
 const manifest: SnapManifest = {
   version: '0.2.1',
   description: 'Grants 7715 permissions from a DeleGator smart account',
@@ -45,6 +45,11 @@ if (kernelSnapId) {
     ...(kernelSnapId ? { [kernelSnapId]: {} } : {}),
     ...(messageSnapId ? { [messageSnapId]: {} } : {}),
   };
+}
+
+if (snapEnv === 'local') {
+  // Grant lifecycle hooks permission in local development environment
+  manifest.initialPermissions['endowment:lifecycle-hooks'] = {};
 }
 
 export default manifest;

--- a/packages/gator-permissions-snap/snap.manifest.ts
+++ b/packages/gator-permissions-snap/snap.manifest.ts
@@ -4,6 +4,7 @@
 import type { SnapManifest } from '@metamask/7715-permissions-shared/types';
 
 const kernelSnapId = process.env.KERNEL_SNAP_ID;
+const messageSnapId = process.env.MESSAGE_SIGNING_SNAP_ID;
 
 const manifest: SnapManifest = {
   version: '0.2.1',
@@ -41,7 +42,8 @@ const manifest: SnapManifest = {
 
 if (kernelSnapId) {
   manifest.initialConnections = {
-    [kernelSnapId]: {},
+    ...(kernelSnapId ? { [kernelSnapId]: {} } : {}),
+    ...(messageSnapId ? { [messageSnapId]: {} } : {}),
   };
 }
 

--- a/packages/gator-permissions-snap/snap.manifest.ts
+++ b/packages/gator-permissions-snap/snap.manifest.ts
@@ -3,11 +3,14 @@
 
 import type { SnapManifest } from '@metamask/7715-permissions-shared/types';
 
+// eslint-disable-next-line import/no-relative-packages
+import packageJson from './package.json' with { type: 'json' };
+
 const kernelSnapId = process.env.KERNEL_SNAP_ID;
 const messageSnapId = process.env.MESSAGE_SIGNING_SNAP_ID;
 const snapEnv = process.env.SNAP_ENV;
 const manifest: SnapManifest = {
-  version: '0.3.0',
+  version: packageJson.version,
   description: 'Grants 7715 permissions from a DeleGator smart account',
   proposedName: 'Gator Permissions',
   repository: {
@@ -48,7 +51,18 @@ if (kernelSnapId) {
 }
 
 if (snapEnv === 'local') {
-  // Grant lifecycle hooks permission in local development environment
+  /**
+   * Grant lifecycle hooks permission in local development environment.
+   *
+   * The lifecycle hooks endowment is required to enable the onInstall handler
+   * which automatically installs the message signing snap during local development.
+   * This ensures that the gator permissions snap can establish the necessary
+   * connection to the message signing snap for 7715 permissions functionality.
+   *
+   * In production environments, the message signing snap is pre-installed by
+   * the MetaMask extension, making this endowment unnecessary and it's excluded
+   * to minimize the snap's permission footprint.
+   */
   manifest.initialPermissions['endowment:lifecycle-hooks'] = {};
 }
 

--- a/packages/gator-permissions-snap/src/index.ts
+++ b/packages/gator-permissions-snap/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-globals */
+import type { GetSnapsResponse } from '@metamask/7715-permissions-shared/types';
 import { logger } from '@metamask/7715-permissions-shared/utils';
 import {
   AuthType,
@@ -7,14 +8,16 @@ import {
   UserStorage,
 } from '@metamask/profile-sync-controller/sdk';
 import {
-  type Json,
-  type JsonRpcParams,
-  type OnRpcRequestHandler,
-  type OnUserInputHandler,
   MethodNotFoundError,
   InvalidRequestError,
   InternalError,
+} from '@metamask/snaps-sdk';
+import type {
   OnInstallHandler,
+  Json,
+  JsonRpcParams,
+  OnRpcRequestHandler,
+  OnUserInputHandler,
 } from '@metamask/snaps-sdk';
 
 import { AccountApiClient } from './clients/accountApiClient';
@@ -38,7 +41,6 @@ import { TokenMetadataService } from './services/tokenMetadataService';
 import { TokenPricesService } from './services/tokenPricesService';
 import { createStateManager } from './stateManagement';
 import { UserEventDispatcher } from './userEventDispatcher';
-import { GetSnapsResponse } from '@metamask/7715-permissions-shared/types';
 
 const isStorePermissionsFeatureEnabled =
   process.env.STORE_PERMISSIONS_ENABLED === 'true';
@@ -240,6 +242,7 @@ export const onInstall: OnInstallHandler = async () => {
    *
    * Since the message signing snap is preinstalled in production, and has
    * initialConnections configured to automatically connect to the gator snap, this is not needed in production.
+   * The following code will be tree-shaken out in production builds.
    */
   // eslint-disable-next-line no-restricted-globals
   if (snapEnv === 'local' && isStorePermissionsFeatureEnabled) {

--- a/packages/permissions-kernel-snap/snap.manifest.ts
+++ b/packages/permissions-kernel-snap/snap.manifest.ts
@@ -5,7 +5,7 @@ import type { SnapManifest } from '@metamask/7715-permissions-shared/types';
 const gatorSnapId = process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
 
 const manifest: SnapManifest = {
-  version: '0.2.0',
+  version: '0.3.0',
   description: 'Manage onchain 7715 permissions',
   proposedName: 'MetaMask Permissions Kernel',
   repository: {

--- a/packages/permissions-kernel-snap/snap.manifest.ts
+++ b/packages/permissions-kernel-snap/snap.manifest.ts
@@ -2,10 +2,11 @@
 /* eslint-disable no-restricted-globals */
 import type { SnapManifest } from '@metamask/7715-permissions-shared/types';
 
-const gatorSnapId = process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
+// eslint-disable-next-line import/no-relative-packages
+import packageJson from './package.json' with { type: 'json' };
 
 const manifest: SnapManifest = {
-  version: '0.3.0',
+  version: packageJson.version,
   description: 'Manage onchain 7715 permissions',
   proposedName: 'MetaMask Permissions Kernel',
   repository: {
@@ -32,11 +33,5 @@ const manifest: SnapManifest = {
   platformVersion: '8.1.0',
   manifestVersion: '0.1',
 };
-
-if (gatorSnapId) {
-  manifest.initialConnections = {
-    [gatorSnapId]: {},
-  };
-}
 
 export default manifest;

--- a/packages/permissions-kernel-snap/snap.manifest.ts
+++ b/packages/permissions-kernel-snap/snap.manifest.ts
@@ -1,5 +1,8 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable no-restricted-globals */
 import type { SnapManifest } from '@metamask/7715-permissions-shared/types';
+
+const gatorSnapId = process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
 
 const manifest: SnapManifest = {
   version: '0.2.0',
@@ -29,5 +32,11 @@ const manifest: SnapManifest = {
   platformVersion: '8.1.0',
   manifestVersion: '0.1',
 };
+
+if (gatorSnapId) {
+  manifest.initialConnections = {
+    [gatorSnapId]: {},
+  };
+}
 
 export default manifest;

--- a/packages/site/src/components/Buttons.tsx
+++ b/packages/site/src/components/Buttons.tsx
@@ -94,17 +94,6 @@ export const ConnectButton = (
   );
 };
 
-export const InstallButton = (
-  props: ComponentProps<typeof Button> & { $isInstalled?: boolean },
-) => {
-  return (
-    <Button {...props}>
-      <FlaskFox />
-      <ButtonText>{props.$isInstalled ? 'Installed' : 'Install'}</ButtonText>
-    </Button>
-  );
-};
-
 export const CustomMessageButton = (
   props: ComponentProps<typeof Button> & { $text?: string },
 ) => {

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -14,7 +14,6 @@ import * as chains from 'viem/chains';
 
 import {
   ConnectButton,
-  InstallButton,
   InstallFlaskButton,
   CustomMessageButton,
   Card,
@@ -33,11 +32,7 @@ import type {
   NativeTokenPeriodicPermissionRequest,
   ERC20TokenPeriodicPermissionRequest,
 } from '../components/permissions/types';
-import {
-  kernelSnapOrigin,
-  gatorSnapOrigin,
-  messageSigningSnapOrigin,
-} from '../config';
+import { kernelSnapOrigin, gatorSnapOrigin } from '../config';
 import {
   useMetaMask,
   useMetaMaskContext,
@@ -98,7 +93,6 @@ const Index = () => {
   const { isFlask, snapsDetected, installedSnaps, provider } = useMetaMask();
   const requestKernelSnap = useRequestSnap(kernelSnapOrigin);
   const requestPermissionSnap = useRequestSnap(gatorSnapOrigin);
-  const requestMessageSigningSnap = useRequestSnap(messageSigningSnapOrigin);
 
   const { delegateAccount } = useDelegateAccount({ chain: selectedChain });
   const { bundlerClient, getFeePerGas } = useBundlerClient({
@@ -122,9 +116,6 @@ const Index = () => {
 
   const isKernelSnapReady = Boolean(installedSnaps[kernelSnapOrigin]);
   const isGatorSnapReady = Boolean(installedSnaps[gatorSnapOrigin]);
-  const isMessageSigningSnapReady = Boolean(
-    installedSnaps[messageSigningSnapOrigin],
-  );
 
   const chainId = selectedChain.id;
   const [permissionType, setPermissionType] = useState('native-token-stream');
@@ -495,23 +486,6 @@ const Index = () => {
             fullWidth
           />
         )}
-
-        <Card
-          content={{
-            title: 'Message Signing Snap',
-            description:
-              'Set up by installing and authorizing the message signing snap.',
-            button: (
-              <InstallButton
-                onClick={requestMessageSigningSnap}
-                disabled={!isMetaMaskReady || isMessageSigningSnapReady}
-                $isInstalled={isMessageSigningSnapReady}
-              />
-            ),
-          }}
-          fullWidth
-          disabled={!isMetaMaskReady}
-        />
 
         <Card
           content={{


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

I found that if `wallet_requestSnaps` is called inside the Gato snap’s lifecycle function to add the local message signing snap, it will add the Gato snap to the message signing snap’s connections.  
However, if `wallet_requestSnaps` is called from the site to add the local message signing snap, the connections are determined only by the message signing snap’s `snap.manifest.json`. In that file, the Gato snap ID is `npm:@metamask/gator-permissions-snap`, not `local:http://localhost:8082`, which causes an unauthorized issue.  

This PR fixes the issue by:
- Using `snapEnv === 'local'` to detect development mode.
- In development mode, automatically installing the local message signing snap.
- In production mode, leveraging Webpack’s tree-shaking so that the related dev-only code is removed from the production output.
- Ensuring `endowment:lifecycle-hooks` is not added to `snap.manifest.json` in production builds.

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Install the latest build of the Flask extension from the `metamask-extension` repo.  
2. Ensure the **Snaps** page in the extension is empty (no snaps installed).  
3. In **development mode** (`snapEnv === 'local'`):
   - Verify that the local message signing snap is installed automatically.  
   - Confirm that the Gato snap is listed as a connection under the message signing snap (check in the extension’s Snaps page).  
   - Ensure no unauthorized connection error occurs.  
4. In **production mode** (`snapEnv === 'production'`):
   - Confirm that the local message signing snap is **not** installed (check in the extension’s Snaps page).  
   - Verify that the code for installing the local snap is removed from the build output.  
   - Ensure `endowment:lifecycle-hooks` is not present in the generated `snap.manifest.json`.  
   - Ensure no unauthorized connection error occurs.  




## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

## snapEnv === 'local'

<img width="735" height="366" alt="image" src="https://github.com/user-attachments/assets/3195ebbc-169f-45d5-b899-41819f51d3d7" />

## snap === 'production'

<img width="723" height="270" alt="image" src="https://github.com/user-attachments/assets/0233a062-10a1-4b01-bf38-d02317914141" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-installs the local message signing snap in dev via lifecycle hook, reads snap versions from package.json, adds conditional connections/permissions, and removes the site UI for manually installing the message signing snap.
> 
> - **Gator Permissions Snap**:
>   - **Lifecycle install (dev-only)**: Adds `onInstall` to auto-install the local message signing snap when `snapEnv === 'local'` and feature flag enabled.
>   - **Manifest**:
>     - Version sourced from `package.json`.
>     - Conditional `initialConnections` for `KERNEL_SNAP_ID` and `MESSAGE_SIGNING_SNAP_ID`.
>     - Grants `endowment:lifecycle-hooks` only in local dev.
> - **Permissions Kernel Snap**:
>   - Manifest version sourced from `package.json`.
> - **Site (UI)**:
>   - Removes message signing snap install flow (button, imports, state, and card) and related origin usage.
>   - Keeps kernel/provider connect flows unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61cf238ec3a8bbeb44dcbe9a04c4ceb8f22269b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->