### PR TITLE
Improve request validation

### DIFF
--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -1,5 +1,5 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
-import { extractPermissionName } from '@metamask/7715-permissions-shared/utils';
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
 import type { AccountController } from './accountController';
@@ -63,7 +63,7 @@ export class PermissionHandlerFactory {
   createPermissionHandler(
     permissionRequest: PermissionRequest,
   ): PermissionHandlerType {
-    const type = extractPermissionName(permissionRequest.permission.type);
+    const type = extractDescriptorName(permissionRequest.permission.type);
 
     const createPermissionHandler = <
       TRequest extends PermissionRequest,

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -3,7 +3,10 @@ import type {
   PermissionRequest,
   PermissionResponse,
 } from '@metamask/7715-permissions-shared/types';
-import { logger } from '@metamask/7715-permissions-shared/utils';
+import {
+  extractDescriptorName,
+  logger,
+} from '@metamask/7715-permissions-shared/utils';
 import type { Delegation } from '@metamask/delegation-core';
 import {
   createNonceTerms,
@@ -355,7 +358,7 @@ export class PermissionRequestLifecycleOrchestrator {
     });
 
     const expiryRule = resolvedRequest.rules?.find(
-      (rule) => rule.type === 'expiry',
+      (rule) => extractDescriptorName(rule.type) === 'expiry',
     );
 
     if (expiryRule) {

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/context.ts
@@ -1,3 +1,4 @@
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 import {
   bigIntToHex,
@@ -55,7 +56,7 @@ export async function applyContext({
 
   const rules: Erc20TokenPeriodicPermissionRequest['rules'] =
     originalRequest.rules?.map((rule) => {
-      if (rule.type === 'expiry') {
+      if (extractDescriptorName(rule.type) === 'expiry') {
         isExpiryRuleFound = true;
         return {
           ...rule,
@@ -157,7 +158,7 @@ export async function buildContext({
     : null;
 
   const expiryRule = permissionRequest.rules?.find(
-    (rule) => rule.type === 'expiry',
+    (rule) => extractDescriptorName(rule.type) === 'expiry',
   );
 
   if (!expiryRule) {

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/types.ts
@@ -3,6 +3,8 @@ import {
   zPermission,
   zMetaMaskPermissionData,
   zAddress,
+  zTimestamp,
+  zStartTime,
 } from '@metamask/7715-permissions-shared/types';
 import { z } from 'zod';
 
@@ -13,7 +15,6 @@ import type {
   TimePeriod,
   BaseMetadata,
 } from '../../core/types';
-import { validateStartTimeZod } from '../../utils/validate';
 
 export type Erc20TokenPeriodicMetadata = BaseMetadata & {
   validationErrors: {
@@ -40,24 +41,8 @@ export const zErc20TokenPeriodicPermission = zPermission.extend({
     zMetaMaskPermissionData,
     z.object({
       periodAmount: zHexStr,
-      periodDuration: z.number().int().positive(),
-      startTime: z
-        .number()
-        .int()
-        .positive()
-        .nullable()
-        .optional()
-        .refine(
-          (value) => {
-            if (value === undefined || value === null) {
-              return true;
-            }
-            return validateStartTimeZod(value);
-          },
-          {
-            message: 'Start time must be today or later',
-          },
-        ),
+      periodDuration: zTimestamp,
+      startTime: zStartTime,
       tokenAddress: zAddress,
     }),
   ),

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/validation.ts
@@ -2,7 +2,7 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
-import { validateHexInteger } from '../validation';
+import { validateHexInteger, validateStartTime } from '../validation';
 import type {
   Erc20TokenPeriodicPermission,
   Erc20TokenPeriodicPermissionRequest,
@@ -29,18 +29,7 @@ function validatePermissionData(
     allowZero: false,
   });
 
-  const expiryRule = rules?.find((rule) => rule.type === 'expiry');
-
-  if (!expiryRule) {
-    throw new InvalidInputError('Expiry rule is required');
-  }
-
-  const expiry = Number(expiryRule.data.timestamp);
-
-  // If startTime is not provided it default to Date.now(), expiry is always in the future so no need to check.
-  if (startTime && startTime >= expiry) {
-    throw new InvalidInputError('Invalid startTime: must be before expiry');
-  }
+  validateStartTime(startTime, rules);
 
   return true;
 }

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -176,7 +176,7 @@ export async function buildContext({
     : null;
 
   const expiryRule = permissionRequest.rules?.find(
-    (rule) => rule.type === 'expiry',
+    (rule) => extractDescriptorName(rule.type) === 'expiry',
   );
 
   if (!expiryRule) {

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/context.ts
@@ -1,3 +1,4 @@
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 import {
   bigIntToHex,
@@ -58,7 +59,7 @@ export async function applyContext({
 
   const rules: Erc20TokenStreamPermissionRequest['rules'] =
     originalRequest.rules?.map((rule) => {
-      if (rule.type === 'expiry') {
+      if (extractDescriptorName(rule.type) === 'expiry') {
         isExpiryRuleFound = true;
         return {
           ...rule,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/types.ts
@@ -3,6 +3,8 @@ import {
   zPermission,
   zMetaMaskPermissionData,
   zAddress,
+  zStartTime,
+  zHexStrNullableOptional,
 } from '@metamask/7715-permissions-shared/types';
 import { z } from 'zod';
 
@@ -13,7 +15,6 @@ import type {
   BaseContext,
   BaseMetadata,
 } from '../../core/types';
-import { validateStartTimeZod } from '../../utils/validate';
 
 export type Erc20TokenStreamMetadata = BaseMetadata & {
   amountPerSecond: string;
@@ -41,26 +42,10 @@ export const zErc20TokenStreamPermission = zPermission.extend({
   data: z.intersection(
     zMetaMaskPermissionData,
     z.object({
-      initialAmount: zHexStr.optional().nullable(),
-      maxAmount: zHexStr.optional().nullable(),
+      initialAmount: zHexStrNullableOptional,
+      maxAmount: zHexStrNullableOptional,
       amountPerSecond: zHexStr,
-      startTime: z
-        .number()
-        .int()
-        .positive()
-        .nullable()
-        .optional()
-        .refine(
-          (value) => {
-            if (value === undefined || value === null) {
-              return true;
-            }
-            return validateStartTimeZod(value);
-          },
-          {
-            message: 'Start time must be today or later',
-          },
-        ),
+      startTime: zStartTime,
       tokenAddress: zAddress,
     }),
   ),

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
@@ -2,7 +2,7 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
-import { validateHexInteger } from '../validation';
+import { validateHexInteger, validateStartTime } from '../validation';
 import type {
   Erc20TokenStreamPermission,
   Erc20TokenStreamPermissionRequest,
@@ -50,18 +50,7 @@ function validatePermissionData(
     );
   }
 
-  const expiryRule = rules?.find((rule) => rule.type === 'expiry');
-
-  if (!expiryRule) {
-    throw new InvalidInputError('Expiry rule is required');
-  }
-
-  const expiry = Number(expiryRule.data.timestamp);
-
-  // If startTime is not provided it default to Date.now(), expiry is always in the future so no need to check.
-  if (startTime && startTime >= expiry) {
-    throw new InvalidInputError('Invalid startTime: must be before expiry');
-  }
+  validateStartTime(startTime, rules);
 
   return true;
 }

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -1,3 +1,4 @@
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 import {
   bigIntToHex,
@@ -56,7 +57,7 @@ export async function applyContext({
 
   const rules: NativeTokenPeriodicPermissionRequest['rules'] =
     originalRequest.rules?.map((rule) => {
-      if (rule.type === 'expiry') {
+      if (extractDescriptorName(rule.type) === 'expiry') {
         isExpiryRuleFound = true;
         return {
           ...rule,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/context.ts
@@ -158,7 +158,7 @@ export async function buildContext({
     : null;
 
   const expiryRule = permissionRequest.rules?.find(
-    (rule) => rule.type === 'expiry',
+    (rule) => extractDescriptorName(rule.type) === 'expiry',
   );
 
   if (!expiryRule) {

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/types.ts
@@ -2,6 +2,8 @@ import {
   zHexStr,
   zPermission,
   zMetaMaskPermissionData,
+  zTimestamp,
+  zStartTime,
 } from '@metamask/7715-permissions-shared/types';
 import { z } from 'zod';
 
@@ -12,7 +14,6 @@ import type {
   TimePeriod,
   BaseMetadata,
 } from '../../core/types';
-import { validateStartTimeZod } from '../../utils/validate';
 
 export type NativeTokenPeriodicMetadata = BaseMetadata & {
   validationErrors: {
@@ -39,24 +40,8 @@ export const zNativeTokenPeriodicPermission = zPermission.extend({
     zMetaMaskPermissionData,
     z.object({
       periodAmount: zHexStr,
-      periodDuration: z.number().int().positive(),
-      startTime: z
-        .number()
-        .int()
-        .positive()
-        .nullable()
-        .optional()
-        .refine(
-          (value) => {
-            if (value === undefined || value === null) {
-              return true;
-            }
-            return validateStartTimeZod(value);
-          },
-          {
-            message: 'Start time must be today or later',
-          },
-        ),
+      periodDuration: zTimestamp,
+      startTime: zStartTime,
     }),
   ),
 });

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/validation.ts
@@ -2,7 +2,7 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
-import { validateHexInteger } from '../validation';
+import { validateHexInteger, validateStartTime } from '../validation';
 import type {
   NativeTokenPeriodicPermission,
   NativeTokenPeriodicPermissionRequest,
@@ -29,16 +29,7 @@ function validatePermissionData(
     allowZero: false,
   });
 
-  const expiryRule = rules?.find((rule) => rule.type === 'expiry');
-  if (!expiryRule) {
-    throw new InvalidInputError('Expiry rule is required');
-  }
-  const expiry = Number(expiryRule.data.timestamp);
-
-  // If startTime is not provided it default to Date.now(), expiry is always in the future so no need to check.
-  if (startTime && startTime >= expiry) {
-    throw new InvalidInputError('Invalid startTime: must be before expiry');
-  }
+  validateStartTime(startTime, rules);
 
   return true;
 }

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/context.ts
@@ -1,3 +1,4 @@
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 import {
   bigIntToHex,
@@ -59,7 +60,7 @@ export async function applyContext({
 
   const rules: NativeTokenStreamPermissionRequest['rules'] =
     originalRequest.rules?.map((rule) => {
-      if (rule.type === 'expiry') {
+      if (extractDescriptorName(rule.type) === 'expiry') {
         isExpiryRuleFound = true;
         return {
           ...rule,
@@ -172,7 +173,7 @@ export async function buildContext({
     : null;
 
   const expiryRule = permissionRequest.rules?.find(
-    (rule) => rule.type === 'expiry',
+    (rule) => extractDescriptorName(rule.type) === 'expiry',
   );
 
   if (!expiryRule) {

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/types.ts
@@ -2,6 +2,8 @@ import {
   zHexStr,
   zPermission,
   zMetaMaskPermissionData,
+  zStartTime,
+  zHexStrNullableOptional,
 } from '@metamask/7715-permissions-shared/types';
 import { z } from 'zod';
 
@@ -12,7 +14,6 @@ import type {
   BaseContext,
   BaseMetadata,
 } from '../../core/types';
-import { validateStartTimeZod } from '../../utils/validate';
 
 export type NativeTokenStreamMetadata = BaseMetadata & {
   amountPerSecond: string;
@@ -40,26 +41,10 @@ export const zNativeTokenStreamPermission = zPermission.extend({
   data: z.intersection(
     zMetaMaskPermissionData,
     z.object({
-      initialAmount: zHexStr.optional().nullable(),
-      maxAmount: zHexStr.optional().nullable(),
+      initialAmount: zHexStrNullableOptional,
+      maxAmount: zHexStrNullableOptional,
       amountPerSecond: zHexStr,
-      startTime: z
-        .number()
-        .int()
-        .positive()
-        .nullable()
-        .optional()
-        .refine(
-          (value) => {
-            if (value === undefined || value === null) {
-              return true;
-            }
-            return validateStartTimeZod(value);
-          },
-          {
-            message: 'Start time must be today or later',
-          },
-        ),
+      startTime: zStartTime,
     }),
   ),
 });

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/validation.ts
@@ -2,7 +2,7 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
-import { validateHexInteger } from '../validation';
+import { validateHexInteger, validateStartTime } from '../validation';
 import type {
   NativeTokenStreamPermission,
   NativeTokenStreamPermissionRequest,
@@ -50,16 +50,7 @@ function validatePermissionData(
     );
   }
 
-  const expiryRule = rules?.find((rule) => rule.type === 'expiry');
-  if (!expiryRule) {
-    throw new InvalidInputError('Expiry rule is required');
-  }
-  const expiry = Number(expiryRule.data.timestamp);
-
-  // If startTime is not provided it default to Date.now(), expiry is always in the future so no need to check.
-  if (startTime && startTime >= expiry) {
-    throw new InvalidInputError('Invalid startTime: must be before expiry');
-  }
+  validateStartTime(startTime, rules);
 
   return true;
 }

--- a/packages/gator-permissions-snap/src/permissions/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/validation.ts
@@ -1,3 +1,4 @@
+import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import type { Hex } from '@metamask/delegation-core';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
@@ -17,7 +18,7 @@ export function validateHexInteger({
   required,
 }: {
   name: string;
-  value: Hex | undefined;
+  value: Hex | undefined | null;
   allowZero: boolean;
   required: boolean;
 }) {
@@ -38,5 +39,29 @@ export function validateHexInteger({
 
   if (parsedValue === 0n && !allowZero) {
     throw new InvalidInputError(`Invalid ${name}: must be greater than 0`);
+  }
+}
+
+/**
+ * Validates a start time to ensure it's before expiry.
+ * @param startTime - The start time number to validate.
+ * @param rules - The rules of the permission request.
+ * @throws {Error} If the start time fails validation
+ */
+export function validateStartTime(
+  startTime: number | undefined | null,
+  rules: PermissionRequest['rules'],
+) {
+  const expiryRule = rules?.find((rule) => rule.type === 'expiry');
+  // expiry rule is validated by the zod schema, but we need the expiry in order
+  // to validate the startTime
+  if (!expiryRule) {
+    throw new InvalidInputError('Expiry rule is required');
+  }
+  const expiry = expiryRule.data.timestamp as number;
+
+  // If startTime is not provided it default to Date.now(), expiry is always in the future so no need to check.
+  if (startTime && startTime >= expiry) {
+    throw new InvalidInputError('Invalid startTime: must be before expiry');
   }
 }

--- a/packages/gator-permissions-snap/src/permissions/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/validation.ts
@@ -1,4 +1,5 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import type { Hex } from '@metamask/delegation-core';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
@@ -52,7 +53,9 @@ export function validateStartTime(
   startTime: number | undefined | null,
   rules: PermissionRequest['rules'],
 ) {
-  const expiryRule = rules?.find((rule) => rule.type === 'expiry');
+  const expiryRule = rules?.find(
+    (rule) => extractDescriptorName(rule.type) === 'expiry',
+  );
   // expiry rule is validated by the zod schema, but we need the expiry in order
   // to validate the startTime
   if (!expiryRule) {

--- a/packages/gator-permissions-snap/src/utils/validate.ts
+++ b/packages/gator-permissions-snap/src/utils/validate.ts
@@ -1,17 +1,15 @@
 import {
-  type GrantAttenuatedPermissionsParams,
-  zGrantAttenuatedPermissionsParams,
+  type RequestExecutionPermissionsParam,
+  zRequestExecutionPermissionsParam,
 } from '@metamask/7715-permissions-shared/types';
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
-import { getStartOfTodayLocal } from './time';
-
 export const validatePermissionRequestParam = (
-  params: any | any[],
-): GrantAttenuatedPermissionsParams => {
+  params: unknown,
+): RequestExecutionPermissionsParam => {
   const validateGrantAttenuatedPermissionsParams =
-    zGrantAttenuatedPermissionsParams.safeParse(params);
+    zRequestExecutionPermissionsParam.safeParse(params);
   if (!validateGrantAttenuatedPermissionsParams.success) {
     throw new InvalidInputError(
       extractZodError(validateGrantAttenuatedPermissionsParams.error.errors),
@@ -19,14 +17,4 @@ export const validatePermissionRequestParam = (
   }
 
   return validateGrantAttenuatedPermissionsParams.data;
-};
-
-/**
- * Zod validation for startTime to ensure it's today or later.
- * @param value - Unix timestamp in seconds.
- * @returns True if the start time is today or later, false otherwise.
- */
-export const validateStartTimeZod = (value: number): boolean => {
-  const startOfToday = getStartOfTodayLocal();
-  return value >= startOfToday;
 };

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenPeriodic/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenPeriodic/validation.test.ts
@@ -52,6 +52,17 @@ describe('erc20TokenPeriodic:validation', () => {
       expect(result).toStrictEqual(validPermissionRequest);
     });
 
+    it('should throw for missing expiry', () => {
+      const missingExpiryRequest = {
+        ...validPermissionRequest,
+        rules: [],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(missingExpiryRequest as any),
+      ).toThrow('Expiry rule is required');
+    });
+
     it('should throw for invalid permission type', () => {
       const invalidTypeRequest = {
         ...validPermissionRequest,

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/validation.test.ts
@@ -55,6 +55,17 @@ describe('erc20TokenStream:validation', () => {
       expect(result).toStrictEqual(validPermissionRequest);
     });
 
+    it('should throw for missing expiry', () => {
+      const missingExpiryRequest = {
+        ...validPermissionRequest,
+        rules: [],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(missingExpiryRequest as any),
+      ).toThrow('Expiry rule is required');
+    });
+
     it('should throw for invalid permission type', () => {
       const invalidTypeRequest = {
         ...validPermissionRequest,

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/validation.test.ts
@@ -47,6 +47,17 @@ describe('nativeTokenPeriodic:validation', () => {
       expect(result).toStrictEqual(validPermissionRequest);
     });
 
+    it('should throw for missing expiry', () => {
+      const missingExpiryRequest = {
+        ...validPermissionRequest,
+        rules: [],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(missingExpiryRequest as any),
+      ).toThrow('Expiry rule is required');
+    });
+
     it('should throw for invalid permission type', () => {
       const invalidTypeRequest = {
         ...validPermissionRequest,

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/validation.test.ts
@@ -48,6 +48,17 @@ describe('nativeTokenStream:validation', () => {
       expect(result).toStrictEqual(validPermissionRequest);
     });
 
+    it('should throw for missing expiry', () => {
+      const missingExpiryRequest = {
+        ...validPermissionRequest,
+        rules: [],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(missingExpiryRequest as any),
+      ).toThrow('Expiry rule is required');
+    });
+
     it('should throw for invalid permission type', () => {
       const invalidTypeRequest = {
         ...validPermissionRequest,

--- a/packages/gator-permissions-snap/test/profileSync/profileSync.test.ts
+++ b/packages/gator-permissions-snap/test/profileSync/profileSync.test.ts
@@ -50,6 +50,14 @@ describe('profileSync', () => {
     signature: '0x2',
   };
 
+  const expiryRule = {
+    type: 'expiry',
+    isAdjustmentAllowed: false,
+    data: {
+      timestamp: 1234,
+    },
+  };
+
   const mockDelegationHash = hashDelegation(mockDelegation);
   const mockDelegationHashTwo = hashDelegation(mockDelegationTwo);
 
@@ -84,6 +92,7 @@ describe('profileSync', () => {
       signerMeta: {
         delegationManager: '0x1234567890123456789012345678901234567890',
       },
+      rules: [expiryRule],
     },
     siteOrigin: 'https://example.com',
   };
@@ -299,6 +308,7 @@ describe('profileSync', () => {
               signerMeta: {
                 delegationManager: '0x1234567890123456789012345678901234567890',
               },
+              rules: [expiryRule],
             },
             siteOrigin: 'https://example.com',
           },

--- a/packages/gator-permissions-snap/test/utils/validate.test.ts
+++ b/packages/gator-permissions-snap/test/utils/validate.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect } from '@jest/globals';
+import type {
+  PermissionRequest,
+  RequestExecutionPermissionsParam,
+} from '@metamask/7715-permissions-shared/types';
+import { InvalidInputError } from '@metamask/snaps-sdk';
+
+import { validatePermissionRequestParam } from '../../src/utils/validate';
+
+describe('validatePermissionRequestParam', () => {
+  const validPermissionRequest: PermissionRequest = {
+    chainId: '0x1',
+    address: '0x1234567890123456789012345678901234567890',
+    signer: {
+      type: 'account',
+      data: {
+        address: '0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD',
+      },
+    },
+    permission: {
+      type: 'native-token-recurring-allowance',
+      data: {
+        ticker: 'ETH',
+        amount: '0x16345785d8a0000',
+      },
+      isAdjustmentAllowed: true,
+    },
+    rules: [
+      {
+        type: 'expiry',
+        isAdjustmentAllowed: true,
+        data: {
+          timestamp: Math.floor(Date.now() / 1000) + 86400, // 1 day from now
+        },
+      },
+    ],
+  };
+
+  const validRequestParam: RequestExecutionPermissionsParam = {
+    permissionsRequest: [validPermissionRequest],
+    siteOrigin: 'https://example.com',
+  };
+
+  describe('valid cases', () => {
+    it('should validate a valid RequestExecutionPermissionsParam', () => {
+      expect(() => {
+        const result = validatePermissionRequestParam(validRequestParam);
+        expect(result).toStrictEqual(validRequestParam);
+      }).not.toThrow();
+    });
+
+    it('should validate with multiple permission requests', () => {
+      const multiplePermissionsParam = {
+        ...validRequestParam,
+        permissionsRequest: [validPermissionRequest, validPermissionRequest],
+      };
+
+      expect(() => {
+        const result = validatePermissionRequestParam(multiplePermissionsParam);
+        expect(result).toStrictEqual(multiplePermissionsParam);
+      }).not.toThrow();
+    });
+
+    it('should validate with optional address as null', () => {
+      const paramWithNullAddress = {
+        ...validRequestParam,
+        permissionsRequest: [
+          {
+            ...validPermissionRequest,
+            address: null,
+          },
+        ],
+      };
+
+      expect(() => {
+        const result = validatePermissionRequestParam(paramWithNullAddress);
+        expect(result).toStrictEqual(paramWithNullAddress);
+      }).not.toThrow();
+    });
+
+    it('should validate with optional address omitted', () => {
+      const { address, ...permissionWithoutAddress } = validPermissionRequest;
+      const paramWithoutAddress = {
+        ...validRequestParam,
+        permissionsRequest: [permissionWithoutAddress],
+      };
+
+      expect(() => {
+        const result = validatePermissionRequestParam(paramWithoutAddress);
+        expect(result).toStrictEqual(paramWithoutAddress);
+      }).not.toThrow();
+    });
+
+    it('should validate with ERC20 token permission', () => {
+      const erc20PermissionParam = {
+        ...validRequestParam,
+        permissionsRequest: [
+          {
+            ...validPermissionRequest,
+            permission: {
+              type: 'erc20-token-recurring-allowance',
+              isAdjustmentAllowed: true,
+              data: {
+                token: '0x1234567890123456789012345678901234567890',
+                amount: '0x16345785d8a0000',
+              },
+            },
+          },
+        ],
+      };
+
+      expect(() => {
+        const result = validatePermissionRequestParam(erc20PermissionParam);
+        expect(result).toStrictEqual(erc20PermissionParam);
+      }).not.toThrow();
+    });
+  });
+
+  describe('invalid cases', () => {
+    it('should throw InvalidInputError for null input', () => {
+      expect(() => {
+        validatePermissionRequestParam(null);
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for undefined input', () => {
+      expect(() => {
+        validatePermissionRequestParam(undefined);
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for empty object', () => {
+      expect(() => {
+        validatePermissionRequestParam({});
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for missing permissionsRequest', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for missing siteOrigin', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [validPermissionRequest],
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for invalid siteOrigin type', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [validPermissionRequest],
+          siteOrigin: 123,
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for missing chainId in permission request', () => {
+      const { chainId, ...invalidPermission } = validPermissionRequest;
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [invalidPermission],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for invalid chainId format', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [
+            {
+              ...validPermissionRequest,
+              chainId: 'invalid-chain-id',
+            },
+          ],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for missing signer', () => {
+      const { signer, ...invalidPermission } = validPermissionRequest;
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [invalidPermission],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for invalid signer type', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [
+            {
+              ...validPermissionRequest,
+              signer: {
+                type: 'invalid-type',
+                data: {
+                  address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+                },
+              },
+            },
+          ],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for missing permission', () => {
+      const { permission, ...invalidPermission } = validPermissionRequest;
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [invalidPermission],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for missing rules', () => {
+      const { rules, ...invalidPermission } = validPermissionRequest;
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [invalidPermission],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for rules without expiry rule', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [
+            {
+              ...validPermissionRequest,
+              rules: [
+                {
+                  type: 'allowance',
+                  isAdjustmentAllowed: true,
+                  data: {
+                    timestamp: Math.floor(Date.now() / 1000) + 86400,
+                  },
+                },
+              ],
+            },
+          ],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it.each([
+      { timestamp: 'the timestamp is not a number' },
+      'the data is not an object',
+      { timestamp: -1 },
+      { timestamp: 0 },
+      { timestamp: 0.1 },
+      { data: 1234 },
+    ])(
+      'should throw InvalidInputError for invalid expiry rule data %s',
+      (ruleData) => {
+        expect(() => {
+          validatePermissionRequestParam({
+            permissionsRequest: [
+              {
+                ...validPermissionRequest,
+                rules: [
+                  {
+                    type: 'expiry',
+                    isAdjustmentAllowed: true,
+                    data: ruleData,
+                  },
+                ],
+              },
+            ],
+            siteOrigin: 'https://example.com',
+          });
+        }).toThrow(InvalidInputError);
+      },
+    );
+
+    it('should throw InvalidInputError for duplicate rule types', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [
+            {
+              ...validPermissionRequest,
+              rules: [
+                {
+                  type: 'expiry',
+                  isAdjustmentAllowed: true,
+                  data: {
+                    timestamp: Math.floor(Date.now() / 1000) + 86400,
+                  },
+                },
+                {
+                  type: 'expiry',
+                  isAdjustmentAllowed: true,
+                  data: {
+                    timestamp: Math.floor(Date.now() / 1000) + 172800,
+                  },
+                },
+              ],
+            },
+          ],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for invalid address format', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [
+            {
+              ...validPermissionRequest,
+              address: 'invalid-address',
+            },
+          ],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for invalid signer address format', () => {
+      expect(() => {
+        validatePermissionRequestParam({
+          permissionsRequest: [
+            {
+              ...validPermissionRequest,
+              signer: {
+                type: 'account',
+                data: {
+                  address: 'invalid-address',
+                },
+              },
+            },
+          ],
+          siteOrigin: 'https://example.com',
+        });
+      }).toThrow(InvalidInputError);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should throw InvalidInputError for string input', () => {
+      expect(() => {
+        validatePermissionRequestParam('invalid string input');
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for number input', () => {
+      expect(() => {
+        validatePermissionRequestParam(123);
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for array input', () => {
+      expect(() => {
+        validatePermissionRequestParam([validRequestParam]);
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should throw InvalidInputError for boolean input', () => {
+      expect(() => {
+        validatePermissionRequestParam(true);
+      }).toThrow(InvalidInputError);
+    });
+
+    it('should return the validated data when successful', () => {
+      const result = validatePermissionRequestParam(validRequestParam);
+      expect(result).toStrictEqual(validRequestParam);
+      expect(result).toHaveProperty('permissionsRequest');
+      expect(result).toHaveProperty('siteOrigin');
+      expect(Array.isArray(result.permissionsRequest)).toBe(true);
+      expect(typeof result.siteOrigin).toBe('string');
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/utils/validate.test.ts
+++ b/packages/gator-permissions-snap/test/utils/validate.test.ts
@@ -114,6 +114,29 @@ describe('validatePermissionRequestParam', () => {
         expect(result).toStrictEqual(erc20PermissionParam);
       }).not.toThrow();
     });
+
+    it('should validate with expiry rule where the type descriptor is an object', () => {
+      const expiryRuleParam = {
+        ...validRequestParam,
+        permissionsRequest: [
+          {
+            ...validPermissionRequest,
+            rules: [
+              {
+                type: { name: 'expiry' },
+                isAdjustmentAllowed: true,
+                data: { timestamp: Math.floor(Date.now() / 1000) + 86400 },
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(() => {
+        const result = validatePermissionRequestParam(expiryRuleParam);
+        expect(result).toStrictEqual(expiryRuleParam);
+      }).not.toThrow();
+    });
   });
 
   describe('invalid cases', () => {

--- a/packages/permissions-kernel-snap/src/registryManager.ts
+++ b/packages/permissions-kernel-snap/src/registryManager.ts
@@ -8,7 +8,7 @@ import {
   type PermissionOfferRegistry,
 } from '@metamask/7715-permissions-shared/types';
 import {
-  extractPermissionName,
+  extractDescriptorName,
   extractZodError,
   logger,
 } from '@metamask/7715-permissions-shared/utils';
@@ -162,8 +162,8 @@ export const createPermissionOfferRegistryManager = (
       (permission) =>
         !allRegisteredOffers.some(
           (offer) =>
-            extractPermissionName(permission.permission.type) ===
-            extractPermissionName(offer.type),
+            extractDescriptorName(permission.permission.type) ===
+            extractDescriptorName(offer.type),
         ),
     );
 

--- a/packages/permissions-kernel-snap/test/constants.ts
+++ b/packages/permissions-kernel-snap/test/constants.ts
@@ -17,6 +17,15 @@ export const MOCK_PERMISSIONS_REQUEST_SINGLE: PermissionsRequest = [
         allowance: '0x1DCD6500',
       },
     },
+    rules: [
+      {
+        type: 'expiry',
+        isAdjustmentAllowed: true,
+        data: {
+          timestamp: 123456,
+        },
+      },
+    ],
   },
 ];
 
@@ -37,6 +46,15 @@ export const MOCK_PERMISSIONS_REQUEST_MULTIPLE: PermissionsRequest = [
         allowance: '0x1DCD6500',
       },
     },
+    rules: [
+      {
+        type: 'expiry',
+        isAdjustmentAllowed: true,
+        data: {
+          timestamp: 123456,
+        },
+      },
+    ],
   },
   {
     chainId: '0x1',
@@ -55,6 +73,15 @@ export const MOCK_PERMISSIONS_REQUEST_MULTIPLE: PermissionsRequest = [
         allowance: '0x1DCD6500',
       },
     },
+    rules: [
+      {
+        type: 'expiry',
+        isAdjustmentAllowed: true,
+        data: {
+          timestamp: 123456,
+        },
+      },
+    ],
   },
 ];
 
@@ -75,5 +102,14 @@ export const MOCK_PERMISSIONS_REQUEST_NON_SUPPORTED: PermissionsRequest = [
         allowance: '0x1DCD6500',
       },
     },
+    rules: [
+      {
+        type: 'expiry',
+        isAdjustmentAllowed: true,
+        data: {
+          timestamp: 123456,
+        },
+      },
+    ],
   },
 ];

--- a/packages/permissions-kernel-snap/test/end-to-end/index.test.tsx
+++ b/packages/permissions-kernel-snap/test/end-to-end/index.test.tsx
@@ -33,8 +33,14 @@ describe('Kernel Snap', () => {
 
       it('prevents prototype pollution attacks by rejecting prototype method names', async () => {
         // Test various prototype method names that could be used for prototype pollution
-        const prototypeMethods = ['toString', 'valueOf', 'constructor', 'hasOwnProperty', '__proto__'];
-        
+        const prototypeMethods = [
+          'toString',
+          'valueOf',
+          'constructor',
+          'hasOwnProperty',
+          '__proto__',
+        ];
+
         for (const method of prototypeMethods) {
           const response = await snapRequest({
             method,
@@ -82,7 +88,9 @@ describe('Kernel Snap', () => {
               }),
             ]),
           }),
-          message: expect.stringContaining('Invalid parameters for method "snapRpc": At path: 3.jsonrpc -- Expected the literal `"2.0"`, but received: "1.0"'),
+          message: expect.stringContaining(
+            'Invalid parameters for method "snapRpc": At path: 3.jsonrpc -- Expected the literal `"2.0"`, but received: "1.0"',
+          ),
           stack: expect.any(String),
         });
       });
@@ -105,7 +113,7 @@ describe('Kernel Snap', () => {
           jsonrpc: '2.0',
           method: 'wallet_requestExecutionPermissions',
           params: {
-            '__proto__': 'malicious',
+            __proto__: 'malicious',
             normalKey: 'value',
           },
         } as any);
@@ -123,7 +131,7 @@ describe('Kernel Snap', () => {
           method: 'wallet_requestExecutionPermissions',
           params: {
             normalKey: {
-              '__proto__': 'malicious',
+              __proto__: 'malicious',
             },
           },
         } as any);
@@ -186,6 +194,13 @@ describe('Kernel Snap', () => {
                   allowance: '0x1000',
                 },
               },
+              rules: [
+                {
+                  type: 'expiry',
+                  isAdjustmentAllowed: true,
+                  data: { timestamp: 123456 },
+                },
+              ],
             },
           ],
         };

--- a/packages/permissions-kernel-snap/test/rpc/rpc.test.ts
+++ b/packages/permissions-kernel-snap/test/rpc/rpc.test.ts
@@ -45,6 +45,15 @@ describe('RpcHandler', () => {
             allowance: '0x1000',
           },
         },
+        rules: [
+          {
+            type: 'expiry',
+            isAdjustmentAllowed: true,
+            data: {
+              timestamp: 123456,
+            },
+          },
+        ],
       },
     ];
 
@@ -66,6 +75,15 @@ describe('RpcHandler', () => {
               allowance: '0x1000',
             },
           },
+          rules: [
+            {
+              type: 'expiry',
+              isAdjustmentAllowed: true,
+              data: {
+                timestamp: 123456,
+              },
+            },
+          ],
         },
       ];
 
@@ -119,6 +137,15 @@ describe('RpcHandler', () => {
               allowance: '0x1000',
             },
           },
+          rules: [
+            {
+              type: 'expiry',
+              isAdjustmentAllowed: true,
+              data: {
+                timestamp: 123456,
+              },
+            },
+          ],
           address: '0x1234567890123456789012345678901234567890',
           context: '0x1',
           dependencyInfo: [

--- a/packages/permissions-kernel-snap/test/utils/validate.test.ts
+++ b/packages/permissions-kernel-snap/test/utils/validate.test.ts
@@ -74,6 +74,15 @@ describe('validate utils', () => {
               allowed: true,
             },
           },
+          rules: [
+            {
+              type: 'expiry',
+              isAdjustmentAllowed: true,
+              data: {
+                timestamp: 123456,
+              },
+            },
+          ],
           context: '0x1234',
           dependencyInfo: [
             {
@@ -97,6 +106,15 @@ describe('validate utils', () => {
           {
             chainId: '0x1',
             // Missing permission object
+            rules: [
+              {
+                type: 'expiry',
+                isAdjustmentAllowed: true,
+                data: {
+                  timestamp: 123456,
+                },
+              },
+            ],
           },
         ]),
       ).toThrow(

--- a/packages/shared/src/types/7715-permissions-request.ts
+++ b/packages/shared/src/types/7715-permissions-request.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { zPermission, zRule } from './7715-permissions-types';
 import { zAddress, zHexStr } from './common';
+import { extractDescriptorName } from '../utils';
 
 export const zAccountSigner = z.object({
   type: z.literal('account'),
@@ -54,7 +55,9 @@ export const zPermissionRequest = z.object({
    */
   rules: z.array(zRule).refine(
     (rules) => {
-      const hasExpiryRule = rules.some((rule) => rule.type === 'expiry');
+      const hasExpiryRule = rules.some(
+        (rule) => extractDescriptorName(rule.type) === 'expiry',
+      );
 
       if (!hasExpiryRule) {
         return false;

--- a/packages/shared/src/types/7715-permissions-request.ts
+++ b/packages/shared/src/types/7715-permissions-request.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { zPermission, zRule } from './7715-permissions-types';
+import { zPermission, zRule, zTimestamp } from './7715-permissions-types';
 import { zAddress, zHexStr } from './common';
 import { extractDescriptorName } from '../utils';
 
@@ -63,7 +63,7 @@ export const zPermissionRequest = z.object({
         return false;
       }
 
-      const ruleTypes = rules.map((rule) => rule.type);
+      const ruleTypes = rules.map((rule) => extractDescriptorName(rule.type));
 
       const uniqueRuleTypes = new Set(ruleTypes);
       if (uniqueRuleTypes.size !== ruleTypes.length) {
@@ -94,11 +94,6 @@ export const zRequestExecutionPermissionsParam = z.object({
 export type RequestExecutionPermissionsParam = z.infer<
   typeof zRequestExecutionPermissionsParam
 >;
-
-/**
- * A timestamp in seconds.
- */
-export const zTimestamp = z.number().int().positive();
 
 /**
  * Zod validation for startTime to ensure it's today or later.

--- a/packages/shared/src/types/7715-permissions-request.ts
+++ b/packages/shared/src/types/7715-permissions-request.ts
@@ -52,22 +52,81 @@ export const zPermissionRequest = z.object({
   /**
    * Defines the allowed behavior the signer can do on behalf of the account.
    */
-  rules: z.array(zRule).optional().nullable(),
+  rules: z.array(zRule).refine(
+    (rules) => {
+      const hasExpiryRule = rules.some((rule) => rule.type === 'expiry');
+
+      if (!hasExpiryRule) {
+        return false;
+      }
+
+      const ruleTypes = rules.map((rule) => rule.type);
+
+      const uniqueRuleTypes = new Set(ruleTypes);
+      if (uniqueRuleTypes.size !== ruleTypes.length) {
+        return false;
+      }
+
+      return true;
+    },
+    {
+      message: 'Failed rule validation: Expiry rule is missing or invalid',
+    },
+  ),
 });
 export const zPermissionsRequest = z.array(zPermissionRequest);
 
 export type PermissionRequest = z.infer<typeof zPermissionRequest>;
 export type PermissionsRequest = z.infer<typeof zPermissionsRequest>;
 
-export const zGrantAttenuatedPermissionsParams = z.object({
+export const zRequestExecutionPermissionsParam = z.object({
   permissionsRequest: zPermissionsRequest,
   siteOrigin: z.string(),
 });
 
 /**
- * This is the parameters for the grantAttenuatedPermissions method.
+ * This is the parameters for the requestExecutionPermissions method.
  * It is used by the kernel to forward request to permission provider snaps.
  */
-export type GrantAttenuatedPermissionsParams = z.infer<
-  typeof zGrantAttenuatedPermissionsParams
+export type RequestExecutionPermissionsParam = z.infer<
+  typeof zRequestExecutionPermissionsParam
 >;
+
+/**
+ * A timestamp in seconds.
+ */
+export const zTimestamp = z.number().int().positive();
+
+/**
+ * Zod validation for startTime to ensure it's today or later.
+ * @param value - Unix timestamp in seconds.
+ * @returns True if the start time is today or later, false otherwise.
+ */
+const validateStartTimeZod = (value: number): boolean => {
+  const now = new Date();
+  const startOfTodayLocal = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    0,
+    0,
+    0,
+  );
+
+  return value >= Math.floor(startOfTodayLocal.getTime() / 1000);
+};
+
+export const zStartTime = zTimestamp
+  .nullable()
+  .optional()
+  .refine(
+    (value) => {
+      if (value === undefined || value === null) {
+        return true;
+      }
+      return validateStartTimeZod(value);
+    },
+    {
+      message: 'Start time must be today or later',
+    },
+  );

--- a/packages/shared/src/types/7715-permissions-types.ts
+++ b/packages/shared/src/types/7715-permissions-types.ts
@@ -1,6 +1,5 @@
 import { any, z } from 'zod';
 
-import { zTimestamp } from './7715-permissions-request';
 import { extractDescriptorName } from '../utils';
 
 // Rather than only define permissions by name,
@@ -27,6 +26,11 @@ export const zPermission = z.object({
    */
   data: z.record(any()),
 });
+
+/**
+ * A timestamp in seconds.
+ */
+export const zTimestamp = z.number().int().positive();
 
 export const zRule = z
   .object({

--- a/packages/shared/src/types/7715-permissions-types.ts
+++ b/packages/shared/src/types/7715-permissions-types.ts
@@ -1,6 +1,7 @@
 import { any, z } from 'zod';
 
 import { zTimestamp } from './7715-permissions-request';
+import { extractDescriptorName } from '../utils';
 
 // Rather than only define permissions by name,
 // Requestors can optionally make this an object and leave room for forward-extensibility.
@@ -8,7 +9,7 @@ export const zTypeDescriptor = z.union([
   z.string(),
   z.object({
     name: z.string(),
-    description: z.string(),
+    description: z.string().optional(),
   }),
 ]);
 export type TypeDescriptor = z.infer<typeof zTypeDescriptor>;
@@ -43,7 +44,7 @@ export const zRule = z
   })
   .refine((rule) => {
     // Rules are generally free-form, but expiry is a special case.
-    if (rule.type === 'expiry') {
+    if (extractDescriptorName(rule.type) === 'expiry') {
       return zTimestamp.safeParse(rule.data.timestamp).success;
     }
 

--- a/packages/shared/src/types/7715-permissions-types.ts
+++ b/packages/shared/src/types/7715-permissions-types.ts
@@ -1,6 +1,6 @@
 import { any, z } from 'zod';
 
-import { zAddress, zHexStr } from './common';
+import { zTimestamp } from './7715-permissions-request';
 
 // Rather than only define permissions by name,
 // Requestors can optionally make this an object and leave room for forward-extensibility.
@@ -27,19 +27,28 @@ export const zPermission = z.object({
   data: z.record(any()),
 });
 
-export const zRule = z.object({
-  type: zTypeDescriptor,
+export const zRule = z
+  .object({
+    type: zTypeDescriptor,
 
-  /**
-   * Whether the rule can be adjusted
-   */
-  isAdjustmentAllowed: z.boolean(),
+    /**
+     * Whether the rule can be adjusted
+     */
+    isAdjustmentAllowed: z.boolean(),
 
-  /**
-   * Data structure varies by rule type.
-   */
-  data: z.record(any()),
-});
+    /**
+     * Data structure varies by rule type.
+     */
+    data: z.record(z.string(), z.any()),
+  })
+  .refine((rule) => {
+    // Rules are generally free-form, but expiry is a special case.
+    if (rule.type === 'expiry') {
+      return zTimestamp.safeParse(rule.data.timestamp).success;
+    }
+
+    return true;
+  });
 
 /**
  * Default message for when no justification is provided
@@ -128,59 +137,4 @@ export const zMetaMaskPermissionData = z.object({
   justification: zSanitizedJustification,
 });
 
-export const zNativeTokenTransferPermission = zPermission.extend({
-  type: z.literal('native-token-transfer'),
-  data: z.intersection(
-    zMetaMaskPermissionData,
-    z.object({
-      allowance: zHexStr,
-    }),
-  ),
-});
-
-export const zErc20TokenTransferPermission = zPermission.extend({
-  type: z.literal('erc20-token-transfer'),
-  data: z.intersection(
-    zMetaMaskPermissionData,
-    z.object({
-      address: zAddress,
-      allowance: zHexStr,
-    }),
-  ),
-});
-
-export const zErc721TokenTransferPermission = zPermission.extend({
-  type: z.literal('erc721-token-transfer'),
-  data: z.intersection(
-    zMetaMaskPermissionData,
-    z.object({
-      address: zAddress,
-      tokenIds: z.array(zHexStr),
-    }),
-  ),
-});
-
-export const zErc1155TokenTransferPermission = zPermission.extend({
-  type: z.literal('erc1155-token-transfer'),
-  data: z.intersection(
-    zMetaMaskPermissionData,
-    z.object({
-      address: zAddress,
-      allowances: z.record(zHexStr),
-    }),
-  ),
-});
-
-export type NativeTokenTransferPermission = z.infer<
-  typeof zNativeTokenTransferPermission
->;
-export type Erc20TokenTransferPermission = z.infer<
-  typeof zErc20TokenTransferPermission
->;
-export type Erc721TokenTransferPermission = z.infer<
-  typeof zErc721TokenTransferPermission
->;
-export type Erc1155TokenTransferPermission = z.infer<
-  typeof zErc1155TokenTransferPermission
->;
 export type Permission = z.infer<typeof zPermission>;

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -18,4 +18,5 @@ export const zHexStr = z
     return value as Hex;
   });
 
+export const zHexStrNullableOptional = zHexStr.optional().nullable();
 export const zBigInt = z.bigint();

--- a/packages/shared/src/utils/common.ts
+++ b/packages/shared/src/utils/common.ts
@@ -6,7 +6,7 @@ import type { TypeDescriptor } from '../types';
  * @param type - The type of permission to extract the name from.
  * @returns The name of the permission.
  */
-export const extractPermissionName = (type: TypeDescriptor): string => {
+export const extractDescriptorName = (type: TypeDescriptor): string => {
   if (typeof type === 'object') {
     return type.name;
   }


### PR DESCRIPTION
## **Description**

Presently, an expiry rule is required. Providing an invalid expiry may pass validation, but cause failures downstream. This PR adds thorough validation of the expiry rule, and deduplicates some of the validation shared between the different permission types.

Adds validation for rules
- must include a valid `expiry` rule
- may not include duplicate rule types
Improves overall validation with:
- shared `zTimestamp` schema
- shared `zHexStrNullableOptional` schema
- shared `validateStartTime` function
- test coverage for `packages/gator-permissions-snap/test/utils/validate.test.ts`


## **Related issues**

Fixes:

## **Manual testing steps**

Request a permission with a non integer expiry.

Before:
- Permission Picker dialog is shown
- "External accounts cannot sign delegations" error is returned once granted

After:
- Permission request is rejected immediately

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

note: I think there's some additional validation that is implemented in each permission that could be pulled out and shared, but I think that it's not urgent, and it could be picked up when / if we build a Permission "Property" library, where every permission type can just be a collection of pre-defined properties, and we can remove the majority if boilerplate 🎉 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces a valid `expiry` rule with no duplicates, centralizes shared validation (timestamps, startTime, hex), adopts `extractDescriptorName`, and updates tests and types accordingly.
> 
> - **Validation & Rules**:
>   - Require `rules` to include a valid `expiry` and disallow duplicate rule types via `zRule`/`zPermissionRequest` refinement.
>   - Add shared validators: `zTimestamp`, `zStartTime`, `zHexStrNullableOptional`, and `validateStartTime(startTime, rules)`; use across periodic/stream permissions.
> - **APIs & Types**:
>   - Introduce `RequestExecutionPermissionsParam` (replacing `GrantAttenuatedPermissionsParams`).
>   - Switch utility to `extractDescriptorName` everywhere (rules and permissions matching).
> - **Gator Permissions Snap**:
>   - Update contexts/validation to use descriptor-based rule matching and shared startTime checks.
>   - Minor hex validation accepts null where appropriate.
> - **Kernel Snap**:
>   - Registry matching uses descriptor names; tests updated to include `rules` with `expiry`.
> - **Tests**:
>   - Add comprehensive param validation tests and extend existing tests to cover expiry presence/validity and startTime rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9114d0d33cec594b7bdf39d60f52982d6fe3d901. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->