### PR TITLE
feat: upgrade account to smart account

### DIFF
--- a/packages/gator-permissions-snap/src/core/accountController.ts
+++ b/packages/gator-permissions-snap/src/core/accountController.ts
@@ -10,6 +10,9 @@ import {
 } from '@metamask/snaps-sdk';
 import { bigIntToHex, hexToNumber, numberToHex } from '@metamask/utils';
 
+import { getChainMetadata } from './chainMetadata';
+import type { SignDelegationOptions } from './types';
+
 export type AccountUpgradeStatus = {
   isUpgraded: boolean;
 };
@@ -22,9 +25,6 @@ export type AccountUpgradeParams = {
   account: string;
   chainId: number;
 };
-
-import { getChainMetadata } from './chainMetadata';
-import type { SignDelegationOptions } from './types';
 
 /**
  * Controls EOA account operations including address retrieval, delegation signing, and balance queries.
@@ -188,7 +188,9 @@ export class AccountController {
    * @param params - The account and chain ID to check.
    * @returns Promise resolving to the upgrade status.
    */
-  public async getAccountUpgradeStatus(params: AccountUpgradeParams): Promise<AccountUpgradeStatus> {
+  public async getAccountUpgradeStatus(
+    params: AccountUpgradeParams,
+  ): Promise<AccountUpgradeStatus> {
     logger.debug('AccountController:getAccountUpgradeStatus()', params);
 
     try {
@@ -213,7 +215,9 @@ export class AccountController {
    * @param params - The account and chain ID to upgrade.
    * @returns Promise resolving to the upgrade result with transaction hash.
    */
-  public async upgradeAccount(params: AccountUpgradeParams): Promise<AccountUpgradeResult> {
+  public async upgradeAccount(
+    params: AccountUpgradeParams,
+  ): Promise<AccountUpgradeResult> {
     logger.debug('AccountController:upgradeAccount()', params);
 
     try {
@@ -225,9 +229,14 @@ export class AccountController {
       logger.debug('Account upgrade result', result);
 
       // The result should contain a transaction hash
-      if (typeof result === 'object' && result !== null && 'transactionHash' in result) {
+      if (
+        typeof result === 'object' &&
+        result !== null &&
+        'transactionHash' in result
+      ) {
         return {
-          transactionHash: (result as { transactionHash: string }).transactionHash,
+          transactionHash: (result as { transactionHash: string })
+            .transactionHash,
         };
       }
 

--- a/packages/gator-permissions-snap/src/core/accountController.ts
+++ b/packages/gator-permissions-snap/src/core/accountController.ts
@@ -2,12 +2,26 @@ import { logger } from '@metamask/7715-permissions-shared/utils';
 import { type Hex, type Delegation } from '@metamask/delegation-core';
 import {
   ChainDisconnectedError,
+  InternalError,
   ResourceNotFoundError,
   ResourceUnavailableError,
   type SnapsEthereumProvider,
   type SnapsProvider,
 } from '@metamask/snaps-sdk';
 import { bigIntToHex, hexToNumber, numberToHex } from '@metamask/utils';
+
+export type AccountUpgradeStatus = {
+  isUpgraded: boolean;
+};
+
+export type AccountUpgradeResult = {
+  transactionHash: string;
+};
+
+export type AccountUpgradeParams = {
+  account: string;
+  chainId: number;
+};
 
 import { getChainMetadata } from './chainMetadata';
 import type { SignDelegationOptions } from './types';
@@ -167,5 +181,60 @@ export class AccountController {
     const message = { ...delegation, salt: bigIntToHex(delegation.salt) };
 
     return { domain, types, primaryType, message, metadata };
+  }
+
+  /**
+   * Checks if the account is already upgraded to a smart account.
+   * @param params - The account and chain ID to check.
+   * @returns Promise resolving to the upgrade status.
+   */
+  public async getAccountUpgradeStatus(params: AccountUpgradeParams): Promise<AccountUpgradeStatus> {
+    logger.debug('AccountController:getAccountUpgradeStatus()', params);
+
+    try {
+      const result = await this.#ethereumProvider.request({
+        method: 'wallet_getAccountUpgradeStatus',
+        params: [params],
+      });
+
+      logger.debug('Account upgrade status result', result);
+
+      return {
+        isUpgraded: (result as { isUpgraded?: boolean })?.isUpgraded ?? false,
+      };
+    } catch (error) {
+      logger.error('Failed to check account upgrade status', error);
+      throw new InternalError('Failed to check account upgrade status');
+    }
+  }
+
+  /**
+   * Upgrades the account to a smart account.
+   * @param params - The account and chain ID to upgrade.
+   * @returns Promise resolving to the upgrade result with transaction hash.
+   */
+  public async upgradeAccount(params: AccountUpgradeParams): Promise<AccountUpgradeResult> {
+    logger.debug('AccountController:upgradeAccount()', params);
+
+    try {
+      const result = await this.#ethereumProvider.request({
+        method: 'wallet_upgradeAccount',
+        params: [params],
+      });
+
+      logger.debug('Account upgrade result', result);
+
+      // The result should contain a transaction hash
+      if (typeof result === 'object' && result !== null && 'transactionHash' in result) {
+        return {
+          transactionHash: (result as { transactionHash: string }).transactionHash,
+        };
+      }
+
+      throw new Error('Invalid upgrade result: missing transaction hash');
+    } catch (error) {
+      logger.error('Failed to upgrade account', error);
+      throw new InternalError('Failed to upgrade account');
+    }
   }
 }

--- a/packages/gator-permissions-snap/src/core/permissionHandler.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandler.ts
@@ -211,7 +211,15 @@ export class PermissionHandler<
       const {
         justification,
         tokenMetadata: { symbol: tokenSymbol },
+        accountAddressCaip10,
       } = context;
+
+      // Check account upgrade status
+      const { address } = parseCaipAccountId(accountAddressCaip10);
+      const accountUpgradeStatus = await this.#accountController.getAccountUpgradeStatus({
+        account: address,
+        chainId,
+      });
 
       return PermissionHandlerContent({
         origin,
@@ -227,6 +235,7 @@ export class PermissionHandler<
         tokenBalanceFiat: this.#tokenBalanceFiat,
         chainId,
         explorerUrl,
+        isAccountUpgraded: accountUpgradeStatus.isUpgraded,
       });
     };
 

--- a/packages/gator-permissions-snap/src/core/permissionHandler.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandler.ts
@@ -216,10 +216,11 @@ export class PermissionHandler<
 
       // Check account upgrade status
       const { address } = parseCaipAccountId(accountAddressCaip10);
-      const accountUpgradeStatus = await this.#accountController.getAccountUpgradeStatus({
-        account: address,
-        chainId,
-      });
+      const accountUpgradeStatus =
+        await this.#accountController.getAccountUpgradeStatus({
+          account: address,
+          chainId,
+        });
 
       return PermissionHandlerContent({
         origin,

--- a/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
@@ -66,6 +66,7 @@ export type PermissionHandlerContentProps = {
  * @param options.tokenBalanceFiat - The formatted fiat balance of the token.
  * @param options.chainId - The chain ID of the network.
  * @param options.explorerUrl - The URL of the block explorer for the token.
+ * @param options.isAccountUpgraded - Whether the account is upgraded to a smart account.
  * @returns The confirmation content.
  */
 export const PermissionHandlerContent = ({
@@ -84,7 +85,9 @@ export const PermissionHandlerContent = ({
   explorerUrl,
   isAccountUpgraded,
 }: PermissionHandlerContentProps): SnapElement => {
-  const tokenBalanceComponent = TokenBalanceField({ tokenBalance: tokenBalance ?? undefined });
+  const tokenBalanceComponent = TokenBalanceField({
+    tokenBalance: tokenBalance ?? undefined,
+  });
 
   const fiatBalanceComponent = tokenBalanceFiat ? (
     <Text>{tokenBalanceFiat}</Text>
@@ -156,7 +159,8 @@ export const PermissionHandlerContent = ({
             />
             {!isAccountUpgraded && (
               <Text size="sm" color="warning">
-                Account will be upgraded to a smart account via an onchain transaction.
+                This account will be upgraded to a smart account to complete
+                this permission.
               </Text>
             )}
             <Box direction="horizontal" alignment="end">

--- a/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
@@ -47,6 +47,7 @@ export type PermissionHandlerContentProps = {
   tokenBalanceFiat: string | null;
   chainId: number;
   explorerUrl: string;
+  isAccountUpgraded: boolean;
 };
 
 /**
@@ -81,8 +82,9 @@ export const PermissionHandlerContent = ({
   tokenBalanceFiat,
   chainId,
   explorerUrl,
+  isAccountUpgraded,
 }: PermissionHandlerContentProps): SnapElement => {
-  const tokenBalanceComponent = TokenBalanceField({ tokenBalance });
+  const tokenBalanceComponent = TokenBalanceField({ tokenBalance: tokenBalance ?? undefined });
 
   const fiatBalanceComponent = tokenBalanceFiat ? (
     <Text>{tokenBalanceFiat}</Text>
@@ -152,6 +154,11 @@ export const PermissionHandlerContent = ({
               switchGlobalAccount={false}
               value={context.accountAddressCaip10}
             />
+            {!isAccountUpgraded && (
+              <Text size="sm" color="warning">
+                Account will be upgraded to a smart account via an onchain transaction.
+              </Text>
+            )}
             <Box direction="horizontal" alignment="end">
               {fiatBalanceComponent}
               {tokenBalanceComponent}

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -248,13 +248,14 @@ export class PermissionRequestLifecycleOrchestrator {
         await this.#userEventDispatcher.waitForPendingHandlers();
 
         // Check if account needs to be upgraded before processing the permission
-        // We check again because the account could have been upgraded in the time since permission request was created 
+        // We check again because the account could have been upgraded in the time since permission request was created
         // especially if we consider a scenario where we have a permission batch with the same account.
         const { address } = parseCaipAccountId(context.accountAddressCaip10);
-        const upgradeStatus = await this.#accountController.getAccountUpgradeStatus({
-          account: address,
-          chainId,
-        });
+        const upgradeStatus =
+          await this.#accountController.getAccountUpgradeStatus({
+            account: address,
+            chainId,
+          });
 
         if (!upgradeStatus.isUpgraded) {
           // Trigger account upgrade

--- a/packages/gator-permissions-snap/test/core/accountController.test.ts
+++ b/packages/gator-permissions-snap/test/core/accountController.test.ts
@@ -91,6 +91,40 @@ describe('AccountController', () => {
     });
   });
 
+  describe('getAccountUpgradeStatus()', () => {
+    it('should return upgrade status', async () => {
+      mockEthereumProvider.request.mockResolvedValueOnce({
+        isUpgraded: true,
+      });
+
+      const result = await accountController.getAccountUpgradeStatus({
+        account: mockAddress,
+        chainId: sepolia,
+      });
+
+      expect(result).toStrictEqual({ isUpgraded: true });
+    });
+  });
+
+  describe('upgradeAccount()', () => {
+    it('should upgrade account and return transaction hash', async () => {
+      const mockTransactionHash =
+        '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+      mockEthereumProvider.request.mockResolvedValueOnce({
+        transactionHash: mockTransactionHash,
+      });
+
+      const result = await accountController.upgradeAccount({
+        account: mockAddress,
+        chainId: sepolia,
+      });
+
+      expect(result).toStrictEqual({
+        transactionHash: mockTransactionHash,
+      });
+    });
+  });
+
   describe('signDelegation()', () => {
     const unsignedDelegation: Omit<Delegation, 'signature'> = {
       delegate: '0x1234567890abcdef1234567890abcdef12345678',

--- a/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
@@ -42,7 +42,6 @@ type TestLifecycleHandlersType = LifecycleOrchestrationHandlers<
 
 const mockPermissionRequest: PermissionRequest = {
   chainId: '0x1',
-  expiry: 1234567890,
   signer: {
     type: 'account',
     data: {
@@ -69,7 +68,10 @@ const mockContext: TestContextType = {
   },
   accountAddressCaip10: `eip155:1:${mockAddress}`,
   tokenAddressCaip19: `eip155:1/erc20:${mockAssetAddress}`,
-  expiry: '1234567890',
+  expiry: {
+    timestamp: 1234567890,
+    isAdjustmentAllowed: false,
+  },
   isAdjustmentAllowed: false,
 };
 
@@ -135,7 +137,13 @@ const setupTest = () => {
   const accountController = {
     signDelegation: jest.fn(),
     getAccountAddresses: jest.fn(),
+    getAccountUpgradeStatus: jest.fn(),
+    upgradeAccount: jest.fn(),
   } as unknown as jest.Mocked<AccountController>;
+
+  accountController.getAccountUpgradeStatus.mockResolvedValue({
+    isUpgraded: false,
+  });
 
   userEventDispatcher = {
     on: jest.fn(bindEvent),
@@ -1034,6 +1042,15 @@ describe('PermissionHandler', () => {
                     {
                       "key": null,
                       "props": {
+                        "children": "This account will be upgraded to a smart account to complete this permission.",
+                        "color": "warning",
+                        "size": "sm",
+                      },
+                      "type": "Text",
+                    },
+                    {
+                      "key": null,
+                      "props": {
                         "alignment": "end",
                         "children": [
                           {
@@ -1538,6 +1555,15 @@ describe('PermissionHandler', () => {
                         "value": "eip155:1:0x1234567890123456789012345678901234567890",
                       },
                       "type": "AccountSelector",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": "This account will be upgraded to a smart account to complete this permission.",
+                        "color": "warning",
+                        "size": "sm",
+                      },
+                      "type": "Text",
                     },
                     {
                       "key": null,
@@ -2088,6 +2114,15 @@ describe('PermissionHandler', () => {
                     {
                       "key": null,
                       "props": {
+                        "children": "This account will be upgraded to a smart account to complete this permission.",
+                        "color": "warning",
+                        "size": "sm",
+                      },
+                      "type": "Text",
+                    },
+                    {
+                      "key": null,
+                      "props": {
                         "alignment": "end",
                         "children": [
                           {
@@ -2558,6 +2593,15 @@ describe('PermissionHandler', () => {
                         "value": "eip155:1:0x1234567890123456789012345678901234567890",
                       },
                       "type": "AccountSelector",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": "This account will be upgraded to a smart account to complete this permission.",
+                        "color": "warning",
+                        "size": "sm",
+                      },
+                      "type": "Text",
                     },
                     {
                       "key": null,
@@ -3037,6 +3081,15 @@ describe('PermissionHandler', () => {
                         "value": "eip155:1:0x1234567890123456789012345678901234567890",
                       },
                       "type": "AccountSelector",
+                    },
+                    {
+                      "key": null,
+                      "props": {
+                        "children": "This account will be upgraded to a smart account to complete this permission.",
+                        "color": "warning",
+                        "size": "sm",
+                      },
+                      "type": "Text",
                     },
                     {
                       "key": null,

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -21,18 +21,23 @@ import type { UserEventDispatcher } from '../../src/userEventDispatcher';
 
 const randomAddress = () => {
   /* eslint-disable no-restricted-globals */
-  const randomBytes = crypto.getRandomValues(new Uint8Array(20));
+  const randomBytes = new Uint8Array(20);
+  for (let i = 0; i < 20; i++) {
+    randomBytes[i] = Math.floor(Math.random() * 256);
+  }
   return bytesToHex(randomBytes);
 };
 
 const mockSignature = '0x1234';
 const mockInterfaceId = 'test-interface-id';
 const grantingAccountAddress = randomAddress();
+const fixedCaip10Address = `eip155:1:${grantingAccountAddress}`;
 
 const mockContext = {
   expiry: '2024-12-31',
   isAdjustmentAllowed: true,
   address: grantingAccountAddress,
+  accountAddressCaip10: fixedCaip10Address,
 };
 
 const mockMetadata = {
@@ -90,6 +95,8 @@ const mockPopulatedPermission = {
 const mockAccountController = {
   signDelegation: jest.fn(),
   getAccountAddresses: jest.fn(),
+  getAccountUpgradeStatus: jest.fn(async () => ({ isUpgraded: false })),
+  upgradeAccount: jest.fn().mockResolvedValue(undefined),
 } as unknown as jest.Mocked<AccountController>;
 
 const mockConfirmationDialog = {
@@ -154,6 +161,10 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
         ...delegation,
         signature: mockSignature,
       }),
+    );
+
+    mockAccountController.getAccountUpgradeStatus.mockImplementation(
+      async () => ({ isUpgraded: false }),
     );
 
     mockConfirmationDialogFactory.createConfirmation.mockReturnValue(
@@ -560,12 +571,36 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
           'Expiry rule not found. An expiry is required on all permissions.',
         );
       });
+      it('checks account upgrade status and triggers upgrade when needed', async () => {
+        mockAccountController.getAccountUpgradeStatus.mockResolvedValueOnce({
+          isUpgraded: false,
+        });
+
+        const result = await permissionRequestLifecycleOrchestrator.orchestrate(
+          'test-origin',
+          mockPermissionRequest,
+          lifecycleHandlerMocks,
+        );
+
+        expect(
+          mockAccountController.getAccountUpgradeStatus,
+        ).toHaveBeenCalledWith({
+          account: grantingAccountAddress,
+          chainId: 1,
+        });
+        expect(mockAccountController.upgradeAccount).toHaveBeenCalledWith({
+          account: grantingAccountAddress,
+          chainId: 1,
+        });
+        expect(result.approved).toBe(true);
+      });
+
       it('correctly sets up the onConfirmationCreated hook to update the context', async () => {
         const initialContext = {
           foo: 'original',
           expiry: '2024-12-31',
           isAdjustmentAllowed: true,
-          accountAddressCaip10: grantingAccountAddress,
+          accountAddressCaip10: fixedCaip10Address,
           tokenAddressCaip19: 'eip155:1:0x1234',
           tokenMetadata: {
             decimals: 18,
@@ -577,7 +612,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
           foo: 'updated',
           expiry: '2025-01-01',
           isAdjustmentAllowed: true,
-          accountAddressCaip10: grantingAccountAddress,
+          accountAddressCaip10: fixedCaip10Address,
           tokenAddressCaip19: 'eip155:1:0x1234',
           tokenMetadata: {
             decimals: 18,
@@ -644,6 +679,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
           foo: 'bar',
           expiry: '2024-12-31',
           isAdjustmentAllowed: false, // Adjustment not allowed
+          accountAddressCaip10: fixedCaip10Address,
         };
 
         const mockPermissionRequestWithAdjustmentNotAllowed = {
@@ -702,7 +738,8 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
        * 4. Applies context to resolve the permission request.
        * 5. Populates the permission with required values.
        * 6. Appends caveats to the permission.
-       * 7. Signs the delegation for the permission.
+       * 7. Checks and upgrades account if necessary.
+       * 8. Signs the delegation for the permission.
        */
 
       beforeEach(async () => {
@@ -803,7 +840,19 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
       });
 
       /*
-       * 7. Signs the delegation for the permission.
+       * 7. Checks and upgrades account if necessary.
+       */
+      it('checks account upgrade status before processing permission', async () => {
+        expect(
+          mockAccountController.getAccountUpgradeStatus,
+        ).toHaveBeenCalledWith({
+          account: grantingAccountAddress,
+          chainId: 1,
+        });
+      });
+
+      /*
+       * 8. Signs the delegation for the permission.
        */
       it('signs the delegation for the permission', async () => {
         expect(mockAccountController.signDelegation).toHaveBeenCalledWith(


### PR DESCRIPTION
## **Description**

If permission is being done by an account that has not been transformed to Smart account then we trigger an account upgrade.

## **Related issues**

Depends on: https://github.com/MetaMask/metamask-extension/pull/36452

## **Manual testing steps**

1. Go localhost:8000
2. Make sure your account is not a smart account
3. Grant a new permission
4. Permission page should show a warning that your account will be upgraded
5. After clicking grant first a transaction for upgrading the account should show

## **Screenshots/Recordings**

### **After**

https://github.com/user-attachments/assets/7818c2e9-88a6-438e-970a-541f9bfaedc3

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.