### PR TITLE
fix: update warning icon color to error red for malicious addresses

### DIFF
--- a/packages/gator-permissions-snap/package.json
+++ b/packages/gator-permissions-snap/package.json
@@ -50,7 +50,7 @@
     "@metamask/abi-utils": "3.0.0",
     "@metamask/delegation-core": "0.3.0",
     "@metamask/profile-sync-controller": "21.0.0",
-    "@metamask/snaps-sdk": "10.2.0",
+    "@metamask/snaps-sdk": "11.0.0",
     "@metamask/utils": "11.4.2",
     "zod": "3.25.76"
   },

--- a/packages/gator-permissions-snap/src/ui/components/AddressField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/AddressField.tsx
@@ -52,7 +52,7 @@ export const AddressField = ({
             {addressContent}
           </Box>
           <Box direction="horizontal" alignment="end">
-            <Icon name="danger" size="md" color="primary" />
+            <Icon name="danger" size="md" color="error" />
             <Text alignment="end" color="error">
               {warningLabel}
             </Text>

--- a/packages/gator-permissions-snap/src/ui/components/TextField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TextField.tsx
@@ -41,7 +41,7 @@ export const TextField = ({
     <Box direction="vertical">
       <Text alignment="end">{value}</Text>
       <Box direction="horizontal" alignment="end">
-        <Icon name="danger" size="md" color="primary" />
+        <Icon name="danger" size="md" color="error" />
         <Text color="error">{warningLabel}</Text>
       </Box>
     </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,7 +3086,7 @@ __metadata:
     "@metamask/profile-sync-controller": "npm:21.0.0"
     "@metamask/snaps-cli": "npm:8.3.0"
     "@metamask/snaps-jest": "npm:9.8.0"
-    "@metamask/snaps-sdk": "npm:10.2.0"
+    "@metamask/snaps-sdk": "npm:11.0.0"
     "@metamask/utils": "npm:11.4.2"
     "@types/react": "npm:18.2.4"
     "@types/react-dom": "npm:18.2.4"
@@ -3693,6 +3693,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-sdk@npm:11.0.0":
+  version: 11.0.0
+  resolution: "@metamask/snaps-sdk@npm:11.0.0"
+  dependencies:
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/providers": "npm:^22.1.1"
+    "@metamask/rpc-errors": "npm:^7.0.3"
+    "@metamask/superstruct": "npm:^3.2.1"
+    "@metamask/utils": "npm:^11.10.0"
+    luxon: "npm:^3.5.0"
+  checksum: 10/83dc24c9c583ca257874498ed2b124160c559afd56f043a6e0f617fc3edc4fcbd4b1ef15efb4a197a71a8a6dd2ab20b6da87463b4261928311d39eb29f64668a
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-sdk@npm:^10.0.0, @metamask/snaps-sdk@npm:^10.1.0, @metamask/snaps-sdk@npm:^10.2.0, @metamask/snaps-sdk@npm:^10.3.0":
   version: 10.3.0
   resolution: "@metamask/snaps-sdk@npm:10.3.0"
@@ -3855,6 +3869,25 @@ __metadata:
     semver: "npm:^7.5.4"
     uuid: "npm:^9.0.1"
   checksum: 10/f8f5e99ba6c6de0395ed4e0acc82ee9c0dca26991ea6a8f10b3896e72745790966a8eded8c42be905d9f01fa99c1fd29a7f68541e2ef9854fc14984a0b514ad3
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^11.10.0":
+  version: 11.10.0
+  resolution: "@metamask/utils@npm:11.10.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.3"
+    "@types/debug": "npm:^4.1.7"
+    "@types/lodash": "npm:^4.17.20"
+    debug: "npm:^4.3.4"
+    lodash: "npm:^4.17.21"
+    pony-cause: "npm:^2.1.10"
+    semver: "npm:^7.5.4"
+    uuid: "npm:^9.0.1"
+  checksum: 10/691a268af66593b60e9807a069127993cea3cdc941f99d5d7ca4664868754f08945821f1787b2f3e99e4497df63ceb0af37a2419ad494da29a1fddffe94f5797
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes the warning icon color for potentially malicious websites and addresses in the gator-permissions-snap. Previously, the warning icons were displayed in blue (using `color="primary"`), but they should be displayed in error red to better indicate the warning level.

## Changes

- **Updated `@metamask/snaps-sdk`** from `10.2.0` to `11.0.0`
  - This version adds support for the `"error"` color value on Icon components
- **Updated `AddressField.tsx`**: Changed icon color from `"primary"` to `"error"` (line 55)
- **Updated `TextField.tsx`**: Changed icon color from `"primary"` to `"error"` (line 44)
- **Updated `yarn.lock`**: Reflects the dependency update

## Testing

- Built the project successfully
- All tests pass (57 test suites, 853 tests)
- All snapshots pass (33 snapshots)

## Visual Impact

<img width="495" height="228" alt="image" src="https://github.com/user-attachments/assets/70e0d8af-7b88-4909-89fc-4f43143e2fb1" />


Warning icons for the following scenarios now display in error red instead of blue:
- ⚠️ Potentially malicious website
- ⚠️ Malicious website  
- ⚠️ Potentially malicious address
- ⚠️ Malicious address

## Notes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C089Z7KQPS9/p1773886191304869?thread_ts=1773886191.304869&cid=C089Z7KQPS9)

<div><a href="https://cursor.com/agents/bc-bec4f433-701d-5a26-b8e9-1cdb7948626c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bec4f433-701d-5a26-b8e9-1cdb7948626c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

