### PR TITLE
Feat: Existing permissions banner with list

### DIFF
--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -262,6 +262,15 @@
     "existingPermissionsConfirmButton": {
       "message": "Continue"
     },
+    "existingPermissionsExistingMessage": {
+      "message": "You have granted permissions to this site in the past."
+    },
+    "existingPermissionsSimilarMessage": {
+      "message": "You have granted similar permissions to this site in the past."
+    },
+    "existingPermissionsLink": {
+      "message": "Review them"
+    },
     "chainLabel": {
       "message": "Network"
     },

--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -271,6 +271,9 @@
     "existingPermissionsLink": {
       "message": "Review them"
     },
+    "existingPermissionsLoadError": {
+      "message": "We couldn’t load the list. You can go back and try again."
+    },
     "chainLabel": {
       "message": "Network"
     },

--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -257,10 +257,10 @@
       "message": "Existing permissions"
     },
     "existingPermissionsDescription": {
-      "message": "You've already granted permissions for this site. Do you want to continue?"
+      "message": "Permissions you’ve already granted to this site"
     },
     "existingPermissionsConfirmButton": {
-      "message": "Continue"
+      "message": "Back to request"
     },
     "existingPermissionsExistingMessage": {
       "message": "You have granted permissions to this site in the past."

--- a/packages/gator-permissions-snap/src/core/confirmation.tsx
+++ b/packages/gator-permissions-snap/src/core/confirmation.tsx
@@ -21,6 +21,8 @@ export class ConfirmationDialog {
 
   readonly #timeoutFactory: TimeoutFactory;
 
+  static isGrantDisabled = true;
+
   #ui: SnapElement;
 
   #timeout: Timeout | undefined;
@@ -191,12 +193,13 @@ export class ConfirmationDialog {
    */
   async updateContent({
     ui,
+    isGrantDisabled,
   }: {
     ui: SnapElement;
     isGrantDisabled: boolean;
   }): Promise<void> {
     this.#ui = ui;
-
+    ConfirmationDialog.isGrantDisabled = isGrantDisabled;
     await this.#dialogInterface.show(this.#buildConfirmation());
   }
 

--- a/packages/gator-permissions-snap/src/core/confirmation.tsx
+++ b/packages/gator-permissions-snap/src/core/confirmation.tsx
@@ -1,21 +1,19 @@
 import { UserInputEventType } from '@metamask/snaps-sdk';
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
-import { Button, Container, Footer } from '@metamask/snaps-sdk/jsx';
 
 import type { DialogInterface } from './dialogInterface';
 import type { UserEventDispatcher } from '../userEventDispatcher';
 import type { Timeout, TimeoutFactory } from './timeoutFactory';
 import type { ConfirmationProps } from './types';
-import { t } from '../utils/i18n';
 
 /**
  * Dialog for handling user confirmation of permission grants.
  * Manages the UI state, timeout behavior, and user interactions.
  */
 export class ConfirmationDialog {
-  static readonly #cancelButton = 'cancel-button';
+  static readonly cancelButton = 'cancel-button';
 
-  static readonly #grantButton = 'grant-button';
+  static readonly grantButton = 'grant-button';
 
   readonly #dialogInterface: DialogInterface;
 
@@ -24,8 +22,6 @@ export class ConfirmationDialog {
   readonly #timeoutFactory: TimeoutFactory;
 
   #ui: SnapElement;
-
-  #isGrantDisabled = true;
 
   #timeout: Timeout | undefined;
 
@@ -119,7 +115,7 @@ export class ConfirmationDialog {
       });
 
       const { unbind: unbindGrantButtonClick } = this.#userEventDispatcher.on({
-        elementName: ConfirmationDialog.#grantButton,
+        elementName: ConfirmationDialog.grantButton,
         eventType: UserInputEventType.ButtonClickEvent,
         interfaceId,
         handler: async () => {
@@ -141,7 +137,7 @@ export class ConfirmationDialog {
       });
 
       const { unbind: unbindCancelButtonClick } = this.#userEventDispatcher.on({
-        elementName: ConfirmationDialog.#cancelButton,
+        elementName: ConfirmationDialog.cancelButton,
         eventType: UserInputEventType.ButtonClickEvent,
         interfaceId,
         handler: async () => {
@@ -184,23 +180,7 @@ export class ConfirmationDialog {
   }
 
   #buildConfirmation(): JSX.Element {
-    return (
-      <Container>
-        {this.#ui}
-        <Footer>
-          <Button name={ConfirmationDialog.#cancelButton} variant="destructive">
-            {t('cancelButton')}
-          </Button>
-          <Button
-            name={ConfirmationDialog.#grantButton}
-            variant="primary"
-            disabled={this.#isGrantDisabled}
-          >
-            {t('grantButton')}
-          </Button>
-        </Footer>
-      </Container>
-    );
+    return this.#ui;
   }
 
   /**
@@ -211,13 +191,11 @@ export class ConfirmationDialog {
    */
   async updateContent({
     ui,
-    isGrantDisabled,
   }: {
     ui: SnapElement;
     isGrantDisabled: boolean;
   }): Promise<void> {
     this.#ui = ui;
-    this.#isGrantDisabled = isGrantDisabled;
 
     await this.#dialogInterface.show(this.#buildConfirmation());
   }

--- a/packages/gator-permissions-snap/src/core/confirmation.tsx
+++ b/packages/gator-permissions-snap/src/core/confirmation.tsx
@@ -21,8 +21,6 @@ export class ConfirmationDialog {
 
   readonly #timeoutFactory: TimeoutFactory;
 
-  static isGrantDisabled = true;
-
   #ui: SnapElement;
 
   #timeout: Timeout | undefined;
@@ -187,19 +185,13 @@ export class ConfirmationDialog {
 
   /**
    * Updates the confirmation dialog content.
+   * Grant enable/disable is encoded in the `ui` tree (for example `PermissionHandlerContent` props).
+   *
    * @param options - The update options.
    * @param options.ui - The new UI content.
-   * @param options.isGrantDisabled - Whether the grant button should be disabled.
    */
-  async updateContent({
-    ui,
-    isGrantDisabled,
-  }: {
-    ui: SnapElement;
-    isGrantDisabled: boolean;
-  }): Promise<void> {
+  async updateContent({ ui }: { ui: SnapElement }): Promise<void> {
     this.#ui = ui;
-    ConfirmationDialog.isGrantDisabled = isGrantDisabled;
     await this.#dialogInterface.show(this.#buildConfirmation());
   }
 

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
@@ -20,8 +20,7 @@ export const EXISTING_PERMISSIONS_CONFIRM_BUTTON =
   'existing-permissions-confirm';
 
 /**
- * Builds the existing permissions display content.
- * Shows a comparison between an existing permission and what the user is about to grant.
+ * Builds the existing permissions display content: a grouped list of stored grants for review.
  *
  * @param config - The configuration for the existing permissions display.
  * @returns The existing permissions UI as a JSX.Element.

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
@@ -7,6 +7,8 @@ import {
   Container,
   Button,
   Footer,
+  Skeleton,
+  SnapElement,
 } from '@metamask/snaps-sdk/jsx';
 import { Hex } from '@metamask/utils';
 
@@ -18,6 +20,59 @@ import { t } from '../../utils/i18n';
 // Button name constant for event handling
 export const EXISTING_PERMISSIONS_CONFIRM_BUTTON =
   'existing-permissions-confirm';
+
+/**
+ * Builds a skeleton loading UI for the existing permissions page.
+ * Displays placeholder content while permissions are being loaded and formatted.
+ *
+ * @returns The skeleton UI as a JSX.Element.
+ */
+export function buildExistingPermissionsSkeletonContent(
+  config: ExistingPermissionDisplayConfig,
+): SnapElement {
+  const { title, description, buttonLabel } = config;
+
+  return (
+    <Container>
+      <Box direction="vertical">
+        <Box center={true}>
+          <Heading size="lg">{t(title)}</Heading>
+          <Text>{t(description)}</Text>
+        </Box>
+
+        {/* Show 2 skeleton account groups */}
+        {[0, 1].map((index) => (
+          <Section key={`skeleton-account-${index}`}>
+            <Box direction="vertical">
+              <Box direction="horizontal" alignment="space-between">
+                <Text fontWeight="bold">{t('accountLabel')}</Text>
+                <Skeleton />
+              </Box>
+              {/* Show 2 skeleton permission cards */}
+              {[0, 1].map((permIndex) => (
+                <Box
+                  key={`skeleton-permission-${permIndex}`}
+                  direction="vertical"
+                >
+                  <Box direction="vertical">
+                    <Skeleton />
+                    <Skeleton />
+                    <Skeleton />
+                  </Box>
+                </Box>
+              ))}
+            </Box>
+          </Section>
+        ))}
+      </Box>
+      <Footer>
+        <Button name={EXISTING_PERMISSIONS_CONFIRM_BUTTON} disabled={true}>
+          {t(buttonLabel)}
+        </Button>
+      </Footer>
+    </Container>
+  );
+}
 
 /**
  * Builds the existing permissions display content: a grouped list of stored grants for review.

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
@@ -25,6 +25,7 @@ export const EXISTING_PERMISSIONS_CONFIRM_BUTTON =
  * Builds a skeleton loading UI for the existing permissions page.
  * Displays placeholder content while permissions are being loaded and formatted.
  *
+ * @param config - Title, description, and button label keys (same as the full list view).
  * @returns The skeleton UI as a JSX.Element.
  */
 export function buildExistingPermissionsSkeletonContent(
@@ -67,6 +68,39 @@ export function buildExistingPermissionsSkeletonContent(
       </Box>
       <Footer>
         <Button name={EXISTING_PERMISSIONS_CONFIRM_BUTTON} disabled={true}>
+          {t(buttonLabel)}
+        </Button>
+      </Footer>
+    </Container>
+  );
+}
+
+/**
+ * Fallback when loading or formatting the existing-permissions list fails.
+ * Keeps the confirm action enabled so the user can return to the main request.
+ *
+ * @param config - Title, description, and button label keys.
+ * @returns Fallback UI as a SnapElement.
+ */
+export function buildExistingPermissionsFallbackContent(
+  config: Pick<
+    ExistingPermissionDisplayConfig,
+    'title' | 'description' | 'buttonLabel'
+  >,
+): SnapElement {
+  const { title, description, buttonLabel } = config;
+
+  return (
+    <Container>
+      <Box direction="vertical">
+        <Box center={true}>
+          <Heading size="lg">{t(title)}</Heading>
+          <Text>{t(description)}</Text>
+          <Text>{t('existingPermissionsLoadError')}</Text>
+        </Box>
+      </Box>
+      <Footer>
+        <Button name={EXISTING_PERMISSIONS_CONFIRM_BUTTON}>
           {t(buttonLabel)}
         </Button>
       </Footer>

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
@@ -50,7 +50,7 @@ export function buildExistingPermissionsContent(
               </Section>
               {permissions.map((detail, index) => (
                 <PermissionCard
-                  key={`permission-${index}`}
+                  key={`${accountAddress}-${index}`}
                   detail={detail}
                   index={index}
                 />

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
@@ -1,17 +1,4 @@
-import {
-  Box,
-  Button,
-  Container,
-  Section,
-  Footer,
-  Heading,
-  Text,
-  Address,
-  Divider,
-  Bold,
-  Skeleton,
-} from '@metamask/snaps-sdk/jsx';
-import type { SnapElement } from '@metamask/snaps-sdk/jsx';
+import { Box, Section, Heading, Text, Address } from '@metamask/snaps-sdk/jsx';
 import { Hex } from '@metamask/utils';
 
 import { groupPermissionsByFromAddress } from './permissionFormatter';
@@ -23,65 +10,6 @@ import { t } from '../../utils/i18n';
 export const EXISTING_PERMISSIONS_CONFIRM_BUTTON =
   'existing-permissions-confirm';
 
-// Maximum number of permissions to display per account
-const MAX_PERMISSIONS_PER_ACCOUNT = 3;
-
-/**
- * Builds a skeleton loading state for the existing permissions dialog.
- * Shows placeholder UI while permissions are being fetched and formatted.
- *
- * @param config - The configuration for the existing permissions display (used for title/description).
- * @returns The skeleton loading UI as a JSX.Element.
- */
-export function buildExistingPermissionsSkeletonContent(
-  config: ExistingPermissionDisplayConfig,
-): SnapElement {
-  const { title, description, buttonLabel } = config;
-
-  return (
-    <Container>
-      <Box direction="vertical">
-        <Box center={true}>
-          <Heading size="lg">{t(title)}</Heading>
-          <Text>{t(description)}</Text>
-        </Box>
-
-        {/* Show 2 skeleton account groups */}
-        {[0, 1].map((index) => (
-          <Section key={`skeleton-account-${index}`}>
-            <Box direction="vertical">
-              <Box direction="horizontal" alignment="space-between">
-                <Text fontWeight="bold">{t('accountLabel')}</Text>
-                <Skeleton />
-              </Box>
-              <Divider />
-              {/* Show 2 skeleton permission cards */}
-              {[0, 1].map((permIndex) => (
-                <Box
-                  key={`skeleton-permission-${permIndex}`}
-                  direction="vertical"
-                >
-                  {permIndex > 0 && <Divider />}
-                  <Box direction="vertical">
-                    <Skeleton />
-                    <Skeleton />
-                    <Skeleton />
-                  </Box>
-                </Box>
-              ))}
-            </Box>
-          </Section>
-        ))}
-      </Box>
-      <Footer>
-        <Button name={EXISTING_PERMISSIONS_CONFIRM_BUTTON} disabled={true}>
-          {t(buttonLabel)}
-        </Button>
-      </Footer>
-    </Container>
-  );
-}
-
 /**
  * Builds the existing permissions display content.
  * Shows a comparison between an existing permission and what the user is about to grant.
@@ -92,63 +20,34 @@ export function buildExistingPermissionsSkeletonContent(
 export function buildExistingPermissionsContent(
   config: ExistingPermissionDisplayConfig,
 ): JSX.Element {
-  const { existingPermissions, title, description, buttonLabel } = config;
+  const { existingPermissions, title, description } = config;
 
   const grouped = groupPermissionsByFromAddress(existingPermissions);
 
   return (
-    <Container>
-      <Box direction="vertical">
-        <Box center={true}>
-          <Heading size="lg">{t(title)}</Heading>
-          <Text>{t(description)}</Text>
-        </Box>
-
-        {Object.entries(grouped).map(([accountAddress, permissions]) => {
-          const displayedPermissions = permissions.slice(
-            0,
-            MAX_PERMISSIONS_PER_ACCOUNT,
-          );
-          const hasMorePermissions =
-            permissions.length > MAX_PERMISSIONS_PER_ACCOUNT;
-          const moreCount = permissions.length - MAX_PERMISSIONS_PER_ACCOUNT;
-
-          return (
-            <Section key={`account-${accountAddress}`}>
-              <Box direction="vertical">
-                <Box direction="horizontal" alignment="space-between">
-                  <Text fontWeight="bold">{t('accountLabel')}</Text>
-                  <Address address={accountAddress as Hex} displayName={true} />
-                </Box>
-                <Divider />
-                {displayedPermissions.map((detail, index) => (
-                  <PermissionCard
-                    key={`permission-${index}`}
-                    detail={detail}
-                    index={index}
-                  />
-                ))}
-                {hasMorePermissions && (
-                  <Box direction="vertical">
-                    <Divider />
-                    <Text>
-                      {moreCount === 1
-                        ? t('morePermissionsCountSingle')
-                        : t('morePermissionsCountPlural', [String(moreCount)])}
-                      <Bold>{t('dappConnectionsLink')}</Bold>
-                    </Text>
-                  </Box>
-                )}
-              </Box>
-            </Section>
-          );
-        })}
+    <Box direction="vertical">
+      <Box center={true}>
+        <Heading size="lg">{t(title)}</Heading>
+        <Text>{t(description)}</Text>
       </Box>
-      <Footer>
-        <Button name={EXISTING_PERMISSIONS_CONFIRM_BUTTON}>
-          {t(buttonLabel)}
-        </Button>
-      </Footer>
-    </Container>
+
+      {Object.entries(grouped).map(([accountAddress, permissions]) => {
+        return (
+          <Box key={`account-${accountAddress}`} direction="vertical">
+            <Section direction="horizontal" alignment="space-between">
+              <Text fontWeight="bold">{t('accountLabel')}</Text>
+              <Address address={accountAddress as Hex} displayName={true} />
+            </Section>
+            {permissions.map((detail, index) => (
+              <PermissionCard
+                key={`permission-${index}`}
+                detail={detail}
+                index={index}
+              />
+            ))}
+          </Box>
+        );
+      })}
+    </Box>
   );
 }

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
@@ -109,7 +109,7 @@ export function buildExistingPermissionsFallbackContent(
 }
 
 /**
- * Builds the existing permissions display content: a grouped list of stored grants for review.
+ * Builds the existing permissions display content: a grouped list of stored granted permissions for review.
  *
  * @param config - The configuration for the existing permissions display.
  * @returns The existing permissions UI as a JSX.Element.

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsContent.tsx
@@ -1,4 +1,13 @@
-import { Box, Section, Heading, Text, Address } from '@metamask/snaps-sdk/jsx';
+import {
+  Box,
+  Section,
+  Heading,
+  Text,
+  Address,
+  Container,
+  Button,
+  Footer,
+} from '@metamask/snaps-sdk/jsx';
 import { Hex } from '@metamask/utils';
 
 import { groupPermissionsByFromAddress } from './permissionFormatter';
@@ -20,34 +29,41 @@ export const EXISTING_PERMISSIONS_CONFIRM_BUTTON =
 export function buildExistingPermissionsContent(
   config: ExistingPermissionDisplayConfig,
 ): JSX.Element {
-  const { existingPermissions, title, description } = config;
+  const { existingPermissions, title, description, buttonLabel } = config;
 
   const grouped = groupPermissionsByFromAddress(existingPermissions);
 
   return (
-    <Box direction="vertical">
-      <Box center={true}>
-        <Heading size="lg">{t(title)}</Heading>
-        <Text>{t(description)}</Text>
-      </Box>
+    <Container>
+      <Box direction="vertical">
+        <Box center={true}>
+          <Heading size="lg">{t(title)}</Heading>
+          <Text>{t(description)}</Text>
+        </Box>
 
-      {Object.entries(grouped).map(([accountAddress, permissions]) => {
-        return (
-          <Box key={`account-${accountAddress}`} direction="vertical">
-            <Section direction="horizontal" alignment="space-between">
-              <Text fontWeight="bold">{t('accountLabel')}</Text>
-              <Address address={accountAddress as Hex} displayName={true} />
-            </Section>
-            {permissions.map((detail, index) => (
-              <PermissionCard
-                key={`permission-${index}`}
-                detail={detail}
-                index={index}
-              />
-            ))}
-          </Box>
-        );
-      })}
-    </Box>
+        {Object.entries(grouped).map(([accountAddress, permissions]) => {
+          return (
+            <Box key={`account-${accountAddress}`} direction="vertical">
+              <Section direction="horizontal" alignment="space-between">
+                <Text fontWeight="bold">{t('accountLabel')}</Text>
+                <Address address={accountAddress as Hex} displayName={true} />
+              </Section>
+              {permissions.map((detail, index) => (
+                <PermissionCard
+                  key={`permission-${index}`}
+                  detail={detail}
+                  index={index}
+                />
+              ))}
+            </Box>
+          );
+        })}
+      </Box>
+      <Footer>
+        <Button name={EXISTING_PERMISSIONS_CONFIRM_BUTTON}>
+          {t(buttonLabel)}
+        </Button>
+      </Footer>
+    </Container>
   );
 }

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -170,7 +170,7 @@ export class ExistingPermissionsService {
   }
 
   /**
-   * Compares stored grants for the site to the requested permission (stream vs periodic category).
+   * Compares stored granted permissions for the site to the requested permission (stream vs periodic category).
    * Fetches from profile sync. Prefer {@link getExistingPermissions} + {@link getExistingPermissionsStatusFromList}
    * when you already have a snapshot for this origin.
    *

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   buildExistingPermissionsContent,
+  buildExistingPermissionsFallbackContent,
   buildExistingPermissionsSkeletonContent,
 } from './existingPermissionsContent';
 import { ExistingPermissionsState } from './existingPermissionsState';
@@ -124,18 +125,18 @@ export class ExistingPermissionsService {
   }
 
   /**
-   * Compares stored grants for the site to the requested permission (stream vs periodic category).
+   * Derives banner state from an in-memory snapshot of stored grants (no profile sync I/O).
+   * Use with {@link getExistingPermissions} once per permission request lifecycle.
    *
-   * @param siteOrigin - The requesting dApp origin.
+   * @param existingPermissions - Stored grants for the requesting origin (already filtered).
    * @param requestedPermission - The permission the user is about to grant.
    * @returns Banner-driving status, or {@link ExistingPermissionsState.None} if none stored or on error.
    */
-  async getExistingPermissionsStatus(
-    siteOrigin: string,
+  getExistingPermissionsStatusFromList(
+    existingPermissions: StoredGrantedPermission[],
     requestedPermission: Permission,
-  ): Promise<ExistingPermissionsState> {
+  ): ExistingPermissionsState {
     try {
-      const existingPermissions = await this.getExistingPermissions(siteOrigin);
       if (existingPermissions.length === 0) {
         return ExistingPermissionsState.None;
       }
@@ -159,9 +160,8 @@ export class ExistingPermissionsService {
         : ExistingPermissionsState.DissimilarPermissions;
     } catch (error) {
       logger.error(
-        'ExistingPermissionsService.getExistingPermissionsStatus() failed',
+        'ExistingPermissionsService.getExistingPermissionsStatusFromList() failed',
         {
-          siteOrigin,
           error: error instanceof Error ? error.message : error,
         },
       );
@@ -170,44 +170,62 @@ export class ExistingPermissionsService {
   }
 
   /**
+   * Compares stored grants for the site to the requested permission (stream vs periodic category).
+   * Fetches from profile sync. Prefer {@link getExistingPermissions} + {@link getExistingPermissionsStatusFromList}
+   * when you already have a snapshot for this origin.
+   *
+   * @param siteOrigin - The requesting dApp origin.
+   * @param requestedPermission - The permission the user is about to grant.
+   * @returns Banner-driving status, or {@link ExistingPermissionsState.None} if none stored or on error.
+   */
+  async getExistingPermissionsStatus(
+    siteOrigin: string,
+    requestedPermission: Permission,
+  ): Promise<ExistingPermissionsState> {
+    const existingPermissions = await this.getExistingPermissions(siteOrigin);
+    return this.getExistingPermissionsStatusFromList(
+      existingPermissions,
+      requestedPermission,
+    );
+  }
+
+  /**
    * Shows existing permissions in a dialog with skeleton loading state.
-   * First displays a skeleton placeholder, then updates with actual formatted content.
+   * Uses a snapshot from {@link getExistingPermissions} so profile sync is not queried again.
    *
    * @param dialogInterface - The dialog interface to show content in.
-   * @param siteOrigin - The origin of the requesting dApp.
+   * @param existingPermissions - Stored grants for this origin (same snapshot as status computation).
    */
   async showExistingPermissions(
     dialogInterface: DialogInterface,
-    siteOrigin: string,
+    existingPermissions: StoredGrantedPermission[],
   ): Promise<void> {
+    const skeletonConfig: ExistingPermissionDisplayConfig = {
+      existingPermissions: [],
+      title: 'existingPermissionsTitle',
+      description: 'existingPermissionsDescription',
+      buttonLabel: 'existingPermissionsConfirmButton',
+    };
+
     try {
-      // Show skeleton immediately with configuration for UI labels
-      const skeletonConfig: ExistingPermissionDisplayConfig = {
-        existingPermissions: [],
-        title: 'existingPermissionsTitle',
-        description: 'existingPermissionsDescription',
-        buttonLabel: 'existingPermissionsConfirmButton',
-      };
       await dialogInterface.show(
         buildExistingPermissionsSkeletonContent(skeletonConfig),
       );
 
-      // Load and format permissions in the background
-      const existingPermissions = await this.getExistingPermissions(siteOrigin);
       const formattedContent =
         await this.createExistingPermissionsContent(existingPermissions);
 
-      // Update dialog with actual content
       await dialogInterface.show(formattedContent);
     } catch (error) {
       logger.error(
         'ExistingPermissionsService.showExistingPermissions() failed',
         {
-          siteOrigin,
           error: error instanceof Error ? error.message : error,
         },
       );
-      // Dialog continues gracefully even if formatting fails
+      await dialogInterface.show(
+        buildExistingPermissionsFallbackContent(skeletonConfig),
+      );
     }
   }
 }

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -1,30 +1,33 @@
-import { Permission } from '@metamask/7715-permissions-shared/types';
+import type { Permission } from '@metamask/7715-permissions-shared/types';
+import {
+  extractDescriptorName,
+  logger,
+} from '@metamask/7715-permissions-shared/utils';
 
 import { buildExistingPermissionsContent } from './existingPermissionsContent';
 import { formatPermissionWithTokenMetadata } from './permissionFormatter';
 import type { ExistingPermissionDisplayConfig } from './types';
-import { extractDescriptorName } from '../../../../shared/src/utils/common';
 import type {
   ProfileSyncManager,
   StoredGrantedPermission,
 } from '../../profileSync/profileSync';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
-import type { UserEventDispatcher } from '../../userEventDispatcher';
 
 /**
- * Extracts the category (stream or periodic) from a permission type.
- * E.g., 'native-token-stream' → 'stream', 'erc20-token-periodic' → 'periodic'
+ * Extracts the category (stream or periodic) from a permission type name.
+ * Uses suffix checks so unrelated names that merely contain "stream" as a substring are not misclassified.
+ *
  * @param permissionTypeName - The permission type name to extract category from.
  * @returns The category ('stream' or 'periodic') or null if unrecognized.
  */
 function extractPermissionCategory(
   permissionTypeName: string,
 ): 'stream' | 'periodic' | null {
-  if (permissionTypeName.includes('stream')) {
-    return 'stream';
-  }
-  if (permissionTypeName.includes('periodic')) {
+  if (permissionTypeName.endsWith('-periodic')) {
     return 'periodic';
+  }
+  if (permissionTypeName.endsWith('-stream')) {
+    return 'stream';
   }
   return null;
 }
@@ -40,8 +43,7 @@ export enum ExistingPermissionsState {
 }
 
 /**
- * Service for displaying existing permissions when a dApp requests new ones.
- * Provides UI for showing the comparison between existing and requested permissions.
+ * Loads stored permissions for a site and builds the existing-permissions review UI (banner + full list).
  */
 export class ExistingPermissionsService {
   readonly #profileSyncManager: ProfileSyncManager;
@@ -53,7 +55,6 @@ export class ExistingPermissionsService {
     tokenMetadataService,
   }: {
     profileSyncManager: ProfileSyncManager;
-    userEventDispatcher: UserEventDispatcher;
     tokenMetadataService: TokenMetadataService;
   }) {
     this.#profileSyncManager = profileSyncManager;
@@ -82,7 +83,14 @@ export class ExistingPermissionsService {
       );
 
       return matching;
-    } catch {
+    } catch (error) {
+      logger.error(
+        'ExistingPermissionsService.getExistingPermissions() failed',
+        {
+          siteOrigin,
+          error: error instanceof Error ? error.message : error,
+        },
+      );
       return [];
     }
   }
@@ -106,7 +114,7 @@ export class ExistingPermissionsService {
       buttonLabel: 'existingPermissionsConfirmButton',
     };
 
-    return Promise.resolve(buildExistingPermissionsContent(config));
+    return buildExistingPermissionsContent(config);
   }
 
   async getExistingPermissionsStatus(
@@ -136,7 +144,14 @@ export class ExistingPermissionsService {
       return hasSimilar
         ? ExistingPermissionsState.SimilarPermissions
         : ExistingPermissionsState.DissimilarPermissions;
-    } catch {
+    } catch (error) {
+      logger.error(
+        'ExistingPermissionsService.getExistingPermissionsStatus() failed',
+        {
+          siteOrigin,
+          error: error instanceof Error ? error.message : error,
+        },
+      );
       return ExistingPermissionsState.None;
     }
   }

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -74,11 +74,15 @@ export class ExistingPermissionsService {
       const allPermissions =
         await this.#profileSyncManager.getAllGrantedPermissions();
 
-      // Return all non-revoked permissions for the origin across all chains
+      // Normalize origin once instead of on each iteration
+      const normalizedOrigin = siteOrigin.toLowerCase();
+
+      // Return all non-revoked permissions for the origin across all chains.
+      // A permission is considered valid if it has both 'from' (account) and 'chainId'.
       const matching = allPermissions.filter(
         (permission) =>
           permission.revocationMetadata === undefined &&
-          permission.siteOrigin.toLowerCase() === siteOrigin.toLowerCase() &&
+          permission.siteOrigin.toLowerCase() === normalizedOrigin &&
           permission.permissionResponse.from &&
           permission.permissionResponse.chainId,
       );

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -65,7 +65,7 @@ export class ExistingPermissionsService {
    * Entries without `permissionResponse.from` or `permissionResponse.chainId` are omitted.
    *
    * @param siteOrigin - The origin of the requesting dApp.
-   * @returns Non-revoked stored grants for the origin, or an empty array on failure or if none match.
+   * @returns Non-revoked stored granted permissions for the origin, or an empty array on failure or if none match.
    */
   async getExistingPermissions(
     siteOrigin: string,

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -1,19 +1,43 @@
-import { UserInputEventType } from '@metamask/snaps-sdk';
+import { Permission } from '@metamask/7715-permissions-shared/types';
 
-import {
-  buildExistingPermissionsContent,
-  buildExistingPermissionsSkeletonContent,
-  EXISTING_PERMISSIONS_CONFIRM_BUTTON,
-} from './existingPermissionsContent';
+import { buildExistingPermissionsContent } from './existingPermissionsContent';
 import { formatPermissionWithTokenMetadata } from './permissionFormatter';
 import type { ExistingPermissionDisplayConfig } from './types';
+import { extractDescriptorName } from '../../../../shared/src/utils/common';
 import type {
   ProfileSyncManager,
   StoredGrantedPermission,
 } from '../../profileSync/profileSync';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
 import type { UserEventDispatcher } from '../../userEventDispatcher';
-import type { DialogInterface } from '../dialogInterface';
+
+/**
+ * Extracts the category (stream or periodic) from a permission type.
+ * E.g., 'native-token-stream' → 'stream', 'erc20-token-periodic' → 'periodic'
+ * @param permissionTypeName - The permission type name to extract category from.
+ * @returns The category ('stream' or 'periodic') or null if unrecognized.
+ */
+function extractPermissionCategory(
+  permissionTypeName: string,
+): 'stream' | 'periodic' | null {
+  if (permissionTypeName.includes('stream')) {
+    return 'stream';
+  }
+  if (permissionTypeName.includes('periodic')) {
+    return 'periodic';
+  }
+  return null;
+}
+
+/**
+ * Status of existing permissions for a site with respect to the currently requested permission.
+ * Used to drive a single network call and one UI decision (banner type or none).
+ */
+export enum ExistingPermissionsState {
+  None = 'None',
+  DissimilarPermissions = 'DissimilarPermissions',
+  SimilarPermissions = 'SimilarPermissions',
+}
 
 /**
  * Service for displaying existing permissions when a dApp requests new ones.
@@ -22,13 +46,10 @@ import type { DialogInterface } from '../dialogInterface';
 export class ExistingPermissionsService {
   readonly #profileSyncManager: ProfileSyncManager;
 
-  readonly #userEventDispatcher: UserEventDispatcher;
-
   readonly #tokenMetadataService: TokenMetadataService;
 
   constructor({
     profileSyncManager,
-    userEventDispatcher,
     tokenMetadataService,
   }: {
     profileSyncManager: ProfileSyncManager;
@@ -36,32 +57,7 @@ export class ExistingPermissionsService {
     tokenMetadataService: TokenMetadataService;
   }) {
     this.#profileSyncManager = profileSyncManager;
-    this.#userEventDispatcher = userEventDispatcher;
     this.#tokenMetadataService = tokenMetadataService;
-  }
-
-  /**
-   * Finds existing permissions matching the given origin.
-   * Returns all permissions granted to the origin across all chains (not limited to the requested chainId).
-   * Filters by isRevoked and siteOrigin only.
-   *
-   * @param siteOrigin - The origin of the requesting dApp.
-   * @returns An array of matching stored permissions across all chains, or an empty array if not found.
-   */
-  async #findMatchingExistingPermission(
-    siteOrigin: string,
-  ): Promise<StoredGrantedPermission[]> {
-    const allPermissions =
-      await this.#profileSyncManager.getAllGrantedPermissions();
-
-    // Return all non-revoked permissions for the origin across all chains
-    const matching = allPermissions.filter(
-      (permission) =>
-        permission.revocationMetadata === undefined &&
-        permission.siteOrigin.toLowerCase() === siteOrigin.toLowerCase(),
-    );
-
-    return matching;
   }
 
   /**
@@ -73,121 +69,75 @@ export class ExistingPermissionsService {
     siteOrigin: string,
   ): Promise<StoredGrantedPermission[]> {
     try {
-      return await this.#findMatchingExistingPermission(siteOrigin);
+      const allPermissions =
+        await this.#profileSyncManager.getAllGrantedPermissions();
+
+      // Return all non-revoked permissions for the origin across all chains
+      const matching = allPermissions.filter(
+        (permission) =>
+          permission.revocationMetadata === undefined &&
+          permission.siteOrigin.toLowerCase() === siteOrigin.toLowerCase() &&
+          permission.permissionResponse.from &&
+          permission.permissionResponse.chainId,
+      );
+
+      return matching;
     } catch {
       return [];
     }
   }
 
-  /**
-   * Shows the existing permissions dialog and waits for user acknowledgement.
-   * @param options - The options object.
-   * @param options.dialogInterface - The dialog interface to use for displaying content.
-   * @param options.existingPermissions - The existing permissions to display.
-   * @returns Object with wasCancelled flag indicating if user dismissed the dialog.
-   */
-  async showExistingPermissions({
-    dialogInterface,
-    existingPermissions,
-  }: {
-    dialogInterface: DialogInterface;
-    existingPermissions: StoredGrantedPermission[] | undefined;
-  }): Promise<{ wasCancelled: boolean }> {
+  async createExistingPermissionsContent(
+    existingPermissions: StoredGrantedPermission[],
+  ): Promise<JSX.Element> {
+    const formattedPermissions = await Promise.all(
+      existingPermissions.map(async (stored) =>
+        formatPermissionWithTokenMetadata(
+          stored.permissionResponse,
+          this.#tokenMetadataService,
+        ),
+      ),
+    );
+
+    const config: ExistingPermissionDisplayConfig = {
+      existingPermissions: formattedPermissions,
+      title: 'existingPermissionsTitle',
+      description: 'existingPermissionsDescription',
+      buttonLabel: 'existingPermissionsConfirmButton',
+    };
+
+    return Promise.resolve(buildExistingPermissionsContent(config));
+  }
+
+  async getExistingPermissionsStatus(
+    siteOrigin: string,
+    requestedPermission: Permission,
+  ): Promise<ExistingPermissionsState> {
     try {
-      if (!existingPermissions || existingPermissions.length === 0) {
-        return { wasCancelled: false };
+      const existingPermissions = await this.getExistingPermissions(siteOrigin);
+      if (existingPermissions.length === 0) {
+        return ExistingPermissionsState.None;
       }
-
-      // Validate permissions before displaying them
-      // A permission is valid if it has both 'from' and 'chainId' fields
-      const validPermissions = existingPermissions.filter(
-        (stored) =>
-          stored.permissionResponse.from && stored.permissionResponse.chainId,
+      const requestedCategory = extractPermissionCategory(
+        extractDescriptorName(requestedPermission.type),
       );
-
-      // If all permissions are invalid, treat as no existing permissions
-      if (validPermissions.length === 0) {
-        return { wasCancelled: false };
-      }
-
-      // Build configuration for the skeleton display (shown immediately)
-      const config: ExistingPermissionDisplayConfig = {
-        existingPermissions: [],
-        title: 'existingPermissionsTitle',
-        description: 'existingPermissionsDescription',
-        buttonLabel: 'existingPermissionsConfirmButton',
-      };
-
-      // Track unbind functions to clean up handlers
-      const unbindFunctions: (() => void)[] = [];
-
-      // Helper to cleanup all event handlers
-      const unbindAll = (): void => {
-        unbindFunctions.forEach((fn) => fn());
-      };
-
-      const wasConfirmed = await new Promise<boolean>((resolve) => {
-        // Show skeleton immediately
-        const skeletonContent = buildExistingPermissionsSkeletonContent(config);
-
-        dialogInterface
-          .show(skeletonContent, () => {
-            unbindAll();
-            resolve(false); // User cancelled via X button
-          })
-          .then(async (interfaceId) => {
-            try {
-              // Format permissions with token metadata (this may take time)
-              const formattedPermissions = await Promise.all(
-                validPermissions.map(async (stored) =>
-                  formatPermissionWithTokenMetadata(
-                    stored.permissionResponse,
-                    this.#tokenMetadataService,
-                  ),
-                ),
-              );
-
-              // Build configuration for the actual permissions display
-              const actualConfig: ExistingPermissionDisplayConfig = {
-                existingPermissions: formattedPermissions,
-                title: 'existingPermissionsTitle',
-                description: 'existingPermissionsDescription',
-                buttonLabel: 'existingPermissionsConfirmButton',
-              };
-
-              // Update dialog with actual content
-              const actualContent =
-                buildExistingPermissionsContent(actualConfig);
-              await dialogInterface.show(actualContent);
-            } catch {
-              // If formatting fails, dialog still shows with skeleton
-              // This is acceptable - user can still interact with the dialog
-            }
-
-            // Handler for acknowledge button
-            const { unbind: unbindConfirm } = this.#userEventDispatcher.on({
-              elementName: EXISTING_PERMISSIONS_CONFIRM_BUTTON,
-              eventType: UserInputEventType.ButtonClickEvent,
-              interfaceId,
-              handler: async () => {
-                unbindAll();
-                resolve(true); // User acknowledged
-              },
-            });
-            unbindFunctions.push(unbindConfirm);
-
-            return undefined;
-          })
-          .catch(() => {
-            unbindAll();
-            resolve(false); // Error = treat as cancelled
-          });
-      });
-
-      return { wasCancelled: !wasConfirmed };
+      // Only treat as similar when both have a recognized category (stream/periodic) and they match.
+      // Unrecognized types (e.g. revocation) return null; null === null would falsely mark them as similar.
+      const hasSimilar =
+        requestedCategory !== null &&
+        existingPermissions.some((stored) => {
+          const storedCategory = extractPermissionCategory(
+            extractDescriptorName(stored.permissionResponse.permission.type),
+          );
+          return (
+            storedCategory !== null && storedCategory === requestedCategory
+          );
+        });
+      return hasSimilar
+        ? ExistingPermissionsState.SimilarPermissions
+        : ExistingPermissionsState.DissimilarPermissions;
     } catch {
-      // If anything goes wrong, just return false to continue with the flow
-      return { wasCancelled: false };
+      return ExistingPermissionsState.None;
     }
   }
 }

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/7715-permissions-shared/utils';
 
 import { buildExistingPermissionsContent } from './existingPermissionsContent';
+import { ExistingPermissionsState } from './existingPermissionsState';
 import { formatPermissionWithTokenMetadata } from './permissionFormatter';
 import type { ExistingPermissionDisplayConfig } from './types';
 import type {
@@ -12,6 +13,8 @@ import type {
   StoredGrantedPermission,
 } from '../../profileSync/profileSync';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
+
+export { ExistingPermissionsState } from './existingPermissionsState';
 
 /**
  * Extracts the category (stream or periodic) from a permission type name.
@@ -33,17 +36,8 @@ function extractPermissionCategory(
 }
 
 /**
- * Status of existing permissions for a site with respect to the currently requested permission.
- * Used to drive a single network call and one UI decision (banner type or none).
- */
-export enum ExistingPermissionsState {
-  None = 'None',
-  DissimilarPermissions = 'DissimilarPermissions',
-  SimilarPermissions = 'SimilarPermissions',
-}
-
-/**
- * Loads stored permissions for a site and builds the existing-permissions review UI (banner + full list).
+ * Loads stored permissions for a site, classifies them against the current request for banner UI,
+ * and builds the full existing-permissions review screen.
  */
 export class ExistingPermissionsService {
   readonly #profileSyncManager: ProfileSyncManager;
@@ -63,8 +57,10 @@ export class ExistingPermissionsService {
 
   /**
    * Gets existing permissions matching the given origin.
+   * Entries without `permissionResponse.from` or `permissionResponse.chainId` are omitted.
+   *
    * @param siteOrigin - The origin of the requesting dApp.
-   * @returns An array of matching stored permissions, or an empty array if not found.
+   * @returns Non-revoked stored grants for the origin, or an empty array on failure or if none match.
    */
   async getExistingPermissions(
     siteOrigin: string,
@@ -95,6 +91,12 @@ export class ExistingPermissionsService {
     }
   }
 
+  /**
+   * Builds the full-screen list of stored permissions (formatted for display) and a confirm control.
+   *
+   * @param existingPermissions - Stored grants to render; typically from {@link getExistingPermissions}.
+   * @returns JSX for the existing-permissions review container.
+   */
   async createExistingPermissionsContent(
     existingPermissions: StoredGrantedPermission[],
   ): Promise<JSX.Element> {
@@ -117,6 +119,13 @@ export class ExistingPermissionsService {
     return buildExistingPermissionsContent(config);
   }
 
+  /**
+   * Compares stored grants for the site to the requested permission (stream vs periodic category).
+   *
+   * @param siteOrigin - The requesting dApp origin.
+   * @param requestedPermission - The permission the user is about to grant.
+   * @returns Banner-driving status, or {@link ExistingPermissionsState.None} if none stored or on error.
+   */
   async getExistingPermissionsStatus(
     siteOrigin: string,
     requestedPermission: Permission,

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -4,7 +4,10 @@ import {
   logger,
 } from '@metamask/7715-permissions-shared/utils';
 
-import { buildExistingPermissionsContent } from './existingPermissionsContent';
+import {
+  buildExistingPermissionsContent,
+  buildExistingPermissionsSkeletonContent,
+} from './existingPermissionsContent';
 import { ExistingPermissionsState } from './existingPermissionsState';
 import { formatPermissionWithTokenMetadata } from './permissionFormatter';
 import type { ExistingPermissionDisplayConfig } from './types';
@@ -13,6 +16,7 @@ import type {
   StoredGrantedPermission,
 } from '../../profileSync/profileSync';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
+import type { DialogInterface } from '../dialogInterface';
 
 export { ExistingPermissionsState } from './existingPermissionsState';
 
@@ -162,6 +166,48 @@ export class ExistingPermissionsService {
         },
       );
       return ExistingPermissionsState.None;
+    }
+  }
+
+  /**
+   * Shows existing permissions in a dialog with skeleton loading state.
+   * First displays a skeleton placeholder, then updates with actual formatted content.
+   *
+   * @param dialogInterface - The dialog interface to show content in.
+   * @param siteOrigin - The origin of the requesting dApp.
+   */
+  async showExistingPermissions(
+    dialogInterface: DialogInterface,
+    siteOrigin: string,
+  ): Promise<void> {
+    try {
+      // Show skeleton immediately with configuration for UI labels
+      const skeletonConfig: ExistingPermissionDisplayConfig = {
+        existingPermissions: [],
+        title: 'existingPermissionsTitle',
+        description: 'existingPermissionsDescription',
+        buttonLabel: 'existingPermissionsConfirmButton',
+      };
+      await dialogInterface.show(
+        buildExistingPermissionsSkeletonContent(skeletonConfig),
+      );
+
+      // Load and format permissions in the background
+      const existingPermissions = await this.getExistingPermissions(siteOrigin);
+      const formattedContent =
+        await this.createExistingPermissionsContent(existingPermissions);
+
+      // Update dialog with actual content
+      await dialogInterface.show(formattedContent);
+    } catch (error) {
+      logger.error(
+        'ExistingPermissionsService.showExistingPermissions() failed',
+        {
+          siteOrigin,
+          error: error instanceof Error ? error.message : error,
+        },
+      );
+      // Dialog continues gracefully even if formatting fails
     }
   }
 }

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsState.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsState.ts
@@ -1,0 +1,9 @@
+/**
+ * Status of existing permissions for a site with respect to the currently requested permission.
+ * Drives banner severity and whether the confirmation flow prefetches stored grants for this origin.
+ */
+export enum ExistingPermissionsState {
+  None = 'None',
+  DissimilarPermissions = 'DissimilarPermissions',
+  SimilarPermissions = 'SimilarPermissions',
+}

--- a/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
@@ -7,7 +7,4 @@ export {
   formatPermissionWithTokenMetadata,
   groupPermissionsByFromAddress,
 } from './permissionFormatter';
-export type {
-  ExistingPermissionDisplayConfig,
-  FormattedPermissionForDisplay,
-} from './types';
+export type { ExistingPermissionDisplayConfig } from './types';

--- a/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
@@ -1,3 +1,4 @@
+export { ExistingPermissionsState } from './existingPermissionsState';
 export { ExistingPermissionsService } from './existingPermissionsService';
 export {
   buildExistingPermissionsContent,

--- a/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
@@ -2,6 +2,7 @@ export { ExistingPermissionsState } from './existingPermissionsState';
 export { ExistingPermissionsService } from './existingPermissionsService';
 export {
   buildExistingPermissionsContent,
+  buildExistingPermissionsFallbackContent,
   buildExistingPermissionsSkeletonContent,
   EXISTING_PERMISSIONS_CONFIRM_BUTTON,
 } from './existingPermissionsContent';

--- a/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
@@ -2,6 +2,7 @@ export { ExistingPermissionsState } from './existingPermissionsState';
 export { ExistingPermissionsService } from './existingPermissionsService';
 export {
   buildExistingPermissionsContent,
+  buildExistingPermissionsSkeletonContent,
   EXISTING_PERMISSIONS_CONFIRM_BUTTON,
 } from './existingPermissionsContent';
 export {

--- a/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/index.ts
@@ -1,7 +1,6 @@
 export { ExistingPermissionsService } from './existingPermissionsService';
 export {
   buildExistingPermissionsContent,
-  buildExistingPermissionsSkeletonContent,
   EXISTING_PERMISSIONS_CONFIRM_BUTTON,
 } from './existingPermissionsContent';
 export {

--- a/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
@@ -3,7 +3,6 @@ import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import { hexToNumber } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import type { FormattedPermissionForDisplay } from './types';
 import { DEFAULT_MAX_AMOUNT } from '../../permissions/erc20TokenStream/context';
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
 import { t } from '../../utils/i18n';
@@ -15,7 +14,10 @@ import { nameAndExplorerUrlByChainId } from '../chainMetadata';
  * Represents formatted permission details as an object.
  */
 export type PermissionDetail = {
-  [key: string]: string;
+  [key: string]: {
+    label: string;
+    value: string;
+  };
 };
 
 /**
@@ -45,14 +47,14 @@ function formatTokenAmountWithMetadata(
 
 /**
  * Extracts permission details into a display-friendly format.
- * Converts a permission (response or display-formatted) into a key-value object for UI rendering.
+ * Converts a permission (response or display-formatted) into a structured object with translated labels and formatted values.
  * Note: Token amounts (periodAmount, maxAmount) should be pre-formatted with metadata by formatPermissionWithTokenMetadata.
  *
  * @param permission - The permission to extract details from (should be pre-formatted with token metadata).
- * @returns Object of permission details for display.
+ * @returns Object of permission details with label, value, and key for each field.
  */
 function extractPermissionDetails(
-  permission: FormattedPermissionForDisplay,
+  permission: PermissionResponse,
 ): PermissionDetail {
   const details: PermissionDetail = {};
 
@@ -61,11 +63,12 @@ function extractPermissionDetails(
   // Extract chain information
   const chainMetadata =
     nameAndExplorerUrlByChainId[hexToNumber(permission.chainId)];
-  if (chainMetadata) {
-    details[t('chainLabel')] = chainMetadata.name;
-  } else {
-    details[t('chainLabel')] = permission.chainId;
-  }
+  const chainLabel = t('chainLabel');
+  const chainValue = chainMetadata ? chainMetadata.name : permission.chainId;
+  details.chainId = {
+    label: chainLabel,
+    value: chainValue,
+  };
 
   // Extract permission details based on permission type
   const permissionData = permission.permission.data;
@@ -73,14 +76,22 @@ function extractPermissionDetails(
   if (permissionData && typeof permissionData === 'object') {
     // For revocation-type permissions
     if (permissionType === 'erc20-token-revocation') {
-      details[t('revokeTokenApprovalsLabel')] = t('allTokens');
+      const revokeLabel = t('revokeTokenApprovalsLabel');
+      const revokeValue = t('allTokens');
+      details.tokenApprovals = {
+        label: revokeLabel,
+        value: revokeValue,
+      };
 
       // Add justification if available
       if ('justification' in permissionData) {
         const { justification } = permissionData;
         if (justification !== undefined && justification !== null) {
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string -- display value from permission data
-          details[t('justificationLabel')] = String(justification);
+          const justificationLabel = t('justificationLabel');
+          details.justification = {
+            label: justificationLabel,
+            value: String(justification),
+          };
         }
       }
     }
@@ -92,14 +103,18 @@ function extractPermissionDetails(
       const { periodAmount, periodDuration, justification } = permissionData;
 
       if (periodAmount !== undefined && periodAmount !== null) {
+        const amountLabel = t('amountLabel');
         // periodAmount is already formatted with token metadata by formatPermissionWithTokenMetadata
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string -- display value from permission data
-        details[t('amountLabel')] = String(periodAmount);
+        details.periodAmount = {
+          label: amountLabel,
+          value: String(periodAmount),
+        };
       }
 
       if (periodDuration !== undefined && periodDuration !== null) {
         const timePeriod = getClosestTimePeriod(Number(periodDuration));
-        details[t('periodDurationLabel')] = t(
+        const durationLabel = t('periodDurationLabel');
+        const durationValue = t(
           timePeriod.toLowerCase() as
             | 'hourly'
             | 'daily'
@@ -108,11 +123,18 @@ function extractPermissionDetails(
             | 'monthly'
             | 'yearly',
         );
+        details.periodDuration = {
+          label: durationLabel,
+          value: durationValue,
+        };
       }
 
       if (justification !== undefined && justification !== null) {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string -- display value from permission data
-        details[t('justificationLabel')] = String(justification);
+        const justificationLabel = t('justificationLabel');
+        details.justification = {
+          label: justificationLabel,
+          value: String(justification),
+        };
       }
     }
     // For stream-type permissions
@@ -123,21 +145,32 @@ function extractPermissionDetails(
       const { maxAmount, startTime, justification } = permissionData;
 
       if (maxAmount !== undefined && maxAmount !== null) {
+        const maxAmountLabel = t('maxAmountLabel');
         // maxAmount is already formatted with token metadata by formatPermissionWithTokenMetadata
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string -- display value from permission data
-        details[t('maxAmountLabel')] = String(maxAmount);
+        details.maxAmount = {
+          label: maxAmountLabel,
+          value: String(maxAmount),
+        };
       }
 
       if (startTime !== undefined && startTime !== null) {
+        const startTimeLabel = t('startTimeLabel');
         const date = new Date(Number(startTime) * 1000);
-        details[t('startTimeLabel')] = date.toLocaleString(undefined, {
+        const startTimeValue = date.toLocaleString(undefined, {
           timeZone: 'UTC',
         });
+        details.startTime = {
+          label: startTimeLabel,
+          value: startTimeValue,
+        };
       }
 
       if (justification !== undefined && justification !== null) {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string -- display value from permission data
-        details[t('justificationLabel')] = String(justification);
+        const justificationLabel = t('justificationLabel');
+        details.justification = {
+          label: justificationLabel,
+          value: String(justification),
+        };
       }
     }
   }
@@ -153,7 +186,7 @@ function extractPermissionDetails(
  * @returns Object with CAIP-10 addresses as keys and arrays of permission details as values.
  */
 export function groupPermissionsByFromAddress(
-  permissions: FormattedPermissionForDisplay[],
+  permissions: PermissionResponse[],
 ): Record<Hex, PermissionDetail[]> {
   const result: Record<Hex, PermissionDetail[]> = {};
 
@@ -183,12 +216,12 @@ export function groupPermissionsByFromAddress(
  *
  * @param permission - The permission response to format.
  * @param tokenMetadataService - Service for fetching token metadata.
- * @returns The permission with display-formatted token amounts; typed as FormattedPermissionForDisplay to prevent misuse.
+ * @returns The permission with display-formatted token amounts; typed as PermissionResponse to prevent misuse.
  */
 export async function formatPermissionWithTokenMetadata(
   permission: PermissionResponse,
   tokenMetadataService: TokenMetadataService,
-): Promise<FormattedPermissionForDisplay> {
+): Promise<PermissionResponse> {
   const permissionData = permission.permission.data as Record<string, unknown>;
 
   if (!permissionData || typeof permissionData !== 'object') {

--- a/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
@@ -1,5 +1,8 @@
 import type { PermissionResponse } from '@metamask/7715-permissions-shared/types';
-import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
+import {
+  extractDescriptorName,
+  logger,
+} from '@metamask/7715-permissions-shared/utils';
 import { hexToNumber } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
@@ -293,8 +296,14 @@ export async function formatPermissionWithTokenMetadata(
         data: formattedData,
       },
     };
-  } catch {
-    // If token metadata fetch fails, return original permission
+  } catch (error) {
+    logger.debug(
+      'formatPermissionWithTokenMetadata: token metadata fetch failed, using raw permission data',
+      {
+        chainId: permission.chainId,
+        error: error instanceof Error ? error.message : error,
+      },
+    );
     return permission;
   }
 }

--- a/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
@@ -182,10 +182,11 @@ function extractPermissionDetails(
 }
 
 /**
- * Converts existingPermissions array to an object keyed by CAIP-10 from address.
- * Groups already-formatted permissions by account address.
+ * Converts permissions to an object keyed by CAIP-10 `from` address.
+ * Callers should pass responses that have been through {@link formatPermissionWithTokenMetadata}
+ * when token amounts should appear human-readable in the UI.
  *
- * @param permissions - The display-formatted permissions to group.
+ * @param permissions - Permission responses to group (entries without `from`/`chainId` are skipped).
  * @returns Object with CAIP-10 addresses as keys and arrays of permission details as values.
  */
 export function groupPermissionsByFromAddress(
@@ -219,7 +220,8 @@ export function groupPermissionsByFromAddress(
  *
  * @param permission - The permission response to format.
  * @param tokenMetadataService - Service for fetching token metadata.
- * @returns The permission with display-formatted token amounts; typed as PermissionResponse to prevent misuse.
+ * @returns The same permission shape with display-formatted token amounts in `data`; still typed as
+ *   `PermissionResponse`, so treat `data` as UI-only after this call (not raw hex for on-chain math).
  */
 export async function formatPermissionWithTokenMetadata(
   permission: PermissionResponse,

--- a/packages/gator-permissions-snap/src/core/existingpermissions/types.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/types.ts
@@ -3,24 +3,11 @@ import type { PermissionResponse } from '@metamask/7715-permissions-shared/types
 import type { MessageKey } from '../../utils/i18n';
 
 /**
- * Permission response with display-formatted fields (e.g. `maxAmount` as "1.5 ETH" instead of Hex).
- * Use only for UI display. Do not pass to code that expects raw Hex (e.g. formatUnitsFromHex, hexToNumber).
- */
-export type FormattedPermissionForDisplay = Omit<
-  PermissionResponse,
-  'permission'
-> & {
-  permission: Omit<PermissionResponse['permission'], 'data'> & {
-    data: Record<string, unknown>;
-  };
-};
-
-/**
  * Configuration for displaying existing permissions.
  */
 export type ExistingPermissionDisplayConfig = {
   /** The existing permissions to display (with formatted values for UI only) */
-  existingPermissions: FormattedPermissionForDisplay[];
+  existingPermissions: PermissionResponse[];
   /** The translation key for the dialog title */
   title: MessageKey;
   /** The translation key for the comparison description */

--- a/packages/gator-permissions-snap/src/core/permissionHandler.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandler.ts
@@ -53,7 +53,7 @@ import { logger } from '../../../shared/src/utils/logger';
 import { createCancellableOperation } from '../utils/cancellableOperation';
 import type { MessageKey } from '../utils/i18n';
 import { formatUnits } from '../utils/value';
-import { ExistingPermissionsState } from './existingpermissions/existingPermissionsService';
+import type { ExistingPermissionsState } from './existingpermissions/existingPermissionsState';
 
 export const JUSTIFICATION_SHOW_MORE_BUTTON_NAME = 'show-more-justification';
 
@@ -221,6 +221,7 @@ export class PermissionHandler<
       scanDappUrlResult,
       scanAddressResult,
       existingPermissionsStatus,
+      isGrantDisabled,
     }: {
       context: TContext;
       metadata: TMetadata;
@@ -229,6 +230,7 @@ export class PermissionHandler<
       scanDappUrlResult: ScanDappUrlResult | null;
       scanAddressResult: FetchAddressScanResult | null;
       existingPermissionsStatus: ExistingPermissionsState;
+      isGrantDisabled: boolean;
     }): Promise<JSX.Element> => {
       const { name: networkName, explorerUrl } = getChainMetadata({ chainId });
 
@@ -270,6 +272,7 @@ export class PermissionHandler<
         explorerUrl,
         isAccountUpgraded: this.#accountUpgradeStatus.isUpgraded,
         existingPermissionsStatus,
+        isGrantDisabled,
       });
     };
 

--- a/packages/gator-permissions-snap/src/core/permissionHandler.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandler.ts
@@ -30,9 +30,11 @@ import type {
   AccountUpgradeStatus,
 } from './accountController';
 import { getChainMetadata } from './chainMetadata';
+import { EXISTING_PERMISSIONS_CONFIRM_BUTTON } from './existingpermissions';
 import {
   ACCOUNT_SELECTOR_NAME,
   PermissionHandlerContent,
+  SHOW_EXISTING_PERMISSIONS_BUTTON_NAME,
   SkeletonPermissionHandlerContent,
 } from './permissionHandlerContent';
 import type { PermissionRequestLifecycleOrchestrator } from './permissionRequestLifecycleOrchestrator';
@@ -51,6 +53,7 @@ import { logger } from '../../../shared/src/utils/logger';
 import { createCancellableOperation } from '../utils/cancellableOperation';
 import type { MessageKey } from '../utils/i18n';
 import { formatUnits } from '../utils/value';
+import { ExistingPermissionsState } from './existingpermissions/existingPermissionsService';
 
 export const JUSTIFICATION_SHOW_MORE_BUTTON_NAME = 'show-more-justification';
 
@@ -217,6 +220,7 @@ export class PermissionHandler<
       chainId,
       scanDappUrlResult,
       scanAddressResult,
+      existingPermissionsStatus,
     }: {
       context: TContext;
       metadata: TMetadata;
@@ -224,6 +228,7 @@ export class PermissionHandler<
       chainId: number;
       scanDappUrlResult: ScanDappUrlResult | null;
       scanAddressResult: FetchAddressScanResult | null;
+      existingPermissionsStatus: ExistingPermissionsState;
     }): Promise<JSX.Element> => {
       const { name: networkName, explorerUrl } = getChainMetadata({ chainId });
 
@@ -264,6 +269,7 @@ export class PermissionHandler<
         chainId,
         explorerUrl,
         isAccountUpgraded: this.#accountUpgradeStatus.isUpgraded,
+        existingPermissionsStatus,
       });
     };
 
@@ -418,6 +424,34 @@ export class PermissionHandler<
         },
       });
 
+      const { unbind: unbindShowExistingPermissionsButtonClick } =
+        this.#userEventDispatcher.on({
+          elementName: SHOW_EXISTING_PERMISSIONS_BUTTON_NAME,
+          eventType: UserInputEventType.ButtonClickEvent,
+          interfaceId,
+          handler: async () => {
+            currentContext = {
+              ...currentContext,
+              showExistingPermissions: true,
+            };
+            await rerender();
+          },
+        });
+
+      const { unbind: unbindExistingPermissionsConfirmButtonClick } =
+        this.#userEventDispatcher.on({
+          elementName: EXISTING_PERMISSIONS_CONFIRM_BUTTON,
+          eventType: UserInputEventType.ButtonClickEvent,
+          interfaceId,
+          handler: async () => {
+            currentContext = {
+              ...currentContext,
+              showExistingPermissions: false,
+            };
+            await rerender();
+          },
+        });
+
       const unbindRuleHandlers = bindRuleHandlers({
         rules: this.#rules,
         userEventDispatcher: this.#userEventDispatcher,
@@ -433,6 +467,8 @@ export class PermissionHandler<
         unbindRuleHandlers();
         unbindShowMoreButtonClick();
         unbindAccountSelected();
+        unbindShowExistingPermissionsButtonClick();
+        unbindExistingPermissionsConfirmButtonClick();
       };
     };
 

--- a/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
@@ -280,7 +280,7 @@ export const PermissionHandlerContent = ({
         <Button
           name={ConfirmationDialog.grantButton}
           variant="primary"
-          disabled={false}
+          disabled={ConfirmationDialog.isGrantDisabled}
         >
           {t('grantButton')}
         </Button>

--- a/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
@@ -9,9 +9,12 @@ import {
   AccountSelector,
   Banner,
   Button,
+  Container,
+  Footer,
 } from '@metamask/snaps-sdk/jsx';
 import { parseCaipAssetType } from '@metamask/utils';
 
+import { ConfirmationDialog } from './confirmation';
 import { JUSTIFICATION_SHOW_MORE_BUTTON_NAME } from './permissionHandler';
 import type { BaseContext, IconData } from './types';
 import {
@@ -183,92 +186,106 @@ export const PermissionHandlerContent = ({
   );
 
   return (
-    <Box>
-      <Box direction="vertical">
-        <Box center={true}>
-          <Heading size="lg">{t(permissionTitle)}</Heading>
-          <Text>{t(permissionSubtitle)}</Text>
-        </Box>
-        <Section>
-          <Box direction="vertical">
-            <Box direction="horizontal" alignment="space-between">
-              <Box direction="horizontal">
-                <Text>{t('accountLabel')}</Text>
-                <TooltipIcon tooltip={t('accountTooltip')} />
-              </Box>
-            </Box>
-            <AccountSelector
-              name={ACCOUNT_SELECTOR_NAME}
-              chainIds={[`eip155:${chainId}`]}
-              switchGlobalAccount={false}
-              value={context.accountAddressCaip10}
-            />
-            {!isAccountUpgraded && (
-              <Text size="sm" color="warning">
-                {t('accountUpgradeWarning')}
-              </Text>
-            )}
-            {hasAsset && (
-              <Box direction="horizontal" alignment="end">
-                {fiatBalanceComponent}
-                {tokenBalanceComponent}
-              </Box>
-            )}
+    <Container>
+      <Box>
+        <Box direction="vertical">
+          <Box center={true}>
+            <Heading size="lg">{t(permissionTitle)}</Heading>
+            <Text>{t(permissionSubtitle)}</Text>
           </Box>
-        </Section>
-        {existingPermissionsStatus ===
-          ExistingPermissionsState.SimilarPermissions && (
-          <Banner title={t('existingPermissionsTitle')} severity="warning">
-            <Text>{t('existingPermissionsSimilarMessage')}</Text>
-            <Button name={SHOW_EXISTING_PERMISSIONS_BUTTON_NAME}>
-              {t('existingPermissionsLink')}
-            </Button>
-          </Banner>
-        )}
-        {existingPermissionsStatus ===
-          ExistingPermissionsState.DissimilarPermissions && (
-          <Banner title={t('existingPermissionsTitle')} severity="info">
-            <Text>{t('existingPermissionsExistingMessage')}</Text>
-            <Button name={SHOW_EXISTING_PERMISSIONS_BUTTON_NAME}>
-              {t('existingPermissionsLink')}
-            </Button>
-          </Banner>
-        )}
-        <Section>
-          <Box direction="vertical" alignment="space-between">
-            <Box direction="horizontal">
-              <Text>{t('justificationLabel')}</Text>
-              <TooltipIcon tooltip={t('justificationTooltip')} />
+          <Section>
+            <Box direction="vertical">
+              <Box direction="horizontal" alignment="space-between">
+                <Box direction="horizontal">
+                  <Text>{t('accountLabel')}</Text>
+                  <TooltipIcon tooltip={t('accountTooltip')} />
+                </Box>
+              </Box>
+              <AccountSelector
+                name={ACCOUNT_SELECTOR_NAME}
+                chainIds={[`eip155:${chainId}`]}
+                switchGlobalAccount={false}
+                value={context.accountAddressCaip10}
+              />
+              {!isAccountUpgraded && (
+                <Text size="sm" color="warning">
+                  {t('accountUpgradeWarning')}
+                </Text>
+              )}
+              {hasAsset && (
+                <Box direction="horizontal" alignment="end">
+                  {fiatBalanceComponent}
+                  {tokenBalanceComponent}
+                </Box>
+              )}
             </Box>
-            <ShowMoreText
-              text={justification}
-              buttonName={JUSTIFICATION_SHOW_MORE_BUTTON_NAME}
-              isCollapsed={isJustificationCollapsed}
-            />
-          </Box>
-        </Section>
-        <Section>
-          {fromField}
-          {addressField}
-          <TextField
-            label={t('networkLabel')}
-            value={networkName}
-            tooltip={t('networkTooltip')}
-          />
-          {hasAsset && (
-            <TokenField
-              label={t('tokenLabel')}
-              tokenSymbol={tokenSymbol}
-              tokenAddress={tokenAddress}
-              explorerUrl={tokenExplorerUrl}
-              tooltip={t('tokenTooltip')}
-              iconData={tokenIconData}
-            />
+          </Section>
+          {existingPermissionsStatus ===
+            ExistingPermissionsState.SimilarPermissions && (
+            <Banner title={t('existingPermissionsTitle')} severity="warning">
+              <Text>{t('existingPermissionsSimilarMessage')}</Text>
+              <Button name={SHOW_EXISTING_PERMISSIONS_BUTTON_NAME}>
+                {t('existingPermissionsLink')}
+              </Button>
+            </Banner>
           )}
-        </Section>
-        {children}
+          {existingPermissionsStatus ===
+            ExistingPermissionsState.DissimilarPermissions && (
+            <Banner title={t('existingPermissionsTitle')} severity="info">
+              <Text>{t('existingPermissionsExistingMessage')}</Text>
+              <Button name={SHOW_EXISTING_PERMISSIONS_BUTTON_NAME}>
+                {t('existingPermissionsLink')}
+              </Button>
+            </Banner>
+          )}
+          <Section>
+            <Box direction="vertical" alignment="space-between">
+              <Box direction="horizontal">
+                <Text>{t('justificationLabel')}</Text>
+                <TooltipIcon tooltip={t('justificationTooltip')} />
+              </Box>
+              <ShowMoreText
+                text={justification}
+                buttonName={JUSTIFICATION_SHOW_MORE_BUTTON_NAME}
+                isCollapsed={isJustificationCollapsed}
+              />
+            </Box>
+          </Section>
+          <Section>
+            {fromField}
+            {addressField}
+            <TextField
+              label={t('networkLabel')}
+              value={networkName}
+              tooltip={t('networkTooltip')}
+            />
+            {hasAsset && (
+              <TokenField
+                label={t('tokenLabel')}
+                tokenSymbol={tokenSymbol}
+                tokenAddress={tokenAddress}
+                explorerUrl={tokenExplorerUrl}
+                tooltip={t('tokenTooltip')}
+                iconData={tokenIconData}
+              />
+            )}
+          </Section>
+          {children}
+        </Box>
       </Box>
-    </Box>
+      <Footer>
+        <Button name={ConfirmationDialog.cancelButton} variant="destructive">
+          {t('cancelButton')}
+        </Button>
+        <Button
+          name={ConfirmationDialog.grantButton}
+          variant="primary"
+          disabled={false}
+        >
+          {t('grantButton')}
+        </Button>
+      </Footer>
+    </Container>
   );
 };
 
@@ -280,49 +297,66 @@ export const SkeletonPermissionHandlerContent = ({
   permissionSubtitle: MessageKey;
 }): JSX.Element => {
   return (
-    <Box>
-      <Box direction="vertical">
-        <Box center={true}>
-          <Heading size="lg">{t(permissionTitle)}</Heading>
-          <Text>{t(permissionSubtitle)}</Text>
-        </Box>
-        <Section>
-          <Box direction="vertical">
-            <Box direction="horizontal" alignment="space-between">
-              <Box direction="horizontal">
-                <Text>{t('accountLabel')}</Text>
-                <TooltipIcon tooltip={t('accountTooltip')} />
-              </Box>
-            </Box>
-            <Skeleton />
+    <Container>
+      <Box>
+        <Box direction="vertical">
+          <Box center={true}>
+            <Heading size="lg">{t(permissionTitle)}</Heading>
+            <Text>{t(permissionSubtitle)}</Text>
           </Box>
-        </Section>
-        <Section>
-          <SkeletonField
-            label={t('justificationLabel')}
-            tooltip={t('justificationTooltip')}
-          />
-        </Section>
-        <Section>
-          <SkeletonField
-            label={t('requestFromLabel')}
-            tooltip={t('requestFromTooltip')}
-          />
-          <SkeletonField
-            label={t('recipientLabel')}
-            tooltip={t('recipientTooltip')}
-          />
-          <SkeletonField
-            label={t('networkLabel')}
-            tooltip={t('networkTooltip')}
-          />
-          <SkeletonField label={t('tokenLabel')} tooltip={t('tokenTooltip')} />
-        </Section>
-        <Section>
-          <Skeleton />
-          <Skeleton />
-        </Section>
+          <Section>
+            <Box direction="vertical">
+              <Box direction="horizontal" alignment="space-between">
+                <Box direction="horizontal">
+                  <Text>{t('accountLabel')}</Text>
+                  <TooltipIcon tooltip={t('accountTooltip')} />
+                </Box>
+              </Box>
+              <Skeleton />
+            </Box>
+          </Section>
+          <Section>
+            <SkeletonField
+              label={t('justificationLabel')}
+              tooltip={t('justificationTooltip')}
+            />
+          </Section>
+          <Section>
+            <SkeletonField
+              label={t('requestFromLabel')}
+              tooltip={t('requestFromTooltip')}
+            />
+            <SkeletonField
+              label={t('recipientLabel')}
+              tooltip={t('recipientTooltip')}
+            />
+            <SkeletonField
+              label={t('networkLabel')}
+              tooltip={t('networkTooltip')}
+            />
+            <SkeletonField
+              label={t('tokenLabel')}
+              tooltip={t('tokenTooltip')}
+            />
+          </Section>
+          <Section>
+            <Skeleton />
+            <Skeleton />
+          </Section>
+        </Box>
       </Box>
-    </Box>
+      <Footer>
+        <Button name={ConfirmationDialog.cancelButton} variant="destructive">
+          {t('cancelButton')}
+        </Button>
+        <Button
+          name={ConfirmationDialog.grantButton}
+          variant="primary"
+          disabled={true}
+        >
+          {t('grantButton')}
+        </Button>
+      </Footer>
+    </Container>
   );
 };

--- a/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
@@ -36,7 +36,7 @@ import {
 } from '../ui/components';
 import type { MessageKey } from '../utils/i18n';
 import { t } from '../utils/i18n';
-import { ExistingPermissionsState } from './existingpermissions/existingPermissionsService';
+import { ExistingPermissionsState } from './existingpermissions/existingPermissionsState';
 
 export const ACCOUNT_SELECTOR_NAME = 'account-selector';
 export const SHOW_EXISTING_PERMISSIONS_BUTTON_NAME =
@@ -64,6 +64,8 @@ export type PermissionHandlerContentProps = {
   explorerUrl: string | undefined;
   isAccountUpgraded: boolean;
   existingPermissionsStatus: ExistingPermissionsState;
+  /** When true, the primary grant button is not clickable. */
+  isGrantDisabled: boolean;
 };
 
 /**
@@ -88,6 +90,7 @@ export type PermissionHandlerContentProps = {
  * @param options.explorerUrl - The URL of the block explorer for the token.
  * @param options.isAccountUpgraded - Whether the account is upgraded to a smart account.
  * @param options.existingPermissionsStatus - Status of existing permissions for banner UI.
+ * @param options.isGrantDisabled - Whether the grant button should render disabled.
  * @returns The confirmation content.
  */
 export const PermissionHandlerContent = ({
@@ -110,6 +113,7 @@ export const PermissionHandlerContent = ({
   explorerUrl,
   isAccountUpgraded,
   existingPermissionsStatus,
+  isGrantDisabled,
 }: PermissionHandlerContentProps): SnapElement => {
   const tokenBalanceComponent = TokenBalanceField({
     tokenBalance,
@@ -280,7 +284,7 @@ export const PermissionHandlerContent = ({
         <Button
           name={ConfirmationDialog.grantButton}
           variant="primary"
-          disabled={ConfirmationDialog.isGrantDisabled}
+          disabled={isGrantDisabled}
         >
           {t('grantButton')}
         </Button>

--- a/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
@@ -7,6 +7,8 @@ import {
   Text,
   Skeleton,
   AccountSelector,
+  Banner,
+  Button,
 } from '@metamask/snaps-sdk/jsx';
 import { parseCaipAssetType } from '@metamask/utils';
 
@@ -31,8 +33,11 @@ import {
 } from '../ui/components';
 import type { MessageKey } from '../utils/i18n';
 import { t } from '../utils/i18n';
+import { ExistingPermissionsState } from './existingpermissions/existingPermissionsService';
 
 export const ACCOUNT_SELECTOR_NAME = 'account-selector';
+export const SHOW_EXISTING_PERMISSIONS_BUTTON_NAME =
+  'show-existing-permissions-button';
 
 export type PermissionHandlerContentProps = {
   children: SnapElement;
@@ -55,6 +60,7 @@ export type PermissionHandlerContentProps = {
   chainId: number;
   explorerUrl: string | undefined;
   isAccountUpgraded: boolean;
+  existingPermissionsStatus: ExistingPermissionsState;
 };
 
 /**
@@ -78,6 +84,7 @@ export type PermissionHandlerContentProps = {
  * @param options.chainId - The chain ID of the network.
  * @param options.explorerUrl - The URL of the block explorer for the token.
  * @param options.isAccountUpgraded - Whether the account is upgraded to a smart account.
+ * @param options.existingPermissionsStatus - Status of existing permissions for banner UI.
  * @returns The confirmation content.
  */
 export const PermissionHandlerContent = ({
@@ -99,6 +106,7 @@ export const PermissionHandlerContent = ({
   chainId,
   explorerUrl,
   isAccountUpgraded,
+  existingPermissionsStatus,
 }: PermissionHandlerContentProps): SnapElement => {
   const tokenBalanceComponent = TokenBalanceField({
     tokenBalance,
@@ -208,6 +216,24 @@ export const PermissionHandlerContent = ({
             )}
           </Box>
         </Section>
+        {existingPermissionsStatus ===
+          ExistingPermissionsState.SimilarPermissions && (
+          <Banner title={t('existingPermissionsTitle')} severity="warning">
+            <Text>{t('existingPermissionsSimilarMessage')}</Text>
+            <Button name={SHOW_EXISTING_PERMISSIONS_BUTTON_NAME}>
+              {t('existingPermissionsLink')}
+            </Button>
+          </Banner>
+        )}
+        {existingPermissionsStatus ===
+          ExistingPermissionsState.DissimilarPermissions && (
+          <Banner title={t('existingPermissionsTitle')} severity="info">
+            <Text>{t('existingPermissionsExistingMessage')}</Text>
+            <Button name={SHOW_EXISTING_PERMISSIONS_BUTTON_NAME}>
+              {t('existingPermissionsLink')}
+            </Button>
+          </Banner>
+        )}
         <Section>
           <Box direction="vertical" alignment="space-between">
             <Box direction="horizontal">

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -43,6 +43,7 @@ import type {
 } from '../clients/trustSignalsClient';
 import type { NonceCaveatService } from '../services/nonceCaveatService';
 import type { SnapsMetricsService } from '../services/snapsMetricsService';
+import { ExistingPermissionsState } from './existingpermissions/existingPermissionsService';
 
 /**
  * Orchestrator for the permission request lifecycle.
@@ -161,10 +162,17 @@ export class PermissionRequestLifecycleOrchestrator {
     const dialogInterface =
       this.#dialogInterfaceFactory.createDialogInterface();
 
-    // Start loading existing permissions in the background before showing introduction
-    // This way if the introduction is shown, the existing permissions will already be loaded
-    const existingPermissionsPromise =
-      this.#existingPermissionsService.getExistingPermissions(origin);
+    // Start loading existing-permissions status in the background so it can run in parallel
+    // with the introduction flow; result is only needed when building confirmation content.
+    // Chain .catch() so the promise never rejects: if the user cancels at intro we return
+    // without awaiting it, and any processing error (e.g. malformed stored permission type)
+    // should not cause an unhandled rejection or crash the dialog.
+    const existingPermissionsStatusPromise = this.#existingPermissionsService
+      .getExistingPermissionsStatus(
+        origin,
+        validatedPermissionRequest.permission,
+      )
+      .catch(() => ExistingPermissionsState.None);
 
     // Check if we need to show introduction
     if (
@@ -196,32 +204,6 @@ export class PermissionRequestLifecycleOrchestrator {
       await this.#permissionIntroductionService.markIntroductionAsSeen(
         permissionType,
       );
-    }
-
-    // Await the existing permissions that were started loading earlier
-    const existingPermissions = await existingPermissionsPromise;
-
-    if (existingPermissions?.length > 0) {
-      const { wasCancelled } =
-        await this.#existingPermissionsService.showExistingPermissions({
-          dialogInterface,
-          existingPermissions,
-        });
-
-      // If user cancelled the existing permissions dialog, reject the permission request
-      if (wasCancelled) {
-        await this.#snapsMetricsService.trackPermissionRejected({
-          origin,
-          permissionType,
-          chainId: permissionRequest.chainId,
-          permissionData: permissionRequest.permission.data,
-        });
-
-        return {
-          approved: false,
-          reason: 'Permission request denied at existing permissions screen',
-        };
-      }
     }
 
     // only necessary when not pre-installed, to ensure that the account
@@ -292,14 +274,24 @@ export class PermissionRequestLifecycleOrchestrator {
 
         const metadata = await lifecycleHandlers.deriveMetadata({ context });
 
-        const ui = await lifecycleHandlers.createConfirmationContent({
-          context,
-          metadata,
-          origin,
-          chainId,
-          scanDappUrlResult,
-          scanAddressResult,
-        });
+        const existingPermissionsStatus =
+          await existingPermissionsStatusPromise;
+
+        const ui = context.showExistingPermissions
+          ? await this.#existingPermissionsService.createExistingPermissionsContent(
+              await this.#existingPermissionsService.getExistingPermissions(
+                origin,
+              ),
+            )
+          : await lifecycleHandlers.createConfirmationContent({
+              context,
+              metadata,
+              origin,
+              chainId,
+              scanDappUrlResult,
+              scanAddressResult,
+              existingPermissionsStatus,
+            });
 
         await confirmationDialog.updateContent({
           ui,

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -43,7 +43,7 @@ import type {
 } from '../clients/trustSignalsClient';
 import type { NonceCaveatService } from '../services/nonceCaveatService';
 import type { SnapsMetricsService } from '../services/snapsMetricsService';
-import { ExistingPermissionsState } from './existingpermissions/existingPermissionsService';
+import { ExistingPermissionsState } from './existingpermissions/existingPermissionsState';
 
 /**
  * Orchestrator for the permission request lifecycle.
@@ -172,7 +172,16 @@ export class PermissionRequestLifecycleOrchestrator {
         origin,
         validatedPermissionRequest.permission,
       )
-      .catch(() => ExistingPermissionsState.None);
+      .catch((error: unknown) => {
+        logger.error(
+          'PermissionRequestLifecycleOrchestrator: getExistingPermissionsStatus rejected',
+          {
+            origin,
+            error: error instanceof Error ? error.message : error,
+          },
+        );
+        return ExistingPermissionsState.None;
+      });
 
     // Check if we need to show introduction
     if (
@@ -277,6 +286,8 @@ export class PermissionRequestLifecycleOrchestrator {
         const existingPermissionsStatus =
           await existingPermissionsStatusPromise;
 
+        const grantDisabled = isGrantDisabled || hasValidationErrors(metadata);
+
         const ui = context.showExistingPermissions
           ? await this.#existingPermissionsService.createExistingPermissionsContent(
               await this.#existingPermissionsService.getExistingPermissions(
@@ -291,12 +302,10 @@ export class PermissionRequestLifecycleOrchestrator {
               scanDappUrlResult,
               scanAddressResult,
               existingPermissionsStatus,
+              isGrantDisabled: grantDisabled,
             });
 
-        await confirmationDialog.updateContent({
-          ui,
-          isGrantDisabled: isGrantDisabled || hasValidationErrors(metadata),
-        });
+        await confirmationDialog.updateContent({ ui });
       };
 
       lastUpdateConfirmationPromise =

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -162,19 +162,24 @@ export class PermissionRequestLifecycleOrchestrator {
     const dialogInterface =
       this.#dialogInterfaceFactory.createDialogInterface();
 
-    // Start loading existing-permissions status in the background so it can run in parallel
-    // with the introduction flow; result is only needed when building confirmation content.
+    // One profile-sync read per permission request: same snapshot drives the banner and the
+    // "review existing" list. getExistingPermissions() already resolves to [] on failure (never rejects).
+    const existingPermissionsForOriginPromise =
+      this.#existingPermissionsService.getExistingPermissions(origin);
+
+    // Derive banner state from that snapshot in parallel with the introduction flow.
     // Chain .catch() so the promise never rejects: if the user cancels at intro we return
-    // without awaiting it, and any processing error (e.g. malformed stored permission type)
-    // should not cause an unhandled rejection or crash the dialog.
-    const existingPermissionsStatusPromise = this.#existingPermissionsService
-      .getExistingPermissionsStatus(
-        origin,
-        validatedPermissionRequest.permission,
+    // without awaiting it, and any processing error should not cause an unhandled rejection.
+    const existingPermissionsStatusPromise = existingPermissionsForOriginPromise
+      .then((list) =>
+        this.#existingPermissionsService.getExistingPermissionsStatusFromList(
+          list,
+          validatedPermissionRequest.permission,
+        ),
       )
       .catch((error: unknown) => {
         logger.error(
-          'PermissionRequestLifecycleOrchestrator: getExistingPermissionsStatus rejected',
+          'PermissionRequestLifecycleOrchestrator: existing permissions status from snapshot failed',
           {
             origin,
             error: error instanceof Error ? error.message : error,
@@ -269,6 +274,9 @@ export class PermissionRequestLifecycleOrchestrator {
     let scanDappUrlResult: ScanDappUrlResult | null = null;
     let scanAddressResult: FetchAddressScanResult | null = null;
 
+    /** Avoid re-running skeleton + format when trust-signal refreshes fire while the subview is open. */
+    let existingPermissionsSubviewActive = false;
+
     const updateConfirmation = async ({
       newContext,
       isGrantDisabled,
@@ -289,12 +297,18 @@ export class PermissionRequestLifecycleOrchestrator {
         const grantDisabled = isGrantDisabled || hasValidationErrors(metadata);
 
         if (context.showExistingPermissions) {
-          // Show skeleton first, then update with real content
-          await this.#existingPermissionsService.showExistingPermissions(
-            dialogInterface,
-            origin,
-          );
+          if (!existingPermissionsSubviewActive) {
+            // Set synchronously before awaits so eslint require-atomic-updates is satisfied;
+            // runUpdate calls are serialized via lastUpdateConfirmationPromise.
+            existingPermissionsSubviewActive = true;
+            const snapshot = await existingPermissionsForOriginPromise;
+            await this.#existingPermissionsService.showExistingPermissions(
+              dialogInterface,
+              snapshot,
+            );
+          }
         } else {
+          existingPermissionsSubviewActive = false;
           const ui = await lifecycleHandlers.createConfirmationContent({
             context,
             metadata,

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -288,24 +288,26 @@ export class PermissionRequestLifecycleOrchestrator {
 
         const grantDisabled = isGrantDisabled || hasValidationErrors(metadata);
 
-        const ui = context.showExistingPermissions
-          ? await this.#existingPermissionsService.createExistingPermissionsContent(
-              await this.#existingPermissionsService.getExistingPermissions(
-                origin,
-              ),
-            )
-          : await lifecycleHandlers.createConfirmationContent({
-              context,
-              metadata,
-              origin,
-              chainId,
-              scanDappUrlResult,
-              scanAddressResult,
-              existingPermissionsStatus,
-              isGrantDisabled: grantDisabled,
-            });
+        if (context.showExistingPermissions) {
+          // Show skeleton first, then update with real content
+          await this.#existingPermissionsService.showExistingPermissions(
+            dialogInterface,
+            origin,
+          );
+        } else {
+          const ui = await lifecycleHandlers.createConfirmationContent({
+            context,
+            metadata,
+            origin,
+            chainId,
+            scanDappUrlResult,
+            scanAddressResult,
+            existingPermissionsStatus,
+            isGrantDisabled: grantDisabled,
+          });
 
-        await confirmationDialog.updateContent({ ui });
+          await confirmationDialog.updateContent({ ui });
+        }
       };
 
       lastUpdateConfirmationPromise =

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -20,6 +20,7 @@ import type { PermissionRequestLifecycleOrchestrator } from './permissionRequest
 import type { TimeoutFactory } from './timeoutFactory';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { MessageKey } from '../utils/i18n';
+import { ExistingPermissionsState } from './existingpermissions/existingPermissionsService';
 
 /**
  * Represents the result of a permission request.
@@ -57,6 +58,7 @@ export type BaseContext = {
     symbol: string;
     iconDataBase64: string | null;
   };
+  showExistingPermissions: boolean | null;
 };
 
 export type BaseMetadata = {
@@ -144,6 +146,7 @@ export type LifecycleOrchestrationHandlers<
     chainId: number;
     scanDappUrlResult: ScanDappUrlResult | null;
     scanAddressResult: FetchAddressScanResult | null;
+    existingPermissionsStatus: ExistingPermissionsState;
   }) => Promise<SnapElement>;
   applyContext: (args: {
     context: TContext;

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -58,7 +58,11 @@ export type BaseContext = {
     symbol: string;
     iconDataBase64: string | null;
   };
-  showExistingPermissions: boolean | null;
+  /**
+   * When true, the confirmation UI shows stored permissions for this site instead of the grant form.
+   * Omitted or falsey means the normal confirmation content. Set by the permission handler when the user opens the existing-permissions view.
+   */
+  showExistingPermissions?: boolean | null;
 };
 
 export type BaseMetadata = {

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -20,7 +20,7 @@ import type { PermissionRequestLifecycleOrchestrator } from './permissionRequest
 import type { TimeoutFactory } from './timeoutFactory';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { MessageKey } from '../utils/i18n';
-import { ExistingPermissionsState } from './existingpermissions/existingPermissionsService';
+import type { ExistingPermissionsState } from './existingpermissions/existingPermissionsState';
 
 /**
  * Represents the result of a permission request.
@@ -151,6 +151,8 @@ export type LifecycleOrchestrationHandlers<
     scanDappUrlResult: ScanDappUrlResult | null;
     scanAddressResult: FetchAddressScanResult | null;
     existingPermissionsStatus: ExistingPermissionsState;
+    /** Whether the grant control should render disabled (validation + caller intent). */
+    isGrantDisabled: boolean;
   }) => Promise<SnapElement>;
   applyContext: (args: {
     context: TContext;
@@ -170,7 +172,6 @@ export type LifecycleOrchestrationHandlers<
    * @param confirmationCreatedArgs.interfaceId - The interface ID for the confirmation dialog
    * @param confirmationCreatedArgs.initialContext - The initial context for the confirmation dialog
    * @param confirmationCreatedArgs.updateContext - Function to update the context of the confirmation dialog
-   * @param confirmationCreatedArgs.isAdjustmentAllowed - Whether adjustments to the confirmation dialog are allowed
    */
   onConfirmationCreated?: (confirmationCreatedArgs: {
     interfaceId: string;

--- a/packages/gator-permissions-snap/src/index.ts
+++ b/packages/gator-permissions-snap/src/index.ts
@@ -191,7 +191,6 @@ const permissionIntroductionService = new PermissionIntroductionService({
 
 const existingPermissionsService = new ExistingPermissionsService({
   profileSyncManager,
-  userEventDispatcher,
   tokenMetadataService,
 });
 

--- a/packages/gator-permissions-snap/src/ui/components/PermissionCard.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/PermissionCard.tsx
@@ -24,16 +24,23 @@ export const PermissionCard = ({
 }: PermissionCardProps): JSX.Element => {
   return (
     <Section key={`permission-${index}`} direction="vertical">
-      {Object.entries(detail).map(([label, value]) => (
-        <Box
-          direction="horizontal"
-          alignment="space-between"
-          key={`${index}-${label}`}
-        >
-          <Text>{label}:</Text>
-          <Text> {value}</Text>
-        </Box>
-      ))}
+      {Object.entries(detail).map(([key, item]) =>
+        key === 'justification' ? (
+          <Box direction="vertical" alignment="start" key={`${index}-${key}`}>
+            <Text>{item.label}:</Text>
+            <Text> {item.value}</Text>
+          </Box>
+        ) : (
+          <Box
+            direction="horizontal"
+            alignment="space-between"
+            key={`${index}-${key}`}
+          >
+            <Text>{item.label}:</Text>
+            <Text> {item.value}</Text>
+          </Box>
+        ),
+      )}
     </Section>
   );
 };

--- a/packages/gator-permissions-snap/src/ui/components/PermissionCard.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/PermissionCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Text } from '@metamask/snaps-sdk/jsx';
+import { Box, Section, Text } from '@metamask/snaps-sdk/jsx';
 
 import type { PermissionDetail } from '../../core/existingpermissions/permissionFormatter';
 
@@ -23,8 +23,7 @@ export const PermissionCard = ({
   index,
 }: PermissionCardProps): JSX.Element => {
   return (
-    <Box key={`permission-${index}`} direction="vertical">
-      {index > 0 && <Divider />}
+    <Section key={`permission-${index}`} direction="vertical">
       {Object.entries(detail).map(([label, value]) => (
         <Box
           direction="horizontal"
@@ -35,6 +34,6 @@ export const PermissionCard = ({
           <Text> {value}</Text>
         </Box>
       ))}
-    </Box>
+    </Section>
   );
 };

--- a/packages/gator-permissions-snap/src/ui/components/PermissionCard.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/PermissionCard.tsx
@@ -23,7 +23,7 @@ export const PermissionCard = ({
   index,
 }: PermissionCardProps): JSX.Element => {
   return (
-    <Section key={`permission-${index}`} direction="vertical">
+    <Section direction="vertical">
       {Object.entries(detail).map(([key, item]) =>
         key === 'justification' ? (
           <Box direction="vertical" alignment="start" key={`${index}-${key}`}>

--- a/packages/gator-permissions-snap/test/core/confirmation.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation.test.ts
@@ -324,7 +324,6 @@ describe('ConfirmationDialog', () => {
 
       await confirmationDialog.updateContent({
         ui: updatedUi,
-        isGrantDisabled: false,
       });
 
       expect(mockSnapsProvider.request).toHaveBeenCalledWith({

--- a/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
@@ -234,7 +234,7 @@ describe('ExistingPermissionsService', () => {
       expect(mockDialogInterface.show).not.toHaveBeenCalled();
     });
 
-    it('should show skeleton immediately then update with real content', async () => {
+    it('should show content after formatting permissions', async () => {
       const permission = createMockStoredPermission();
 
       // Mock dialog.show to capture the callback and resolve immediately
@@ -251,18 +251,15 @@ describe('ExistingPermissionsService', () => {
       // Allow async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // Assert: skeleton should be shown, then updated with real content
-      expect(mockDialogInterface.show).toHaveBeenCalledTimes(2);
+      // Assert: content should be shown once
+      expect(mockDialogInterface.show).toHaveBeenCalledTimes(1);
 
-      // Get both calls
-      const firstCall = mockDialogInterface.show.mock.calls[0];
-      const secondCall = mockDialogInterface.show.mock.calls[1];
-
-      expect(firstCall).toBeDefined();
-      expect(secondCall).toBeDefined();
+      // Get the call
+      const call = mockDialogInterface.show.mock.calls[0];
+      expect(call).toBeDefined();
 
       // Clean up: trigger dialog close to resolve the promise
-      const onCloseCallback = firstCall?.[1];
+      const onCloseCallback = call?.[1];
       onCloseCallback?.();
 
       await resultPromise;

--- a/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, beforeEach, expect, jest } from '@jest/globals';
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  expect,
+  jest,
+} from '@jest/globals';
 import type { Permission } from '@metamask/7715-permissions-shared/types';
+import { logger } from '@metamask/7715-permissions-shared/utils';
 import type { Hex } from '@metamask/utils';
 import { bytesToHex } from '@metamask/utils';
 
@@ -16,7 +24,6 @@ import type {
   TokenMetadata,
   TokenMetadataService,
 } from '../../../src/services/tokenMetadataService';
-import type { UserEventDispatcher } from '../../../src/userEventDispatcher';
 
 // Helper to generate random addresses
 const randomAddress = (): Hex => {
@@ -57,24 +64,16 @@ const createMockStoredPermission = (
 describe('ExistingPermissionsService', () => {
   let service: ExistingPermissionsService;
   let mockProfileSyncManager: jest.Mocked<ProfileSyncManager>;
-  let mockUserEventDispatcher: jest.Mocked<UserEventDispatcher>;
   let mockTokenMetadataService: jest.Mocked<TokenMetadataService>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(logger, 'error').mockImplementation(() => undefined);
 
     // Setup mock ProfileSyncManager
     mockProfileSyncManager = {
       getAllGrantedPermissions: jest.fn(),
     } as unknown as jest.Mocked<ProfileSyncManager>;
-
-    // Setup mock UserEventDispatcher
-    mockUserEventDispatcher = {
-      on: jest.fn().mockReturnValue({
-        unbind: jest.fn(),
-        dispatcher: {} as any,
-      }),
-    } as unknown as jest.Mocked<UserEventDispatcher>;
 
     // Setup mock TokenMetadataService - formatPermissionWithTokenMetadata uses getTokenMetadata
     const tokenMetadata: TokenMetadata = { decimals: 18, symbol: 'ETH' };
@@ -93,9 +92,12 @@ describe('ExistingPermissionsService', () => {
     // Create service with mocks
     service = new ExistingPermissionsService({
       profileSyncManager: mockProfileSyncManager,
-      userEventDispatcher: mockUserEventDispatcher,
       tokenMetadataService: mockTokenMetadataService,
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('getExistingPermissions()', () => {
@@ -183,6 +185,13 @@ describe('ExistingPermissionsService', () => {
 
       // Assert: returns empty array instead of throwing
       expect(result).toStrictEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(
+        'ExistingPermissionsService.getExistingPermissions() failed',
+        expect.objectContaining({
+          siteOrigin: 'https://example.com',
+          error: 'Storage error',
+        }),
+      );
     });
   });
 
@@ -256,6 +265,32 @@ describe('ExistingPermissionsService', () => {
       expect(status).toBe(ExistingPermissionsState.DissimilarPermissions);
     });
 
+    it('should not treat types that merely contain "stream" as stream category', async () => {
+      const permission = createMockStoredPermission();
+      permission.permissionResponse.permission = {
+        type: 'custom-streaming-permission',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      mockProfileSyncManager.getAllGrantedPermissions.mockResolvedValue([
+        permission,
+      ]);
+
+      const requestedPermission: Permission = {
+        type: 'native-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      const status = await service.getExistingPermissionsStatus(
+        'https://example.com',
+        requestedPermission,
+      );
+
+      expect(status).toBe(ExistingPermissionsState.DissimilarPermissions);
+    });
+
     it('should return None on error', async () => {
       mockProfileSyncManager.getAllGrantedPermissions.mockRejectedValue(
         new Error('Storage error'),
@@ -285,7 +320,28 @@ describe('ExistingPermissionsService', () => {
       ]);
 
       expect(content).toBeDefined();
-      expect(mockTokenMetadataService.getTokenMetadata).toBeDefined();
+      expect(mockTokenMetadataService.getTokenMetadata).not.toHaveBeenCalled();
+    });
+
+    it('should call getTokenMetadata when permission has token amount fields', async () => {
+      const from = randomAddress();
+      const permission = createMockStoredPermission('0x1', from);
+      permission.permissionResponse.permission = {
+        type: 'erc20-token-stream',
+        data: {
+          maxAmount: '0xde0b6b3a7640000',
+          tokenAddress: randomAddress(),
+          justification: 'test',
+        },
+        isAdjustmentAllowed: true,
+      };
+
+      const content = await service.createExistingPermissionsContent([
+        permission,
+      ]);
+
+      expect(content).toBeDefined();
+      expect(mockTokenMetadataService.getTokenMetadata).toHaveBeenCalled();
     });
 
     it('should handle empty permission array', async () => {

--- a/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
-import { UserInputEventType } from '@metamask/snaps-sdk';
+import type { Permission } from '@metamask/7715-permissions-shared/types';
 import type { Hex } from '@metamask/utils';
 import { bytesToHex } from '@metamask/utils';
 
 import type { TokenBalanceAndMetadata } from '../../../src/clients/types';
-import type { DialogInterface } from '../../../src/core/dialogInterface';
-import { ExistingPermissionsService } from '../../../src/core/existingpermissions/existingPermissionsService';
+import {
+  ExistingPermissionsService,
+  ExistingPermissionsState,
+} from '../../../src/core/existingpermissions/existingPermissionsService';
 import type {
   ProfileSyncManager,
   StoredGrantedPermission,
@@ -57,7 +59,6 @@ describe('ExistingPermissionsService', () => {
   let mockProfileSyncManager: jest.Mocked<ProfileSyncManager>;
   let mockUserEventDispatcher: jest.Mocked<UserEventDispatcher>;
   let mockTokenMetadataService: jest.Mocked<TokenMetadataService>;
-  let mockDialogInterface: jest.Mocked<DialogInterface>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -88,12 +89,6 @@ describe('ExistingPermissionsService', () => {
           balance: 0n,
         }),
     } as unknown as jest.Mocked<TokenMetadataService>;
-
-    // Setup mock DialogInterface
-    mockDialogInterface = {
-      show: jest.fn(async (_ui: any, _onClose?: () => void) => 'interface-id'),
-      interfaceId: 'interface-id',
-    } as unknown as jest.Mocked<DialogInterface>;
 
     // Create service with mocks
     service = new ExistingPermissionsService({
@@ -191,199 +186,112 @@ describe('ExistingPermissionsService', () => {
     });
   });
 
-  describe('showExistingPermissions()', () => {
-    it('should return early if no existing permissions', async () => {
-      // Action
-      const result = await service.showExistingPermissions({
-        dialogInterface: mockDialogInterface,
-        existingPermissions: undefined,
-      });
+  describe('getExistingPermissionsStatus()', () => {
+    it('should return None when no existing permissions exist', async () => {
+      mockProfileSyncManager.getAllGrantedPermissions.mockResolvedValue([]);
 
-      // Assert
-      expect(result).toStrictEqual({ wasCancelled: false });
-      expect(mockDialogInterface.show).not.toHaveBeenCalled();
-    });
-
-    it('should return early if empty permission array', async () => {
-      // Action
-      const result = await service.showExistingPermissions({
-        dialogInterface: mockDialogInterface,
-        existingPermissions: [],
-      });
-
-      // Assert
-      expect(result).toStrictEqual({ wasCancelled: false });
-      expect(mockDialogInterface.show).not.toHaveBeenCalled();
-    });
-
-    it('should return early if all permissions are invalid', async () => {
-      const invalidPermission1 = createMockStoredPermission();
-      invalidPermission1.permissionResponse.from = undefined as any;
-
-      const invalidPermission2 = createMockStoredPermission();
-      invalidPermission2.permissionResponse.chainId = undefined as any;
-
-      // Action
-      const result = await service.showExistingPermissions({
-        dialogInterface: mockDialogInterface,
-        existingPermissions: [invalidPermission1, invalidPermission2],
-      });
-
-      // Assert: returns early without showing dialog
-      expect(result).toStrictEqual({ wasCancelled: false });
-      expect(mockDialogInterface.show).not.toHaveBeenCalled();
-    });
-
-    it('should show content after formatting permissions', async () => {
-      const permission = createMockStoredPermission();
-
-      // Mock dialog.show to capture the callback and resolve immediately
-      mockDialogInterface.show.mockImplementation(async (_ui, _onClose) => {
-        return 'interface-id';
-      });
-
-      // Action
-      const resultPromise = service.showExistingPermissions({
-        dialogInterface: mockDialogInterface,
-        existingPermissions: [permission],
-      });
-
-      // Allow async operations to complete
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Assert: content should be shown once
-      expect(mockDialogInterface.show).toHaveBeenCalledTimes(1);
-
-      // Get the call
-      const call = mockDialogInterface.show.mock.calls[0];
-      expect(call).toBeDefined();
-
-      // Clean up: trigger dialog close to resolve the promise
-      const onCloseCallback = call?.[1];
-      onCloseCallback?.();
-
-      await resultPromise;
-    });
-
-    it('should call getTokenMetadata when permission has token amount fields', async () => {
-      const permission = createMockStoredPermission();
-      permission.permissionResponse.permission = {
+      const requestedPermission: Permission = {
         type: 'erc20-token-stream',
-        data: {
-          maxAmount: '0xde0b6b3a7640000' as Hex, // 1 ETH in hex
-          startTime: Math.floor(Date.now() / 1000),
-        },
+        data: {},
         isAdjustmentAllowed: true,
       };
 
-      mockDialogInterface.show.mockResolvedValue('interface-id');
-
-      const resultPromise = service.showExistingPermissions({
-        dialogInterface: mockDialogInterface,
-        existingPermissions: [permission],
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      expect(mockTokenMetadataService.getTokenMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({
-          chainId: 1,
-          account: permission.permissionResponse.from,
-        }),
+      const status = await service.getExistingPermissionsStatus(
+        'https://example.com',
+        requestedPermission,
       );
 
-      const onCloseCallback = mockDialogInterface.show.mock.calls[0]?.[1];
-      onCloseCallback?.();
-
-      await resultPromise;
+      expect(status).toBe(ExistingPermissionsState.None);
     });
 
-    it('should filter out invalid permissions from display', async () => {
-      const validPermission = createMockStoredPermission();
-      const invalidPermissionNoFrom = { ...createMockStoredPermission() };
-      invalidPermissionNoFrom.permissionResponse.from = undefined as any;
-
-      mockDialogInterface.show.mockResolvedValue('interface-id');
-
-      // Action
-      const resultPromise = service.showExistingPermissions({
-        dialogInterface: mockDialogInterface,
-        existingPermissions: [validPermission, invalidPermissionNoFrom],
-      });
-
-      // Allow async operations
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Assert: dialog was shown (skeleton + real content attempt)
-      expect(mockDialogInterface.show).toHaveBeenCalled();
-
-      // Trigger dialog close
-      const onCloseCallback = mockDialogInterface.show.mock.calls[0]?.[1];
-      onCloseCallback?.();
-
-      await resultPromise;
-    });
-
-    it('should register button handler for user confirmation', async () => {
-      const permission = createMockStoredPermission();
-
-      mockDialogInterface.show.mockResolvedValue('interface-id');
-
-      // Action
-      const resultPromise = service.showExistingPermissions({
-        dialogInterface: mockDialogInterface,
-        existingPermissions: [permission],
-      });
-
-      // Allow async operations
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Assert: button handler was registered
-      expect(mockUserEventDispatcher.on).toHaveBeenCalledWith(
-        expect.objectContaining({
-          eventType: UserInputEventType.ButtonClickEvent,
-        }),
-      );
-
-      // Clean up
-      const onCloseCallback = mockDialogInterface.show.mock.calls[0]?.[1];
-      onCloseCallback?.();
-
-      await resultPromise;
-    });
-
-    it('should handle errors gracefully without crashing', async () => {
+    it('should return SimilarPermissions when matching categories exist', async () => {
       const permission = createMockStoredPermission();
       permission.permissionResponse.permission = {
         type: 'erc20-token-stream',
-        data: {
-          maxAmount: '0xde0b6b3a7640000' as Hex,
-          startTime: Math.floor(Date.now() / 1000),
-        },
+        data: {},
         isAdjustmentAllowed: true,
       };
-      mockTokenMetadataService.getTokenMetadata.mockRejectedValue(
-        new Error('Token metadata fetch failed'),
+
+      mockProfileSyncManager.getAllGrantedPermissions.mockResolvedValue([
+        permission,
+      ]);
+
+      const requestedPermission: Permission = {
+        type: 'native-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      const status = await service.getExistingPermissionsStatus(
+        'https://example.com',
+        requestedPermission,
       );
 
-      mockDialogInterface.show.mockResolvedValue('interface-id');
+      expect(status).toBe(ExistingPermissionsState.SimilarPermissions);
+    });
 
-      // Action - should not throw when getTokenMetadata fails (dialog stays with skeleton)
-      const resultPromise = service.showExistingPermissions({
-        dialogInterface: mockDialogInterface,
-        existingPermissions: [permission],
-      });
+    it('should return DissimilarPermissions when categories do not match', async () => {
+      const permission = createMockStoredPermission();
+      permission.permissionResponse.permission = {
+        type: 'erc20-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
 
-      // Allow async operations
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      mockProfileSyncManager.getAllGrantedPermissions.mockResolvedValue([
+        permission,
+      ]);
 
-      // Trigger dialog close
-      const onCloseCallback = mockDialogInterface.show.mock.calls[0]?.[1];
-      onCloseCallback?.();
+      const requestedPermission: Permission = {
+        type: 'native-token-periodic',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
 
-      // Assert: should complete without throwing
-      const result = await resultPromise;
-      expect(result).toStrictEqual(expect.objectContaining({}));
+      const status = await service.getExistingPermissionsStatus(
+        'https://example.com',
+        requestedPermission,
+      );
+
+      expect(status).toBe(ExistingPermissionsState.DissimilarPermissions);
+    });
+
+    it('should return None on error', async () => {
+      mockProfileSyncManager.getAllGrantedPermissions.mockRejectedValue(
+        new Error('Storage error'),
+      );
+
+      const requestedPermission: Permission = {
+        type: 'erc20-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      const status = await service.getExistingPermissionsStatus(
+        'https://example.com',
+        requestedPermission,
+      );
+
+      expect(status).toBe(ExistingPermissionsState.None);
+    });
+  });
+
+  describe('createExistingPermissionsContent()', () => {
+    it('should format permissions and build content', async () => {
+      const permission = createMockStoredPermission();
+
+      const content = await service.createExistingPermissionsContent([
+        permission,
+      ]);
+
+      expect(content).toBeDefined();
+      expect(mockTokenMetadataService.getTokenMetadata).toBeDefined();
+    });
+
+    it('should handle empty permission array', async () => {
+      const content = await service.createExistingPermissionsContent([]);
+
+      expect(content).toBeDefined();
     });
   });
 });

--- a/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
@@ -12,6 +12,7 @@ import type { Hex } from '@metamask/utils';
 import { bytesToHex } from '@metamask/utils';
 
 import type { TokenBalanceAndMetadata } from '../../../src/clients/types';
+import type { DialogInterface } from '../../../src/core/dialogInterface';
 import {
   ExistingPermissionsService,
   ExistingPermissionsState,
@@ -308,6 +309,137 @@ describe('ExistingPermissionsService', () => {
       );
 
       expect(status).toBe(ExistingPermissionsState.None);
+    });
+
+    it('should call profile sync only once', async () => {
+      mockProfileSyncManager.getAllGrantedPermissions.mockResolvedValue([]);
+
+      const requestedPermission: Permission = {
+        type: 'erc20-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      await service.getExistingPermissionsStatus(
+        'https://example.com',
+        requestedPermission,
+      );
+
+      expect(
+        mockProfileSyncManager.getAllGrantedPermissions,
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getExistingPermissionsStatusFromList()', () => {
+    it('returns None when list is empty', () => {
+      const requestedPermission: Permission = {
+        type: 'erc20-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      expect(
+        service.getExistingPermissionsStatusFromList([], requestedPermission),
+      ).toBe(ExistingPermissionsState.None);
+    });
+
+    it('returns SimilarPermissions when matching categories exist', () => {
+      const permission = createMockStoredPermission();
+      permission.permissionResponse.permission = {
+        type: 'erc20-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      const requestedPermission: Permission = {
+        type: 'native-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      expect(
+        service.getExistingPermissionsStatusFromList(
+          [permission],
+          requestedPermission,
+        ),
+      ).toBe(ExistingPermissionsState.SimilarPermissions);
+    });
+
+    it('returns DissimilarPermissions when categories do not match', () => {
+      const permission = createMockStoredPermission();
+      permission.permissionResponse.permission = {
+        type: 'erc20-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      const requestedPermission: Permission = {
+        type: 'native-token-periodic',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      expect(
+        service.getExistingPermissionsStatusFromList(
+          [permission],
+          requestedPermission,
+        ),
+      ).toBe(ExistingPermissionsState.DissimilarPermissions);
+    });
+
+    it('does not treat types that merely contain "stream" as stream category', () => {
+      const permission = createMockStoredPermission();
+      permission.permissionResponse.permission = {
+        type: 'custom-streaming-permission',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      const requestedPermission: Permission = {
+        type: 'native-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      expect(
+        service.getExistingPermissionsStatusFromList(
+          [permission],
+          requestedPermission,
+        ),
+      ).toBe(ExistingPermissionsState.DissimilarPermissions);
+    });
+  });
+
+  describe('showExistingPermissions()', () => {
+    it('shows skeleton then list without calling profile sync', async () => {
+      const show = jest.fn().mockResolvedValue(undefined);
+      const dialogInterface = { show } as unknown as DialogInterface;
+
+      await service.showExistingPermissions(dialogInterface, [
+        createMockStoredPermission(),
+      ]);
+
+      expect(show).toHaveBeenCalledTimes(2);
+      expect(
+        mockProfileSyncManager.getAllGrantedPermissions,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('shows fallback UI when formatting fails', async () => {
+      const show = jest.fn().mockResolvedValue(undefined);
+      const dialogInterface = { show } as unknown as DialogInterface;
+      const spy = jest
+        .spyOn(service, 'createExistingPermissionsContent')
+        .mockRejectedValueOnce(new Error('format failed'));
+
+      await service.showExistingPermissions(dialogInterface, [
+        createMockStoredPermission(),
+      ]);
+
+      expect(show).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalled();
+      spy.mockRestore();
     });
   });
 

--- a/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
@@ -1,0 +1,208 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import type { PermissionResponse } from '@metamask/7715-permissions-shared/types';
+import { logger } from '@metamask/7715-permissions-shared/utils';
+import type { Hex } from '@metamask/utils';
+
+import {
+  formatPermissionWithTokenMetadata,
+  groupPermissionsByFromAddress,
+} from '../../../src/core/existingpermissions/permissionFormatter';
+import { DEFAULT_MAX_AMOUNT } from '../../../src/permissions/erc20TokenStream/context';
+import type { TokenMetadataService } from '../../../src/services/tokenMetadataService';
+
+const fromA = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Hex;
+const fromB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Hex;
+const chainId = '0x1' as Hex;
+
+const basePermission = (
+  overrides: Partial<PermissionResponse>,
+): PermissionResponse =>
+  ({
+    chainId,
+    from: fromA,
+    to: '0xcccccccccccccccccccccccccccccccccccccccc' as Hex,
+    context: '0x',
+    dependencies: [],
+    delegationManager: '0xdddddddddddddddddddddddddddddddddddddddd' as Hex,
+    permission: {
+      type: 'erc20-token-stream',
+      data: {},
+      isAdjustmentAllowed: true,
+    },
+    rules: [],
+    ...overrides,
+  }) as PermissionResponse;
+
+describe('groupPermissionsByFromAddress', () => {
+  it('groups permissions by CAIP-10 from address', () => {
+    const p1 = basePermission({
+      permission: {
+        type: 'erc20-token-stream',
+        data: { justification: 'a' },
+        isAdjustmentAllowed: true,
+      },
+    });
+    const p2 = basePermission({
+      from: fromB,
+      permission: {
+        type: 'native-token-stream',
+        data: { justification: 'b' },
+        isAdjustmentAllowed: true,
+      },
+    });
+    const p3 = basePermission({
+      permission: {
+        type: 'erc20-token-periodic',
+        data: { justification: 'c' },
+        isAdjustmentAllowed: true,
+      },
+    });
+
+    const grouped = groupPermissionsByFromAddress([p1, p2, p3]);
+
+    expect(Object.keys(grouped)).toHaveLength(2);
+    expect(grouped[fromA]).toHaveLength(2);
+    expect(grouped[fromB]).toHaveLength(1);
+  });
+
+  it('skips entries without from or chainId', () => {
+    const valid = basePermission({});
+    const missingFrom = basePermission({ from: undefined as unknown as Hex });
+    const missingChain = basePermission({
+      chainId: undefined as unknown as Hex,
+    });
+
+    const grouped = groupPermissionsByFromAddress([
+      valid,
+      missingFrom,
+      missingChain,
+    ]);
+
+    expect(Object.keys(grouped)).toStrictEqual([fromA]);
+  });
+});
+
+describe('formatPermissionWithTokenMetadata', () => {
+  let mockTokenMetadataService: jest.Mocked<
+    Pick<TokenMetadataService, 'getTokenMetadata'>
+  >;
+
+  beforeEach(() => {
+    jest.spyOn(logger, 'debug').mockImplementation(() => undefined);
+    mockTokenMetadataService = {
+      getTokenMetadata: jest
+        .fn()
+        .mockResolvedValue({ decimals: 18, symbol: 'ETH' }),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the permission unchanged when data has no token amount fields', async () => {
+    const permission = basePermission({
+      permission: {
+        type: 'erc20-token-revocation',
+        data: { justification: 'x' },
+        isAdjustmentAllowed: true,
+      },
+    });
+
+    const result = await formatPermissionWithTokenMetadata(
+      permission,
+      mockTokenMetadataService as unknown as TokenMetadataService,
+    );
+
+    expect(result).toStrictEqual(permission);
+    expect(mockTokenMetadataService.getTokenMetadata).not.toHaveBeenCalled();
+  });
+
+  it('formats maxAmount using token metadata', async () => {
+    const permission = basePermission({
+      permission: {
+        type: 'erc20-token-stream',
+        data: {
+          maxAmount: '0x38d7ea4c68000',
+          tokenAddress: '0x0000000000000000000000000000000000000001',
+          justification: 'j',
+        },
+        isAdjustmentAllowed: true,
+      },
+    });
+
+    const result = await formatPermissionWithTokenMetadata(
+      permission,
+      mockTokenMetadataService as unknown as TokenMetadataService,
+    );
+
+    expect(mockTokenMetadataService.getTokenMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chainId: 1,
+        account: fromA,
+        assetAddress: '0x0000000000000000000000000000000000000001',
+      }),
+    );
+    expect(result.permission.data).toMatchObject({
+      maxAmount: expect.stringContaining('ETH') as unknown,
+    });
+  });
+
+  it('maps DEFAULT_MAX_AMOUNT maxAmount to unlimited label', async () => {
+    const permission = basePermission({
+      permission: {
+        type: 'erc20-token-stream',
+        data: {
+          maxAmount: DEFAULT_MAX_AMOUNT,
+          tokenAddress: '0x0000000000000000000000000000000000000001',
+          justification: 'j',
+        },
+        isAdjustmentAllowed: true,
+      },
+    });
+
+    const result = await formatPermissionWithTokenMetadata(
+      permission,
+      mockTokenMetadataService as unknown as TokenMetadataService,
+    );
+
+    expect(result.permission.data).toMatchObject({
+      maxAmount: expect.any(String) as unknown,
+    });
+    const { maxAmount } = result.permission.data as { maxAmount: string };
+    expect(maxAmount.toLowerCase().startsWith('0x')).toBe(false);
+  });
+
+  it('returns original permission when metadata fetch fails', async () => {
+    mockTokenMetadataService.getTokenMetadata.mockRejectedValue(
+      new Error('rpc down'),
+    );
+
+    const permission = basePermission({
+      permission: {
+        type: 'erc20-token-stream',
+        data: {
+          maxAmount: '0x1',
+          tokenAddress: '0x0000000000000000000000000000000000000001',
+          justification: 'j',
+        },
+        isAdjustmentAllowed: true,
+      },
+    });
+
+    const result = await formatPermissionWithTokenMetadata(
+      permission,
+      mockTokenMetadataService as unknown as TokenMetadataService,
+    );
+
+    expect(result).toStrictEqual(permission);
+    expect(logger.debug).toHaveBeenCalled();
+  });
+});

--- a/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
@@ -96,10 +96,13 @@ describe('formatPermissionWithTokenMetadata', () => {
 
   beforeEach(() => {
     jest.spyOn(logger, 'debug').mockImplementation(() => undefined);
+    const getTokenMetadata = jest
+      .fn()
+      .mockResolvedValue({ decimals: 18, symbol: 'ETH' });
     mockTokenMetadataService = {
-      getTokenMetadata: jest
-        .fn()
-        .mockResolvedValue({ decimals: 18, symbol: 'ETH' }),
+      getTokenMetadata: getTokenMetadata as jest.MockedFunction<
+        TokenMetadataService['getTokenMetadata']
+      >,
     };
   });
 

--- a/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
@@ -1224,7 +1224,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": false,
+                "disabled": true,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -1864,7 +1864,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": false,
+                "disabled": true,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -2533,7 +2533,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": false,
+                "disabled": true,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -3138,7 +3138,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": false,
+                "disabled": true,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -3745,7 +3745,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": false,
+                "disabled": true,
                 "name": "grant-button",
                 "variant": "primary",
               },

--- a/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
@@ -5,6 +5,7 @@ import { UserInputEventType } from '@metamask/snaps-sdk';
 import { AddressScanResultType } from '../../src/clients/trustSignalsClient';
 import type { TokenBalanceAndMetadata } from '../../src/clients/types';
 import type { AccountController } from '../../src/core/accountController';
+import { ExistingPermissionsState } from '../../src/core/existingpermissions/existingPermissionsState';
 import { PermissionHandler } from '../../src/core/permissionHandler';
 import type { PermissionRequestLifecycleOrchestrator } from '../../src/core/permissionRequestLifecycleOrchestrator';
 import type {
@@ -414,6 +415,8 @@ describe('PermissionHandler', () => {
           chainId: 1,
           scanDappUrlResult: null,
           scanAddressResult: null,
+          existingPermissionsStatus: ExistingPermissionsState.None,
+          isGrantDisabled: false,
         });
 
         expect(dependencies.createConfirmationContent).toHaveBeenCalledWith({
@@ -436,6 +439,8 @@ describe('PermissionHandler', () => {
           chainId: 1,
           scanDappUrlResult: null,
           scanAddressResult: null,
+          existingPermissionsStatus: ExistingPermissionsState.None,
+          isGrantDisabled: false,
         });
 
         expect(result).toBeDefined();
@@ -459,6 +464,8 @@ describe('PermissionHandler', () => {
             resultType: AddressScanResultType.Malicious,
             label: '',
           },
+          existingPermissionsStatus: ExistingPermissionsState.None,
+          isGrantDisabled: false,
         });
 
         // When label is empty, permissionHandlerContent should use t('maliciousAddressLabel')
@@ -495,7 +502,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         const accountSelectorBoundEvent = getBoundEvent({
@@ -530,7 +536,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         expect(
@@ -558,7 +563,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         const accountSelectorChangeHandler = getBoundEvent({
@@ -607,7 +611,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         const accountSelectorChangeHandler = getBoundEvent({
@@ -654,7 +657,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         const confirmationContent =
@@ -665,6 +667,8 @@ describe('PermissionHandler', () => {
             chainId: 1,
             scanDappUrlResult: null,
             scanAddressResult: null,
+            existingPermissionsStatus: ExistingPermissionsState.None,
+            isGrantDisabled: false,
           });
         expect(confirmationContent).toMatchInlineSnapshot(`
 {
@@ -1224,7 +1228,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": true,
+                "disabled": false,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -1258,7 +1262,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         const accountSelectorChangeHandler = getBoundEvent({
@@ -1290,6 +1293,8 @@ describe('PermissionHandler', () => {
             chainId: 1,
             scanDappUrlResult: null,
             scanAddressResult: null,
+            existingPermissionsStatus: ExistingPermissionsState.None,
+            isGrantDisabled: false,
           });
 
         expect(confirmationContent).toMatchInlineSnapshot(`
@@ -1864,7 +1869,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": true,
+                "disabled": false,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -1923,7 +1928,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         const accountSelectorChangeHandler = getBoundEvent({
@@ -1964,6 +1968,8 @@ describe('PermissionHandler', () => {
             chainId: 1,
             scanDappUrlResult: null,
             scanAddressResult: null,
+            existingPermissionsStatus: ExistingPermissionsState.None,
+            isGrantDisabled: false,
           });
 
         // skeletons in place of both the token balance and fiat balance
@@ -2533,7 +2539,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": true,
+                "disabled": false,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -2563,6 +2569,8 @@ describe('PermissionHandler', () => {
             chainId: 1,
             scanDappUrlResult: null,
             scanAddressResult: null,
+            existingPermissionsStatus: ExistingPermissionsState.None,
+            isGrantDisabled: false,
           });
 
         // concrete token balance, skeleton for fiat balance
@@ -3138,7 +3146,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": true,
+                "disabled": false,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -3168,6 +3176,8 @@ describe('PermissionHandler', () => {
             chainId: 1,
             scanDappUrlResult: null,
             scanAddressResult: null,
+            existingPermissionsStatus: ExistingPermissionsState.None,
+            isGrantDisabled: false,
           });
 
         // concrete token balance, concrete fiat balance
@@ -3745,7 +3755,7 @@ describe('PermissionHandler', () => {
               "key": null,
               "props": {
                 "children": "Grant",
-                "disabled": true,
+                "disabled": false,
                 "name": "grant-button",
                 "variant": "primary",
               },
@@ -3793,7 +3803,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         const accountSelectorChangeHandler = getBoundEvent({
@@ -3847,7 +3856,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: true,
         });
 
         const accountSelectorBoundEvent = getBoundEvent({
@@ -3910,7 +3918,6 @@ describe('PermissionHandler', () => {
           interfaceId: mockInterfaceId,
           initialContext: mockContext,
           updateContext,
-          isAdjustmentAllowed: false, // Adjustment not allowed
         });
 
         // Try to get a rule input handler - it should still be bound

--- a/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionHandler.test.ts
@@ -439,7 +439,7 @@ describe('PermissionHandler', () => {
         });
 
         expect(result).toBeDefined();
-        expect(result.type).toBe('Box');
+        expect(result.type).toBe('Container');
       });
 
       it('uses translated fallback for address warning when scanAddressResult.label is empty', async () => {
@@ -670,513 +670,524 @@ describe('PermissionHandler', () => {
 {
   "key": null,
   "props": {
-    "children": {
-      "key": null,
-      "props": {
-        "children": [
-          {
+    "children": [
+      {
+        "key": null,
+        "props": {
+          "children": {
             "key": null,
             "props": {
-              "center": true,
               "children": [
                 {
                   "key": null,
                   "props": {
-                    "children": "Permission request",
-                    "size": "lg",
+                    "center": true,
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "Permission request",
+                          "size": "lg",
+                        },
+                        "type": "Heading",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "This site wants permissions to spend your tokens.",
+                        },
+                        "type": "Text",
+                      },
+                    ],
                   },
-                  "type": "Heading",
+                  "type": "Box",
                 },
                 {
                   "key": null,
                   "props": {
-                    "children": "This site wants permissions to spend your tokens.",
-                  },
-                  "type": "Text",
-                },
-              ],
-            },
-            "type": "Box",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "children": [
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "space-between",
-                        "children": {
-                          "key": null,
-                          "props": {
-                            "children": [
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": "Account",
-                                },
-                                "type": "Text",
-                              },
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": {
-                                    "key": null,
-                                    "props": {
-                                      "color": "muted",
-                                      "name": "question",
-                                      "size": "inherit",
-                                    },
-                                    "type": "Icon",
-                                  },
-                                  "content": {
-                                    "key": null,
-                                    "props": {
-                                      "children": "The account from which the permission is being granted.",
-                                    },
-                                    "type": "Text",
-                                  },
-                                },
-                                "type": "Tooltip",
-                              },
-                            ],
-                            "direction": "horizontal",
-                          },
-                          "type": "Box",
-                        },
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "chainIds": [
-                          "eip155:1",
-                        ],
-                        "name": "account-selector",
-                        "switchGlobalAccount": false,
-                        "value": "eip155:1:0x1234567890123456789012345678901234567890",
-                      },
-                      "type": "AccountSelector",
-                    },
-                    false,
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "end",
-                        "children": [
-                          {
-                            "key": null,
-                            "props": {},
-                            "type": "Skeleton",
-                          },
-                          {
-                            "key": null,
-                            "props": {},
-                            "type": "Skeleton",
-                          },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "alignment": "space-between",
-                  "children": [
-                    {
+                    "children": {
                       "key": null,
                       "props": {
                         "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Justification",
-                            },
-                            "type": "Text",
-                          },
-                          {
-                            "key": null,
-                            "props": {
+                              "alignment": "space-between",
                               "children": {
                                 "key": null,
                                 "props": {
-                                  "color": "muted",
-                                  "name": "question",
-                                  "size": "inherit",
+                                  "children": [
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Account",
+                                      },
+                                      "type": "Text",
+                                    },
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": {
+                                          "key": null,
+                                          "props": {
+                                            "color": "muted",
+                                            "name": "question",
+                                            "size": "inherit",
+                                          },
+                                          "type": "Icon",
+                                        },
+                                        "content": {
+                                          "key": null,
+                                          "props": {
+                                            "children": "The account from which the permission is being granted.",
+                                          },
+                                          "type": "Text",
+                                        },
+                                      },
+                                      "type": "Tooltip",
+                                    },
+                                  ],
+                                  "direction": "horizontal",
                                 },
-                                "type": "Icon",
+                                "type": "Box",
                               },
-                              "content": {
-                                "key": null,
-                                "props": {
-                                  "children": "Justification given by the recipient for requesting this permission.",
-                                },
-                                "type": "Text",
-                              },
+                              "direction": "horizontal",
                             },
-                            "type": "Tooltip",
+                            "type": "Box",
                           },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Test justification text that is longer than twenty characters",
+                              "chainIds": [
+                                "eip155:1",
+                              ],
+                              "name": "account-selector",
+                              "switchGlobalAccount": false,
+                              "value": "eip155:1:0x1234567890123456789012345678901234567890",
                             },
-                            "type": "Text",
+                            "type": "AccountSelector",
                           },
-                          null,
+                          false,
+                          {
+                            "key": null,
+                            "props": {
+                              "alignment": "end",
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {},
+                                  "type": "Skeleton",
+                                },
+                                {
+                                  "key": null,
+                                  "props": {},
+                                  "type": "Skeleton",
+                                },
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
                         ],
                         "direction": "vertical",
                       },
                       "type": "Box",
                     },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": [
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Request from",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "https://example.com",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                false,
+                false,
                 {
                   "key": null,
                   "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Recipient",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                    "children": {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "0x12345...67890",
+                                    "children": "Justification",
                                   },
                                   "type": "Text",
                                 },
-                                "content": "0x1234567890123456789012345678901234567890",
-                              },
-                              "type": "Tooltip",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Network",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The network on which the permission is being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "Ethereum Mainnet",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Token",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The token being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "ETH",
-                                    "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                    "children": {
+                                      "key": null,
+                                      "props": {
+                                        "color": "muted",
+                                        "name": "question",
+                                        "size": "inherit",
+                                      },
+                                      "type": "Icon",
+                                    },
+                                    "content": {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Justification given by the recipient for requesting this permission.",
+                                      },
+                                      "type": "Text",
+                                    },
                                   },
-                                  "type": "Link",
+                                  "type": "Tooltip",
                                 },
-                                "content": "0x38c4A...611F3",
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": "Test justification text that is longer than twenty characters",
+                                  },
+                                  "type": "Text",
+                                },
+                                null,
+                              ],
+                              "direction": "vertical",
+                            },
+                            "type": "Box",
+                          },
+                        ],
+                        "direction": "vertical",
+                      },
+                      "type": "Box",
+                    },
+                  },
+                  "type": "Section",
+                },
+                {
+                  "key": null,
+                  "props": {
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Request from",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
                               },
-                              "type": "Tooltip",
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "https://example.com",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Recipient",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "0x12345...67890",
+                                        },
+                                        "type": "Text",
+                                      },
+                                      "content": "0x1234567890123456789012345678901234567890",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Network",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The network on which the permission is being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "Ethereum Mainnet",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Token",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The token being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "ETH",
+                                          "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                        },
+                                        "type": "Link",
+                                      },
+                                      "content": "0x38c4A...611F3",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
                             },
                           ],
                           "direction": "horizontal",
@@ -1184,22 +1195,48 @@ describe('PermissionHandler', () => {
                         "type": "Box",
                       },
                     ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                undefined,
               ],
+              "direction": "vertical",
             },
-            "type": "Section",
+            "type": "Box",
           },
-          undefined,
-        ],
-        "direction": "vertical",
+        },
+        "type": "Box",
       },
-      "type": "Box",
-    },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            {
+              "key": null,
+              "props": {
+                "children": "Cancel",
+                "name": "cancel-button",
+                "variant": "destructive",
+              },
+              "type": "Button",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": "Grant",
+                "disabled": false,
+                "name": "grant-button",
+                "variant": "primary",
+              },
+              "type": "Button",
+            },
+          ],
+        },
+        "type": "Footer",
+      },
+    ],
   },
-  "type": "Box",
+  "type": "Container",
 }
 `);
       });
@@ -1259,527 +1296,538 @@ describe('PermissionHandler', () => {
 {
   "key": null,
   "props": {
-    "children": {
-      "key": null,
-      "props": {
-        "children": [
-          {
+    "children": [
+      {
+        "key": null,
+        "props": {
+          "children": {
             "key": null,
             "props": {
-              "center": true,
               "children": [
                 {
                   "key": null,
                   "props": {
-                    "children": "Permission request",
-                    "size": "lg",
+                    "center": true,
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "Permission request",
+                          "size": "lg",
+                        },
+                        "type": "Heading",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "This site wants permissions to spend your tokens.",
+                        },
+                        "type": "Text",
+                      },
+                    ],
                   },
-                  "type": "Heading",
+                  "type": "Box",
                 },
                 {
                   "key": null,
                   "props": {
-                    "children": "This site wants permissions to spend your tokens.",
-                  },
-                  "type": "Text",
-                },
-              ],
-            },
-            "type": "Box",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "children": [
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "space-between",
-                        "children": {
-                          "key": null,
-                          "props": {
-                            "children": [
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": "Account",
-                                },
-                                "type": "Text",
-                              },
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": {
-                                    "key": null,
-                                    "props": {
-                                      "color": "muted",
-                                      "name": "question",
-                                      "size": "inherit",
-                                    },
-                                    "type": "Icon",
-                                  },
-                                  "content": {
-                                    "key": null,
-                                    "props": {
-                                      "children": "The account from which the permission is being granted.",
-                                    },
-                                    "type": "Text",
-                                  },
-                                },
-                                "type": "Tooltip",
-                              },
-                            ],
-                            "direction": "horizontal",
-                          },
-                          "type": "Box",
-                        },
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "chainIds": [
-                          "eip155:1",
-                        ],
-                        "name": "account-selector",
-                        "switchGlobalAccount": false,
-                        "value": "eip155:1:0x1234567890123456789012345678901234567890",
-                      },
-                      "type": "AccountSelector",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": "This account will be upgraded to a smart account to complete this permission.",
-                        "color": "warning",
-                        "size": "sm",
-                      },
-                      "type": "Text",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "end",
-                        "children": [
-                          {
-                            "key": null,
-                            "props": {},
-                            "type": "Skeleton",
-                          },
-                          {
-                            "key": null,
-                            "props": {
-                              "children": [
-                                "1",
-                                " ",
-                                "available",
-                              ],
-                            },
-                            "type": "Text",
-                          },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "alignment": "space-between",
-                  "children": [
-                    {
+                    "children": {
                       "key": null,
                       "props": {
                         "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Justification",
-                            },
-                            "type": "Text",
-                          },
-                          {
-                            "key": null,
-                            "props": {
+                              "alignment": "space-between",
                               "children": {
                                 "key": null,
                                 "props": {
-                                  "color": "muted",
-                                  "name": "question",
-                                  "size": "inherit",
+                                  "children": [
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Account",
+                                      },
+                                      "type": "Text",
+                                    },
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": {
+                                          "key": null,
+                                          "props": {
+                                            "color": "muted",
+                                            "name": "question",
+                                            "size": "inherit",
+                                          },
+                                          "type": "Icon",
+                                        },
+                                        "content": {
+                                          "key": null,
+                                          "props": {
+                                            "children": "The account from which the permission is being granted.",
+                                          },
+                                          "type": "Text",
+                                        },
+                                      },
+                                      "type": "Tooltip",
+                                    },
+                                  ],
+                                  "direction": "horizontal",
                                 },
-                                "type": "Icon",
+                                "type": "Box",
                               },
-                              "content": {
-                                "key": null,
-                                "props": {
-                                  "children": "Justification given by the recipient for requesting this permission.",
-                                },
-                                "type": "Text",
-                              },
+                              "direction": "horizontal",
                             },
-                            "type": "Tooltip",
+                            "type": "Box",
                           },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Test justification text that is longer than twenty characters",
+                              "chainIds": [
+                                "eip155:1",
+                              ],
+                              "name": "account-selector",
+                              "switchGlobalAccount": false,
+                              "value": "eip155:1:0x1234567890123456789012345678901234567890",
+                            },
+                            "type": "AccountSelector",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "This account will be upgraded to a smart account to complete this permission.",
+                              "color": "warning",
+                              "size": "sm",
                             },
                             "type": "Text",
                           },
-                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "alignment": "end",
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {},
+                                  "type": "Skeleton",
+                                },
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": [
+                                      "1",
+                                      " ",
+                                      "available",
+                                    ],
+                                  },
+                                  "type": "Text",
+                                },
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
                         ],
                         "direction": "vertical",
                       },
                       "type": "Box",
                     },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": [
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Request from",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "https://example.com",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                false,
+                false,
                 {
                   "key": null,
                   "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Recipient",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                    "children": {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "0x12345...67890",
+                                    "children": "Justification",
                                   },
                                   "type": "Text",
                                 },
-                                "content": "0x1234567890123456789012345678901234567890",
-                              },
-                              "type": "Tooltip",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Network",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The network on which the permission is being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "Ethereum Mainnet",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Token",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The token being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "ETH",
-                                    "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                    "children": {
+                                      "key": null,
+                                      "props": {
+                                        "color": "muted",
+                                        "name": "question",
+                                        "size": "inherit",
+                                      },
+                                      "type": "Icon",
+                                    },
+                                    "content": {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Justification given by the recipient for requesting this permission.",
+                                      },
+                                      "type": "Text",
+                                    },
                                   },
-                                  "type": "Link",
+                                  "type": "Tooltip",
                                 },
-                                "content": "0x38c4A...611F3",
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": "Test justification text that is longer than twenty characters",
+                                  },
+                                  "type": "Text",
+                                },
+                                null,
+                              ],
+                              "direction": "vertical",
+                            },
+                            "type": "Box",
+                          },
+                        ],
+                        "direction": "vertical",
+                      },
+                      "type": "Box",
+                    },
+                  },
+                  "type": "Section",
+                },
+                {
+                  "key": null,
+                  "props": {
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Request from",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
                               },
-                              "type": "Tooltip",
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "https://example.com",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Recipient",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "0x12345...67890",
+                                        },
+                                        "type": "Text",
+                                      },
+                                      "content": "0x1234567890123456789012345678901234567890",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Network",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The network on which the permission is being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "Ethereum Mainnet",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Token",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The token being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "ETH",
+                                          "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                        },
+                                        "type": "Link",
+                                      },
+                                      "content": "0x38c4A...611F3",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
                             },
                           ],
                           "direction": "horizontal",
@@ -1787,22 +1835,48 @@ describe('PermissionHandler', () => {
                         "type": "Box",
                       },
                     ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                undefined,
               ],
+              "direction": "vertical",
             },
-            "type": "Section",
+            "type": "Box",
           },
-          undefined,
-        ],
-        "direction": "vertical",
+        },
+        "type": "Box",
       },
-      "type": "Box",
-    },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            {
+              "key": null,
+              "props": {
+                "children": "Cancel",
+                "name": "cancel-button",
+                "variant": "destructive",
+              },
+              "type": "Button",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": "Grant",
+                "disabled": false,
+                "name": "grant-button",
+                "variant": "primary",
+              },
+              "type": "Button",
+            },
+          ],
+        },
+        "type": "Footer",
+      },
+    ],
   },
-  "type": "Box",
+  "type": "Container",
 }
 `);
       });
@@ -1897,521 +1971,532 @@ describe('PermissionHandler', () => {
 {
   "key": null,
   "props": {
-    "children": {
-      "key": null,
-      "props": {
-        "children": [
-          {
+    "children": [
+      {
+        "key": null,
+        "props": {
+          "children": {
             "key": null,
             "props": {
-              "center": true,
               "children": [
                 {
                   "key": null,
                   "props": {
-                    "children": "Permission request",
-                    "size": "lg",
+                    "center": true,
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "Permission request",
+                          "size": "lg",
+                        },
+                        "type": "Heading",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "This site wants permissions to spend your tokens.",
+                        },
+                        "type": "Text",
+                      },
+                    ],
                   },
-                  "type": "Heading",
+                  "type": "Box",
                 },
                 {
                   "key": null,
                   "props": {
-                    "children": "This site wants permissions to spend your tokens.",
-                  },
-                  "type": "Text",
-                },
-              ],
-            },
-            "type": "Box",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "children": [
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "space-between",
-                        "children": {
-                          "key": null,
-                          "props": {
-                            "children": [
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": "Account",
-                                },
-                                "type": "Text",
-                              },
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": {
-                                    "key": null,
-                                    "props": {
-                                      "color": "muted",
-                                      "name": "question",
-                                      "size": "inherit",
-                                    },
-                                    "type": "Icon",
-                                  },
-                                  "content": {
-                                    "key": null,
-                                    "props": {
-                                      "children": "The account from which the permission is being granted.",
-                                    },
-                                    "type": "Text",
-                                  },
-                                },
-                                "type": "Tooltip",
-                              },
-                            ],
-                            "direction": "horizontal",
-                          },
-                          "type": "Box",
-                        },
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "chainIds": [
-                          "eip155:1",
-                        ],
-                        "name": "account-selector",
-                        "switchGlobalAccount": false,
-                        "value": "eip155:1:0x1234567890123456789012345678901234567890",
-                      },
-                      "type": "AccountSelector",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": "This account will be upgraded to a smart account to complete this permission.",
-                        "color": "warning",
-                        "size": "sm",
-                      },
-                      "type": "Text",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "end",
-                        "children": [
-                          {
-                            "key": null,
-                            "props": {},
-                            "type": "Skeleton",
-                          },
-                          {
-                            "key": null,
-                            "props": {},
-                            "type": "Skeleton",
-                          },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "alignment": "space-between",
-                  "children": [
-                    {
+                    "children": {
                       "key": null,
                       "props": {
                         "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Justification",
-                            },
-                            "type": "Text",
-                          },
-                          {
-                            "key": null,
-                            "props": {
+                              "alignment": "space-between",
                               "children": {
                                 "key": null,
                                 "props": {
-                                  "color": "muted",
-                                  "name": "question",
-                                  "size": "inherit",
+                                  "children": [
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Account",
+                                      },
+                                      "type": "Text",
+                                    },
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": {
+                                          "key": null,
+                                          "props": {
+                                            "color": "muted",
+                                            "name": "question",
+                                            "size": "inherit",
+                                          },
+                                          "type": "Icon",
+                                        },
+                                        "content": {
+                                          "key": null,
+                                          "props": {
+                                            "children": "The account from which the permission is being granted.",
+                                          },
+                                          "type": "Text",
+                                        },
+                                      },
+                                      "type": "Tooltip",
+                                    },
+                                  ],
+                                  "direction": "horizontal",
                                 },
-                                "type": "Icon",
+                                "type": "Box",
                               },
-                              "content": {
-                                "key": null,
-                                "props": {
-                                  "children": "Justification given by the recipient for requesting this permission.",
-                                },
-                                "type": "Text",
-                              },
+                              "direction": "horizontal",
                             },
-                            "type": "Tooltip",
+                            "type": "Box",
                           },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Test justification text that is longer than twenty characters",
+                              "chainIds": [
+                                "eip155:1",
+                              ],
+                              "name": "account-selector",
+                              "switchGlobalAccount": false,
+                              "value": "eip155:1:0x1234567890123456789012345678901234567890",
+                            },
+                            "type": "AccountSelector",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "This account will be upgraded to a smart account to complete this permission.",
+                              "color": "warning",
+                              "size": "sm",
                             },
                             "type": "Text",
                           },
-                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "alignment": "end",
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {},
+                                  "type": "Skeleton",
+                                },
+                                {
+                                  "key": null,
+                                  "props": {},
+                                  "type": "Skeleton",
+                                },
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
                         ],
                         "direction": "vertical",
                       },
                       "type": "Box",
                     },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": [
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Request from",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "https://example.com",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                false,
+                false,
                 {
                   "key": null,
                   "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Recipient",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                    "children": {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "0x12345...67890",
+                                    "children": "Justification",
                                   },
                                   "type": "Text",
                                 },
-                                "content": "0x1234567890123456789012345678901234567890",
-                              },
-                              "type": "Tooltip",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Network",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The network on which the permission is being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "Ethereum Mainnet",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Token",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The token being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "ETH",
-                                    "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                    "children": {
+                                      "key": null,
+                                      "props": {
+                                        "color": "muted",
+                                        "name": "question",
+                                        "size": "inherit",
+                                      },
+                                      "type": "Icon",
+                                    },
+                                    "content": {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Justification given by the recipient for requesting this permission.",
+                                      },
+                                      "type": "Text",
+                                    },
                                   },
-                                  "type": "Link",
+                                  "type": "Tooltip",
                                 },
-                                "content": "0x38c4A...611F3",
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": "Test justification text that is longer than twenty characters",
+                                  },
+                                  "type": "Text",
+                                },
+                                null,
+                              ],
+                              "direction": "vertical",
+                            },
+                            "type": "Box",
+                          },
+                        ],
+                        "direction": "vertical",
+                      },
+                      "type": "Box",
+                    },
+                  },
+                  "type": "Section",
+                },
+                {
+                  "key": null,
+                  "props": {
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Request from",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
                               },
-                              "type": "Tooltip",
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "https://example.com",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Recipient",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "0x12345...67890",
+                                        },
+                                        "type": "Text",
+                                      },
+                                      "content": "0x1234567890123456789012345678901234567890",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Network",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The network on which the permission is being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "Ethereum Mainnet",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Token",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The token being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "ETH",
+                                          "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                        },
+                                        "type": "Link",
+                                      },
+                                      "content": "0x38c4A...611F3",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
                             },
                           ],
                           "direction": "horizontal",
@@ -2419,22 +2504,48 @@ describe('PermissionHandler', () => {
                         "type": "Box",
                       },
                     ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                undefined,
               ],
+              "direction": "vertical",
             },
-            "type": "Section",
+            "type": "Box",
           },
-          undefined,
-        ],
-        "direction": "vertical",
+        },
+        "type": "Box",
       },
-      "type": "Box",
-    },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            {
+              "key": null,
+              "props": {
+                "children": "Cancel",
+                "name": "cancel-button",
+                "variant": "destructive",
+              },
+              "type": "Button",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": "Grant",
+                "disabled": false,
+                "name": "grant-button",
+                "variant": "primary",
+              },
+              "type": "Button",
+            },
+          ],
+        },
+        "type": "Footer",
+      },
+    ],
   },
-  "type": "Box",
+  "type": "Container",
 }
 `);
 
@@ -2459,527 +2570,538 @@ describe('PermissionHandler', () => {
 {
   "key": null,
   "props": {
-    "children": {
-      "key": null,
-      "props": {
-        "children": [
-          {
+    "children": [
+      {
+        "key": null,
+        "props": {
+          "children": {
             "key": null,
             "props": {
-              "center": true,
               "children": [
                 {
                   "key": null,
                   "props": {
-                    "children": "Permission request",
-                    "size": "lg",
+                    "center": true,
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "Permission request",
+                          "size": "lg",
+                        },
+                        "type": "Heading",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "This site wants permissions to spend your tokens.",
+                        },
+                        "type": "Text",
+                      },
+                    ],
                   },
-                  "type": "Heading",
+                  "type": "Box",
                 },
                 {
                   "key": null,
                   "props": {
-                    "children": "This site wants permissions to spend your tokens.",
-                  },
-                  "type": "Text",
-                },
-              ],
-            },
-            "type": "Box",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "children": [
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "space-between",
-                        "children": {
-                          "key": null,
-                          "props": {
-                            "children": [
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": "Account",
-                                },
-                                "type": "Text",
-                              },
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": {
-                                    "key": null,
-                                    "props": {
-                                      "color": "muted",
-                                      "name": "question",
-                                      "size": "inherit",
-                                    },
-                                    "type": "Icon",
-                                  },
-                                  "content": {
-                                    "key": null,
-                                    "props": {
-                                      "children": "The account from which the permission is being granted.",
-                                    },
-                                    "type": "Text",
-                                  },
-                                },
-                                "type": "Tooltip",
-                              },
-                            ],
-                            "direction": "horizontal",
-                          },
-                          "type": "Box",
-                        },
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "chainIds": [
-                          "eip155:1",
-                        ],
-                        "name": "account-selector",
-                        "switchGlobalAccount": false,
-                        "value": "eip155:1:0x1234567890123456789012345678901234567890",
-                      },
-                      "type": "AccountSelector",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": "This account will be upgraded to a smart account to complete this permission.",
-                        "color": "warning",
-                        "size": "sm",
-                      },
-                      "type": "Text",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "end",
-                        "children": [
-                          {
-                            "key": null,
-                            "props": {},
-                            "type": "Skeleton",
-                          },
-                          {
-                            "key": null,
-                            "props": {
-                              "children": [
-                                "1",
-                                " ",
-                                "available",
-                              ],
-                            },
-                            "type": "Text",
-                          },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "alignment": "space-between",
-                  "children": [
-                    {
+                    "children": {
                       "key": null,
                       "props": {
                         "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Justification",
-                            },
-                            "type": "Text",
-                          },
-                          {
-                            "key": null,
-                            "props": {
+                              "alignment": "space-between",
                               "children": {
                                 "key": null,
                                 "props": {
-                                  "color": "muted",
-                                  "name": "question",
-                                  "size": "inherit",
+                                  "children": [
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Account",
+                                      },
+                                      "type": "Text",
+                                    },
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": {
+                                          "key": null,
+                                          "props": {
+                                            "color": "muted",
+                                            "name": "question",
+                                            "size": "inherit",
+                                          },
+                                          "type": "Icon",
+                                        },
+                                        "content": {
+                                          "key": null,
+                                          "props": {
+                                            "children": "The account from which the permission is being granted.",
+                                          },
+                                          "type": "Text",
+                                        },
+                                      },
+                                      "type": "Tooltip",
+                                    },
+                                  ],
+                                  "direction": "horizontal",
                                 },
-                                "type": "Icon",
+                                "type": "Box",
                               },
-                              "content": {
-                                "key": null,
-                                "props": {
-                                  "children": "Justification given by the recipient for requesting this permission.",
-                                },
-                                "type": "Text",
-                              },
+                              "direction": "horizontal",
                             },
-                            "type": "Tooltip",
+                            "type": "Box",
                           },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Test justification text that is longer than twenty characters",
+                              "chainIds": [
+                                "eip155:1",
+                              ],
+                              "name": "account-selector",
+                              "switchGlobalAccount": false,
+                              "value": "eip155:1:0x1234567890123456789012345678901234567890",
+                            },
+                            "type": "AccountSelector",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "This account will be upgraded to a smart account to complete this permission.",
+                              "color": "warning",
+                              "size": "sm",
                             },
                             "type": "Text",
                           },
-                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "alignment": "end",
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {},
+                                  "type": "Skeleton",
+                                },
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": [
+                                      "1",
+                                      " ",
+                                      "available",
+                                    ],
+                                  },
+                                  "type": "Text",
+                                },
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
                         ],
                         "direction": "vertical",
                       },
                       "type": "Box",
                     },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": [
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Request from",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "https://example.com",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                false,
+                false,
                 {
                   "key": null,
                   "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Recipient",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                    "children": {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "0x12345...67890",
+                                    "children": "Justification",
                                   },
                                   "type": "Text",
                                 },
-                                "content": "0x1234567890123456789012345678901234567890",
-                              },
-                              "type": "Tooltip",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Network",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The network on which the permission is being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "Ethereum Mainnet",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Token",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The token being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "ETH",
-                                    "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                    "children": {
+                                      "key": null,
+                                      "props": {
+                                        "color": "muted",
+                                        "name": "question",
+                                        "size": "inherit",
+                                      },
+                                      "type": "Icon",
+                                    },
+                                    "content": {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Justification given by the recipient for requesting this permission.",
+                                      },
+                                      "type": "Text",
+                                    },
                                   },
-                                  "type": "Link",
+                                  "type": "Tooltip",
                                 },
-                                "content": "0x38c4A...611F3",
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": "Test justification text that is longer than twenty characters",
+                                  },
+                                  "type": "Text",
+                                },
+                                null,
+                              ],
+                              "direction": "vertical",
+                            },
+                            "type": "Box",
+                          },
+                        ],
+                        "direction": "vertical",
+                      },
+                      "type": "Box",
+                    },
+                  },
+                  "type": "Section",
+                },
+                {
+                  "key": null,
+                  "props": {
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Request from",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
                               },
-                              "type": "Tooltip",
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "https://example.com",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Recipient",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "0x12345...67890",
+                                        },
+                                        "type": "Text",
+                                      },
+                                      "content": "0x1234567890123456789012345678901234567890",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Network",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The network on which the permission is being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "Ethereum Mainnet",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Token",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The token being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "ETH",
+                                          "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                        },
+                                        "type": "Link",
+                                      },
+                                      "content": "0x38c4A...611F3",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
                             },
                           ],
                           "direction": "horizontal",
@@ -2987,22 +3109,48 @@ describe('PermissionHandler', () => {
                         "type": "Box",
                       },
                     ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                undefined,
               ],
+              "direction": "vertical",
             },
-            "type": "Section",
+            "type": "Box",
           },
-          undefined,
-        ],
-        "direction": "vertical",
+        },
+        "type": "Box",
       },
-      "type": "Box",
-    },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            {
+              "key": null,
+              "props": {
+                "children": "Cancel",
+                "name": "cancel-button",
+                "variant": "destructive",
+              },
+              "type": "Button",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": "Grant",
+                "disabled": false,
+                "name": "grant-button",
+                "variant": "primary",
+              },
+              "type": "Button",
+            },
+          ],
+        },
+        "type": "Footer",
+      },
+    ],
   },
-  "type": "Box",
+  "type": "Container",
 }
 `);
 
@@ -3027,529 +3175,540 @@ describe('PermissionHandler', () => {
 {
   "key": null,
   "props": {
-    "children": {
-      "key": null,
-      "props": {
-        "children": [
-          {
+    "children": [
+      {
+        "key": null,
+        "props": {
+          "children": {
             "key": null,
             "props": {
-              "center": true,
               "children": [
                 {
                   "key": null,
                   "props": {
-                    "children": "Permission request",
-                    "size": "lg",
+                    "center": true,
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "Permission request",
+                          "size": "lg",
+                        },
+                        "type": "Heading",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "children": "This site wants permissions to spend your tokens.",
+                        },
+                        "type": "Text",
+                      },
+                    ],
                   },
-                  "type": "Heading",
+                  "type": "Box",
                 },
                 {
                   "key": null,
                   "props": {
-                    "children": "This site wants permissions to spend your tokens.",
-                  },
-                  "type": "Text",
-                },
-              ],
-            },
-            "type": "Box",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "children": [
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "space-between",
-                        "children": {
-                          "key": null,
-                          "props": {
-                            "children": [
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": "Account",
-                                },
-                                "type": "Text",
-                              },
-                              {
-                                "key": null,
-                                "props": {
-                                  "children": {
-                                    "key": null,
-                                    "props": {
-                                      "color": "muted",
-                                      "name": "question",
-                                      "size": "inherit",
-                                    },
-                                    "type": "Icon",
-                                  },
-                                  "content": {
-                                    "key": null,
-                                    "props": {
-                                      "children": "The account from which the permission is being granted.",
-                                    },
-                                    "type": "Text",
-                                  },
-                                },
-                                "type": "Tooltip",
-                              },
-                            ],
-                            "direction": "horizontal",
-                          },
-                          "type": "Box",
-                        },
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "chainIds": [
-                          "eip155:1",
-                        ],
-                        "name": "account-selector",
-                        "switchGlobalAccount": false,
-                        "value": "eip155:1:0x1234567890123456789012345678901234567890",
-                      },
-                      "type": "AccountSelector",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": "This account will be upgraded to a smart account to complete this permission.",
-                        "color": "warning",
-                        "size": "sm",
-                      },
-                      "type": "Text",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "alignment": "end",
-                        "children": [
-                          {
-                            "key": null,
-                            "props": {
-                              "children": "$1000",
-                            },
-                            "type": "Text",
-                          },
-                          {
-                            "key": null,
-                            "props": {
-                              "children": [
-                                "1",
-                                " ",
-                                "available",
-                              ],
-                            },
-                            "type": "Text",
-                          },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": {
-                "key": null,
-                "props": {
-                  "alignment": "space-between",
-                  "children": [
-                    {
+                    "children": {
                       "key": null,
                       "props": {
                         "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Justification",
-                            },
-                            "type": "Text",
-                          },
-                          {
-                            "key": null,
-                            "props": {
+                              "alignment": "space-between",
                               "children": {
                                 "key": null,
                                 "props": {
-                                  "color": "muted",
-                                  "name": "question",
-                                  "size": "inherit",
+                                  "children": [
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Account",
+                                      },
+                                      "type": "Text",
+                                    },
+                                    {
+                                      "key": null,
+                                      "props": {
+                                        "children": {
+                                          "key": null,
+                                          "props": {
+                                            "color": "muted",
+                                            "name": "question",
+                                            "size": "inherit",
+                                          },
+                                          "type": "Icon",
+                                        },
+                                        "content": {
+                                          "key": null,
+                                          "props": {
+                                            "children": "The account from which the permission is being granted.",
+                                          },
+                                          "type": "Text",
+                                        },
+                                      },
+                                      "type": "Tooltip",
+                                    },
+                                  ],
+                                  "direction": "horizontal",
                                 },
-                                "type": "Icon",
+                                "type": "Box",
                               },
-                              "content": {
-                                "key": null,
-                                "props": {
-                                  "children": "Justification given by the recipient for requesting this permission.",
-                                },
-                                "type": "Text",
-                              },
+                              "direction": "horizontal",
                             },
-                            "type": "Tooltip",
+                            "type": "Box",
                           },
-                        ],
-                        "direction": "horizontal",
-                      },
-                      "type": "Box",
-                    },
-                    {
-                      "key": null,
-                      "props": {
-                        "children": [
                           {
                             "key": null,
                             "props": {
-                              "children": "Test justification text that is longer than twenty characters",
+                              "chainIds": [
+                                "eip155:1",
+                              ],
+                              "name": "account-selector",
+                              "switchGlobalAccount": false,
+                              "value": "eip155:1:0x1234567890123456789012345678901234567890",
+                            },
+                            "type": "AccountSelector",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": "This account will be upgraded to a smart account to complete this permission.",
+                              "color": "warning",
+                              "size": "sm",
                             },
                             "type": "Text",
                           },
-                          null,
+                          {
+                            "key": null,
+                            "props": {
+                              "alignment": "end",
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": "$1000",
+                                  },
+                                  "type": "Text",
+                                },
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": [
+                                      "1",
+                                      " ",
+                                      "available",
+                                    ],
+                                  },
+                                  "type": "Text",
+                                },
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
                         ],
                         "direction": "vertical",
                       },
                       "type": "Box",
                     },
-                  ],
-                  "direction": "vertical",
-                },
-                "type": "Box",
-              },
-            },
-            "type": "Section",
-          },
-          {
-            "key": null,
-            "props": {
-              "children": [
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Request from",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "https://example.com",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                false,
+                false,
                 {
                   "key": null,
                   "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Recipient",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The site requesting the permission",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                    "children": {
+                      "key": null,
+                      "props": {
+                        "alignment": "space-between",
+                        "children": [
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "0x12345...67890",
+                                    "children": "Justification",
                                   },
                                   "type": "Text",
                                 },
-                                "content": "0x1234567890123456789012345678901234567890",
-                              },
-                              "type": "Tooltip",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Network",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The network on which the permission is being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "alignment": "end",
-                                "children": "Ethereum Mainnet",
-                              },
-                              "type": "Text",
-                            },
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                    ],
-                    "direction": "horizontal",
-                  },
-                  "type": "Box",
-                },
-                {
-                  "key": null,
-                  "props": {
-                    "alignment": "space-between",
-                    "children": [
-                      {
-                        "key": null,
-                        "props": {
-                          "alignment": "space-between",
-                          "children": [
-                            {
-                              "key": null,
-                              "props": {
-                                "children": [
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": "Token",
-                                    },
-                                    "type": "Text",
-                                  },
-                                  {
-                                    "key": null,
-                                    "props": {
-                                      "children": {
-                                        "key": null,
-                                        "props": {
-                                          "color": "muted",
-                                          "name": "question",
-                                          "size": "inherit",
-                                        },
-                                        "type": "Icon",
-                                      },
-                                      "content": {
-                                        "key": null,
-                                        "props": {
-                                          "children": "The token being requested",
-                                        },
-                                        "type": "Text",
-                                      },
-                                    },
-                                    "type": "Tooltip",
-                                  },
-                                ],
-                                "direction": "horizontal",
-                              },
-                              "type": "Box",
-                            },
-                            null,
-                          ],
-                          "direction": "horizontal",
-                        },
-                        "type": "Box",
-                      },
-                      {
-                        "key": null,
-                        "props": {
-                          "children": [
-                            null,
-                            {
-                              "key": null,
-                              "props": {
-                                "children": {
+                                {
                                   "key": null,
                                   "props": {
-                                    "children": "ETH",
-                                    "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                    "children": {
+                                      "key": null,
+                                      "props": {
+                                        "color": "muted",
+                                        "name": "question",
+                                        "size": "inherit",
+                                      },
+                                      "type": "Icon",
+                                    },
+                                    "content": {
+                                      "key": null,
+                                      "props": {
+                                        "children": "Justification given by the recipient for requesting this permission.",
+                                      },
+                                      "type": "Text",
+                                    },
                                   },
-                                  "type": "Link",
+                                  "type": "Tooltip",
                                 },
-                                "content": "0x38c4A...611F3",
+                              ],
+                              "direction": "horizontal",
+                            },
+                            "type": "Box",
+                          },
+                          {
+                            "key": null,
+                            "props": {
+                              "children": [
+                                {
+                                  "key": null,
+                                  "props": {
+                                    "children": "Test justification text that is longer than twenty characters",
+                                  },
+                                  "type": "Text",
+                                },
+                                null,
+                              ],
+                              "direction": "vertical",
+                            },
+                            "type": "Box",
+                          },
+                        ],
+                        "direction": "vertical",
+                      },
+                      "type": "Box",
+                    },
+                  },
+                  "type": "Section",
+                },
+                {
+                  "key": null,
+                  "props": {
+                    "children": [
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Request from",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
                               },
-                              "type": "Tooltip",
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "https://example.com",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Recipient",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The site requesting the permission",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "0x12345...67890",
+                                        },
+                                        "type": "Text",
+                                      },
+                                      "content": "0x1234567890123456789012345678901234567890",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Network",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The network on which the permission is being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "alignment": "end",
+                                      "children": "Ethereum Mainnet",
+                                    },
+                                    "type": "Text",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                          ],
+                          "direction": "horizontal",
+                        },
+                        "type": "Box",
+                      },
+                      {
+                        "key": null,
+                        "props": {
+                          "alignment": "space-between",
+                          "children": [
+                            {
+                              "key": null,
+                              "props": {
+                                "alignment": "space-between",
+                                "children": [
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": [
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": "Token",
+                                          },
+                                          "type": "Text",
+                                        },
+                                        {
+                                          "key": null,
+                                          "props": {
+                                            "children": {
+                                              "key": null,
+                                              "props": {
+                                                "color": "muted",
+                                                "name": "question",
+                                                "size": "inherit",
+                                              },
+                                              "type": "Icon",
+                                            },
+                                            "content": {
+                                              "key": null,
+                                              "props": {
+                                                "children": "The token being requested",
+                                              },
+                                              "type": "Text",
+                                            },
+                                          },
+                                          "type": "Tooltip",
+                                        },
+                                      ],
+                                      "direction": "horizontal",
+                                    },
+                                    "type": "Box",
+                                  },
+                                  null,
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
+                            },
+                            {
+                              "key": null,
+                              "props": {
+                                "children": [
+                                  null,
+                                  {
+                                    "key": null,
+                                    "props": {
+                                      "children": {
+                                        "key": null,
+                                        "props": {
+                                          "children": "ETH",
+                                          "href": "https://etherscan.io/address/0x38c4A4F071d33d6Cf83e2e81F12D9B5D30E611F3",
+                                        },
+                                        "type": "Link",
+                                      },
+                                      "content": "0x38c4A...611F3",
+                                    },
+                                    "type": "Tooltip",
+                                  },
+                                ],
+                                "direction": "horizontal",
+                              },
+                              "type": "Box",
                             },
                           ],
                           "direction": "horizontal",
@@ -3557,22 +3716,48 @@ describe('PermissionHandler', () => {
                         "type": "Box",
                       },
                     ],
-                    "direction": "horizontal",
                   },
-                  "type": "Box",
+                  "type": "Section",
                 },
+                undefined,
               ],
+              "direction": "vertical",
             },
-            "type": "Section",
+            "type": "Box",
           },
-          undefined,
-        ],
-        "direction": "vertical",
+        },
+        "type": "Box",
       },
-      "type": "Box",
-    },
+      {
+        "key": null,
+        "props": {
+          "children": [
+            {
+              "key": null,
+              "props": {
+                "children": "Cancel",
+                "name": "cancel-button",
+                "variant": "destructive",
+              },
+              "type": "Button",
+            },
+            {
+              "key": null,
+              "props": {
+                "children": "Grant",
+                "disabled": false,
+                "name": "grant-button",
+                "variant": "primary",
+              },
+              "type": "Button",
+            },
+          ],
+        },
+        "type": "Footer",
+      },
+    ],
   },
-  "type": "Box",
+  "type": "Container",
 }
 `);
       });

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -27,8 +27,10 @@ import {
 import type { PermissionIntroductionService } from '../../src/core/permissionIntroduction';
 import { PermissionRequestLifecycleOrchestrator } from '../../src/core/permissionRequestLifecycleOrchestrator';
 import type { BaseContext } from '../../src/core/types';
+import type { ProfileSyncManager } from '../../src/profileSync/profileSync';
 import type { NonceCaveatService } from '../../src/services/nonceCaveatService';
 import type { SnapsMetricsService } from '../../src/services/snapsMetricsService';
+import type { TokenMetadataService } from '../../src/services/tokenMetadataService';
 
 const randomAddress = (): Hex => {
   const randomBytes = new Uint8Array(20);
@@ -139,19 +141,30 @@ const mockPermissionIntroductionService = {
   showIntroduction: jest.fn().mockResolvedValue({ wasCancelled: false }),
 } as unknown as jest.Mocked<PermissionIntroductionService>;
 
+const existingPermissionsStatusHelper = new ExistingPermissionsService({
+  profileSyncManager: {
+    getAllGrantedPermissions: jest.fn(),
+  } as unknown as ProfileSyncManager,
+  tokenMetadataService: {} as unknown as TokenMetadataService,
+});
+
 const mockExistingPermissionsService = {
   getExistingPermissions: jest.fn(),
-  getExistingPermissionsStatus: jest.fn(),
-  createExistingPermissionsContent: jest.fn(),
+  getExistingPermissionsStatusFromList: jest.fn(),
+  showExistingPermissions: jest.fn(),
 } as unknown as jest.Mocked<ExistingPermissionsService>;
 
 // Set default mock implementations for existing permissions service
 mockExistingPermissionsService.getExistingPermissions.mockResolvedValue([]);
-mockExistingPermissionsService.getExistingPermissionsStatus.mockResolvedValue(
-  ExistingPermissionsState.None,
+mockExistingPermissionsService.getExistingPermissionsStatusFromList.mockImplementation(
+  (list, perm) =>
+    existingPermissionsStatusHelper.getExistingPermissionsStatusFromList(
+      list,
+      perm,
+    ),
 );
-mockExistingPermissionsService.createExistingPermissionsContent.mockResolvedValue(
-  mockUiContent,
+mockExistingPermissionsService.showExistingPermissions.mockResolvedValue(
+  undefined,
 );
 
 const mockScanAddressResult: FetchAddressScanResult = {
@@ -186,11 +199,15 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
 
     // Reset existing permissions service mocks after clearing
     mockExistingPermissionsService.getExistingPermissions.mockResolvedValue([]);
-    mockExistingPermissionsService.getExistingPermissionsStatus.mockResolvedValue(
-      ExistingPermissionsState.None,
+    mockExistingPermissionsService.getExistingPermissionsStatusFromList.mockImplementation(
+      (list, perm) =>
+        existingPermissionsStatusHelper.getExistingPermissionsStatusFromList(
+          list,
+          perm,
+        ),
     );
-    mockExistingPermissionsService.createExistingPermissionsContent.mockResolvedValue(
-      mockUiContent,
+    mockExistingPermissionsService.showExistingPermissions.mockResolvedValue(
+      undefined,
     );
 
     lifecycleHandlerMocks = {
@@ -297,6 +314,21 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
           to: requestingAccountAddress,
           delegationManager,
         });
+      });
+
+      it('loads existing permissions from profile sync only once per request', async () => {
+        await permissionRequestLifecycleOrchestrator.orchestrate(
+          'test-origin',
+          mockPermissionRequest,
+          lifecycleHandlerMocks,
+        );
+
+        expect(
+          mockExistingPermissionsService.getExistingPermissions,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          mockExistingPermissionsService.getExistingPermissions,
+        ).toHaveBeenCalledWith('test-origin');
       });
 
       it('creates a skeleton confirmation before the context is resolved', async () => {

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -367,7 +367,6 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
 
         expect(mockConfirmationDialog.updateContent).toHaveBeenCalledWith({
           ui: mockUiContent,
-          isGrantDisabled: false,
         });
       });
 
@@ -760,7 +759,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
       });
 
       it('serializes consecutive updateConfirmation calls so they run in order and do not overwrite each other', async () => {
-        // updateConfirmation is called with only newContext and isGrantDisabled; scan results are read from closure variables.
+        // updateConfirmation is called with optional newContext; scan results are read from closure variables.
         mockTrustSignalsClient.scanDappUrl.mockImplementationOnce(
           async (): Promise<ScanDappUrlResult> =>
             new Promise<ScanDappUrlResult>(() => {}),
@@ -1030,6 +1029,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
           scanDappUrlResult: null,
           scanAddressResult: null,
           existingPermissionsStatus: ExistingPermissionsState.None,
+          isGrantDisabled: false,
         });
 
         // Final call has both scan results from closure (after both background scans resolve)
@@ -1043,6 +1043,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
           scanDappUrlResult: { isComplete: false },
           scanAddressResult: mockScanAddressResult,
           existingPermissionsStatus: ExistingPermissionsState.None,
+          isGrantDisabled: false,
         });
 
         expect(mockTrustSignalsClient.fetchAddressScan).toHaveBeenCalledWith(
@@ -1052,7 +1053,6 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
 
         expect(mockConfirmationDialog.updateContent).toHaveBeenCalledWith({
           ui: mockUiContent,
-          isGrantDisabled: false,
         });
       });
 

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -20,12 +20,15 @@ import { getChainMetadata } from '../../src/core/chainMetadata';
 import type { ConfirmationDialog } from '../../src/core/confirmation';
 import type { ConfirmationDialogFactory } from '../../src/core/confirmationFactory';
 import type { DialogInterfaceFactory } from '../../src/core/dialogInterfaceFactory';
+import {
+  ExistingPermissionsService,
+  ExistingPermissionsState,
+} from '../../src/core/existingpermissions/existingPermissionsService';
 import type { PermissionIntroductionService } from '../../src/core/permissionIntroduction';
 import { PermissionRequestLifecycleOrchestrator } from '../../src/core/permissionRequestLifecycleOrchestrator';
 import type { BaseContext } from '../../src/core/types';
+import type { NonceCaveatService } from '../../src/services/nonceCaveatService';
 import type { SnapsMetricsService } from '../../src/services/snapsMetricsService';
-import { ExistingPermissionsService } from 'src/core/existingpermissions/existingPermissionsService';
-import type { NonceCaveatService } from 'src/services/nonceCaveatService';
 
 const randomAddress = (): Hex => {
   const randomBytes = new Uint8Array(20);
@@ -137,9 +140,19 @@ const mockPermissionIntroductionService = {
 } as unknown as jest.Mocked<PermissionIntroductionService>;
 
 const mockExistingPermissionsService = {
-  getExistingPermissions: jest.fn().mockResolvedValue([]),
-  showExistingPermissions: jest.fn().mockResolvedValue({ wasCancelled: false }),
+  getExistingPermissions: jest.fn(),
+  getExistingPermissionsStatus: jest.fn(),
+  createExistingPermissionsContent: jest.fn(),
 } as unknown as jest.Mocked<ExistingPermissionsService>;
+
+// Set default mock implementations for existing permissions service
+mockExistingPermissionsService.getExistingPermissions.mockResolvedValue([]);
+mockExistingPermissionsService.getExistingPermissionsStatus.mockResolvedValue(
+  ExistingPermissionsState.None,
+);
+mockExistingPermissionsService.createExistingPermissionsContent.mockResolvedValue(
+  mockUiContent,
+);
 
 const mockScanAddressResult: FetchAddressScanResult = {
   resultType: AddressScanResultType.Benign,
@@ -170,6 +183,15 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Reset existing permissions service mocks after clearing
+    mockExistingPermissionsService.getExistingPermissions.mockResolvedValue([]);
+    mockExistingPermissionsService.getExistingPermissionsStatus.mockResolvedValue(
+      ExistingPermissionsState.None,
+    );
+    mockExistingPermissionsService.createExistingPermissionsContent.mockResolvedValue(
+      mockUiContent,
+    );
 
     lifecycleHandlerMocks = {
       parseAndValidatePermission: jest.fn().mockImplementation((req) => req),
@@ -1007,6 +1029,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
           chainId: 1,
           scanDappUrlResult: null,
           scanAddressResult: null,
+          existingPermissionsStatus: ExistingPermissionsState.None,
         });
 
         // Final call has both scan results from closure (after both background scans resolve)
@@ -1019,6 +1042,7 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
           chainId: 1,
           scanDappUrlResult: { isComplete: false },
           scanAddressResult: mockScanAddressResult,
+          existingPermissionsStatus: ExistingPermissionsState.None,
         });
 
         expect(mockTrustSignalsClient.fetchAddressScan).toHaveBeenCalledWith(


### PR DESCRIPTION
## **Description**

This PR improves the permission confirmation experience when a dApp origin already has active (non-revoked) granted permissions stored in profile sync.

**User-facing behavior**
- Shows an informational or warning **banner** when existing permissions are detected, with copy that distinguishes **similar** (same broad category: stream vs periodic) vs **dissimilar** permissions.
- Adds a **“Review them”** action that swaps the confirmation UI to a **read-only list** of existing permissions (grouped by account, with formatted token amounts where applicable) and a **Continue** control to return to the normal grant flow.

**Implementation notes**
- Introduces `ExistingPermissionsService` and supporting UI (`existingPermissionsContent`, `PermissionCard`, `permissionFormatter`) integrated via `PermissionRequestLifecycleOrchestrator` and `PermissionHandler` (event handlers for show/hide existing-permissions views).
- Prefetches existing-permissions **status** in parallel with the introduction flow to avoid blocking the first paint of confirmation content.
- **Follow-up hardening**: optional `showExistingPermissions` on `BaseContext` (avoids requiring every `buildContext` to set it); suffix-based stream/periodic categorization (`-stream` / `-periodic`); structured `logger` usage on storage failures and debug logging when token metadata formatting fails; aligned `extractDescriptorName` import with the rest of the snap; removed unused constructor dependency; fixed invalid barrel type export; expanded unit tests (`existingPermissionsService`, `permissionFormatter`).

## **Related issues**

Fixes: <!-- e.g. #123 — replace with your issue -->

## **Manual testing steps**

1. `yarn prepare:snap` (if needed), `yarn build`, then `yarn start` and open the dev site (e.g. http://localhost:8000) with **MetaMask Flask** and the local snaps (kernel / gator) connected.
2. Grant a permission to the test origin for a stream- or periodic-type permission, then trigger **another** permission request from the **same origin**:
   - Confirm a **banner** appears (warning vs info depending on similar vs dissimilar case).
3. Click **“Review them”** and verify the **existing permissions** list renders (accounts, chains, amounts/labels as expected); click **Continue** and confirm you return to the standard confirmation UI.
4. Cancel / complete the flow and confirm no crashes or unhandled rejections when dismissing during intro (existing-permissions status promise should not reject the lifecycle).

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/b3927eda-89cb-45f1-b28f-366a64651b02




## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the permission confirmation UI flow and orchestration (including async updates and button handling), which could impact users’ ability to grant/cancel requests if edge cases regress. Data/security impact is limited since it only reads stored grants and adjusts UI/state.
> 
> **Overview**
> Adds an **existing-permissions banner + review subview** to the permission confirmation experience: when stored non-revoked grants exist for the requesting origin, the confirmation screen shows an info/warning banner (similar vs dissimilar stream/periodic) with a `Review them` action that swaps to a read-only, account-grouped list of existing permissions and a `Back to request` control.
> 
> Refactors confirmation rendering so the footer grant/cancel buttons live inside `PermissionHandlerContent` (not `ConfirmationDialog`), and updates the orchestrator to **prefetch a single profile-sync snapshot** for both banner state and list rendering, with skeleton + fallback UI and improved logging/error handling. Updates permission formatting/display (`PermissionCard`, `permissionFormatter`) to support structured labeled fields and token-amount formatting, and expands tests to cover status classification, formatting behavior, and failure paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62fdddae1009df04d1003eb4e15e981559a5a295. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->