### PR TITLE
Release/19.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-7715-permissions-monorepo",
-  "version": "18.0.0",
+  "version": "19.0.0",
   "private": true,
   "description": "Monorepo for 7715 permissions snaps.",
   "repository": {

--- a/packages/gator-permissions-snap/CHANGELOG.md
+++ b/packages/gator-permissions-snap/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Feat: Existing permissions banner with list ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
+- fix: update warning icon color to error red for malicious addresses ([#287](https://github.com/MetaMask/snap-7715-permissions/pull/287))
+- chore: Add explainer comment to each permission type `caveats.ts` ([#270](https://github.com/MetaMask/snap-7715-permissions/pull/270))
+
 ## [1.3.0]
 
 ### Changed

--- a/packages/gator-permissions-snap/CHANGELOG.md
+++ b/packages/gator-permissions-snap/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- Feat: Existing permissions banner with list ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
-- fix: update warning icon color to error red for malicious addresses ([#287](https://github.com/MetaMask/snap-7715-permissions/pull/287))
-- chore: Add explainer comment to each permission type `caveats.ts` ([#270](https://github.com/MetaMask/snap-7715-permissions/pull/270))
-
 ## [1.3.0]
 
 ### Changed

--- a/packages/permissions-kernel-snap/CHANGELOG.md
+++ b/packages/permissions-kernel-snap/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Feat: Existing permissions banner with list ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
+- fix: update warning icon color to error red for malicious addresses ([#287](https://github.com/MetaMask/snap-7715-permissions/pull/287))
+- chore: Add explainer comment to each permission type `caveats.ts` ([#270](https://github.com/MetaMask/snap-7715-permissions/pull/270))
+- Release/18.0.0 ([#285](https://github.com/MetaMask/snap-7715-permissions/pull/285))
+- fix: existing permissions issues ([#284](https://github.com/MetaMask/snap-7715-permissions/pull/284))
+- feat: enhance existing permissions handling ([#283](https://github.com/MetaMask/snap-7715-permissions/pull/283))
+- Improve clarity of justification field in Permission Picker ([#282](https://github.com/MetaMask/snap-7715-permissions/pull/282))
+
 ## [1.1.0]
 
 ### Added

--- a/yarn.lock
+++ b/yarn.lock
@@ -3853,26 +3853,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.2.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
-  version: 11.9.0
-  resolution: "@metamask/utils@npm:11.9.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^4.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@noble/hashes": "npm:^1.3.1"
-    "@scure/base": "npm:^1.1.3"
-    "@types/debug": "npm:^4.1.7"
-    "@types/lodash": "npm:^4.17.20"
-    debug: "npm:^4.3.4"
-    lodash: "npm:^4.17.21"
-    pony-cause: "npm:^2.1.10"
-    semver: "npm:^7.5.4"
-    uuid: "npm:^9.0.1"
-  checksum: 10/f8f5e99ba6c6de0395ed4e0acc82ee9c0dca26991ea6a8f10b3896e72745790966a8eded8c42be905d9f01fa99c1fd29a7f68541e2ef9854fc14984a0b514ad3
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^11.10.0":
+"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.2.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
   version: 11.10.0
   resolution: "@metamask/utils@npm:11.10.0"
   dependencies:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: version bump, changelog entries, and a lockfile update to resolve `@metamask/utils` to `11.10.0`.
> 
> **Overview**
> Bumps the monorepo version to `19.0.0` and updates both snap `CHANGELOG.md` files with new *Unreleased* entries.
> 
> Also refreshes `yarn.lock`, consolidating `@metamask/utils` dependency ranges to resolve to `11.10.0` (removing the separate `11.9.0` lock entry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44da973962d41d4d0e81c790088f4a76da71e261. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->