### PR TITLE
Release/19.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-7715-permissions-monorepo",
-  "version": "18.0.0",
+  "version": "19.0.0",
   "private": true,
   "description": "Monorepo for 7715 permissions snaps.",
   "repository": {

--- a/packages/gator-permissions-snap/CHANGELOG.md
+++ b/packages/gator-permissions-snap/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Feat: Existing permissions banner with list ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
+- fix: update warning icon color to error red for malicious addresses ([#287](https://github.com/MetaMask/snap-7715-permissions/pull/287))
+- chore: Add explainer comment to each permission type `caveats.ts` ([#270](https://github.com/MetaMask/snap-7715-permissions/pull/270))
+
 ## [1.3.0]
 
 ### Changed

--- a/packages/gator-permissions-snap/CHANGELOG.md
+++ b/packages/gator-permissions-snap/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.1]
 
-### Uncategorized
+### Changed
 
-- Feat: Existing permissions banner with list ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
-- fix: update warning icon color to error red for malicious addresses ([#287](https://github.com/MetaMask/snap-7715-permissions/pull/287))
-- chore: Add explainer comment to each permission type `caveats.ts` ([#270](https://github.com/MetaMask/snap-7715-permissions/pull/270))
+- Use a banner with a list to display existing permissions. ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
+
+### Fixed
+
+- fix: change warning icon color to error red for malicious addresses ([#287](https://github.com/MetaMask/snap-7715-permissions/pull/287))
 
 ## [1.3.0]
 

--- a/packages/gator-permissions-snap/CHANGELOG.md
+++ b/packages/gator-permissions-snap/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1]
+
 ### Uncategorized
 
 - Feat: Existing permissions banner with list ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
@@ -333,7 +335,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure create-release-branch cli tool passes ([#54](https://github.com/MetaMask/snap-7715-permissions/pull/54))
 - Add changelog scripts ([#55](https://github.com/MetaMask/snap-7715-permissions/pull/55))
 
-[Unreleased]: https://github.com/MetaMask/snap-7715-permissions/compare/@metamask/gator-permissions-snap@1.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/snap-7715-permissions/compare/@metamask/gator-permissions-snap@1.3.1...HEAD
+[1.3.1]: https://github.com/MetaMask/snap-7715-permissions/compare/@metamask/gator-permissions-snap@1.3.0...@metamask/gator-permissions-snap@1.3.1
 [1.3.0]: https://github.com/MetaMask/snap-7715-permissions/compare/@metamask/gator-permissions-snap@1.2.0...@metamask/gator-permissions-snap@1.3.0
 [1.2.0]: https://github.com/MetaMask/snap-7715-permissions/compare/@metamask/gator-permissions-snap@1.1.1...@metamask/gator-permissions-snap@1.2.0
 [1.1.1]: https://github.com/MetaMask/snap-7715-permissions/compare/@metamask/gator-permissions-snap@1.1.0...@metamask/gator-permissions-snap@1.1.1

--- a/packages/gator-permissions-snap/package.json
+++ b/packages/gator-permissions-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/gator-permissions-snap",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Grants 7715 permissions from a DeleGator smart account",
   "homepage": "https://github.com/MetaMask/snap-7715-permissions/tree/main/packages/permissions-kernel-snap#readme",
   "bugs": {

--- a/packages/permissions-kernel-snap/CHANGELOG.md
+++ b/packages/permissions-kernel-snap/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Feat: Existing permissions banner with list ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
+- fix: update warning icon color to error red for malicious addresses ([#287](https://github.com/MetaMask/snap-7715-permissions/pull/287))
+- chore: Add explainer comment to each permission type `caveats.ts` ([#270](https://github.com/MetaMask/snap-7715-permissions/pull/270))
+- Release/18.0.0 ([#285](https://github.com/MetaMask/snap-7715-permissions/pull/285))
+- fix: existing permissions issues ([#284](https://github.com/MetaMask/snap-7715-permissions/pull/284))
+- feat: enhance existing permissions handling ([#283](https://github.com/MetaMask/snap-7715-permissions/pull/283))
+- Improve clarity of justification field in Permission Picker ([#282](https://github.com/MetaMask/snap-7715-permissions/pull/282))
+
 ## [1.1.0]
 
 ### Added

--- a/packages/permissions-kernel-snap/CHANGELOG.md
+++ b/packages/permissions-kernel-snap/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- Feat: Existing permissions banner with list ([#288](https://github.com/MetaMask/snap-7715-permissions/pull/288))
-- fix: update warning icon color to error red for malicious addresses ([#287](https://github.com/MetaMask/snap-7715-permissions/pull/287))
-- chore: Add explainer comment to each permission type `caveats.ts` ([#270](https://github.com/MetaMask/snap-7715-permissions/pull/270))
-- Release/18.0.0 ([#285](https://github.com/MetaMask/snap-7715-permissions/pull/285))
-- fix: existing permissions issues ([#284](https://github.com/MetaMask/snap-7715-permissions/pull/284))
-- feat: enhance existing permissions handling ([#283](https://github.com/MetaMask/snap-7715-permissions/pull/283))
-- Improve clarity of justification field in Permission Picker ([#282](https://github.com/MetaMask/snap-7715-permissions/pull/282))
-
 ## [1.1.0]
 
 ### Added

--- a/yarn.lock
+++ b/yarn.lock
@@ -3853,26 +3853,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.2.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
-  version: 11.9.0
-  resolution: "@metamask/utils@npm:11.9.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^4.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@noble/hashes": "npm:^1.3.1"
-    "@scure/base": "npm:^1.1.3"
-    "@types/debug": "npm:^4.1.7"
-    "@types/lodash": "npm:^4.17.20"
-    debug: "npm:^4.3.4"
-    lodash: "npm:^4.17.21"
-    pony-cause: "npm:^2.1.10"
-    semver: "npm:^7.5.4"
-    uuid: "npm:^9.0.1"
-  checksum: 10/f8f5e99ba6c6de0395ed4e0acc82ee9c0dca26991ea6a8f10b3896e72745790966a8eded8c42be905d9f01fa99c1fd29a7f68541e2ef9854fc14984a0b514ad3
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^11.10.0":
+"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.2.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
   version: 11.10.0
   resolution: "@metamask/utils@npm:11.10.0"
   dependencies:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
@metamask/gator-permissions-snap 1.3.1
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily version/changelog updates for a release plus a lockfile refresh; no runtime logic changes beyond dependency resolution updates.
> 
> **Overview**
> Bumps the monorepo version to `19.0.0` and releases `@metamask/gator-permissions-snap` `1.3.1` with an updated `CHANGELOG.md` entry.
> 
> Updates `yarn.lock` to resolve `@metamask/utils` to `11.10.0` (consolidating prior `11.9.0` resolution) as part of the release dependency set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23b9a1cef1c45c7bd507f9cb85136f197beb3b29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->