### PR TITLE
feat: Implements `native-token-swap` permission

### DIFF
--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -294,6 +294,45 @@
     },
     "revokeTokenApprovalsLabel": {
       "message": "Revoke token approvals"
+    },
+    "permissionRequestSubtitleNativeTokenSwap": {
+      "message": "This site wants permission to swap your native token up to a limit you set."
+    },
+    "maxNativeSwapAmountLabel": {
+      "message": "Max allowance"
+    },
+    "maxNativeSwapAmountTooltip": {
+      "message": "Maximum native token allowance that can be spent when swapping on your behalf."
+    },
+    "tokenSwapRestrictionLabel": {
+      "message": "Swappable into"
+    },
+    "tokenSwapRestrictionTooltip": {
+      "message": "Choose whether swaps are limited to whitelisted tokens or may use any token."
+    },
+    "tokenSwapModeWhitelistedOnly": {
+      "message": "Whitelisted tokens only"
+    },
+    "tokenSwapModeAnyToken": {
+      "message": "Any token"
+    },
+    "whitelistedTokensListLinkIntro": {
+      "message": "View the whitelisted token list:"
+    },
+    "whitelistedTokensListLinkLabel": {
+      "message": "Open token list"
+    },
+    "introNativeTokenSwapTitle": {
+      "message": "Native token swap request"
+    },
+    "introNativeTokenSwapDescription": {
+      "message": "Native token swap permissions let a site use your native token for swaps up to a cap. You can require swaps into whitelisted tokens only."
+    },
+    "nativeTokenSwapMaxAmountDetailLabel": {
+      "message": "Max allowance"
+    },
+    "nativeTokenSwapTokenPolicyDetailLabel": {
+      "message": "Token policy"
     }
   }
 }

--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -316,12 +316,6 @@
     "tokenSwapModeAnyToken": {
       "message": "Any token"
     },
-    "whitelistedTokensListLinkIntro": {
-      "message": "View the whitelisted token list:"
-    },
-    "whitelistedTokensListLinkLabel": {
-      "message": "Open token list"
-    },
     "introNativeTokenSwapTitle": {
       "message": "Native token swap request"
     },

--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -296,13 +296,13 @@
       "message": "Revoke token approvals"
     },
     "permissionRequestSubtitleNativeTokenSwap": {
-      "message": "This site wants permission to swap your native token up to a limit you set."
+      "message": "This site wants permission to swap your native token within an allowance you set."
     },
-    "maxNativeSwapAmountLabel": {
-      "message": "Max allowance"
+    "allowanceLabel": {
+      "message": "Allowance"
     },
-    "maxNativeSwapAmountTooltip": {
-      "message": "Maximum native token allowance that can be spent when swapping on your behalf."
+    "allowanceTooltip": {
+      "message": "Native token allowance that can be spent when swapping on your behalf."
     },
     "tokenSwapRestrictionLabel": {
       "message": "Swappable into"
@@ -326,10 +326,10 @@
       "message": "Native token swap request"
     },
     "introNativeTokenSwapDescription": {
-      "message": "Native token swap permissions let a site use your native token for swaps up to a cap. You can require swaps into whitelisted tokens only."
+      "message": "Native token swap permissions let a site use your native token for swaps within an allowance you set. You can require swaps into whitelisted tokens only."
     },
-    "nativeTokenSwapMaxAmountDetailLabel": {
-      "message": "Max allowance"
+    "nativeTokenSwapAllowanceDetailLabel": {
+      "message": "Allowance"
     },
     "nativeTokenSwapTokenPolicyDetailLabel": {
       "message": "Token policy"

--- a/packages/gator-permissions-snap/package.json
+++ b/packages/gator-permissions-snap/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@metamask/abi-utils": "3.0.0",
-    "@metamask/delegation-core": "0.3.0",
+    "@metamask/delegation-core": "1.0.0",
     "@metamask/profile-sync-controller": "21.0.0",
     "@metamask/snaps-sdk": "11.0.0",
     "@metamask/utils": "11.4.2",

--- a/packages/gator-permissions-snap/src/core/chainMetadata.ts
+++ b/packages/gator-permissions-snap/src/core/chainMetadata.ts
@@ -3,6 +3,36 @@ import { numberToHex } from '@metamask/utils';
 
 import { t } from '../utils/i18n';
 
+/**
+ * EIP-155 chain IDs with name/explorer metadata in this snap.
+ *
+ * @see https://chainid.network/chains.json
+ */
+export enum GatorChainId {
+  EthereumMainnet = 0x1,
+  OpMainnet = 0xa,
+  BnbSmartChainMainnet = 0x38,
+  Gnosis = 0x64,
+  Unichain = 0x82,
+  PolygonMainnet = 0x89,
+  Base = 0x2105,
+  ArbitrumOne = 0xa4b1,
+  ArbitrumNova = 0xa4ba,
+  LineaMainnet = 0xe708,
+  Amoy = 0x13882,
+  Berachain = 0x138de,
+  BnbSmartChainTestnet = 0x61,
+  UnichainSepoliaTestnet = 0x515,
+  MegaEthTestnet = 0x18c6,
+  GnosisChiadoTestnet = 0x27d8,
+  LineaSepoliaTestnet = 0xe705,
+  BerachainBepoliaTestnet = 0x138c5,
+  BaseSepoliaTestnet = 0x14a34,
+  ArbitrumSepoliaTestnet = 0x66eee,
+  EthereumSepoliaTestnet = 0xaa36a7,
+  OpSepoliaTestnet = 0xaa37dc,
+}
+
 export type DelegationContracts = {
   delegationManager: Hex;
   eip7702StatelessDeleGatorImpl: Hex;
@@ -21,9 +51,22 @@ export type DelegationContracts = {
   argsEqualityEnforcer: Hex;
   nativeTokenTransferAmountEnforcer: Hex;
   redeemerEnforcer: Hex;
+  /** Present when a token swap adapter is deployed on this chain. */
+  tokenSwapAdapter?: Hex | undefined;
 };
 
-const contracts: DelegationContracts = {
+const TOKEN_SWAP_ADAPTER_BY_CHAIN_ID: Partial<Record<GatorChainId, Hex>> = {
+  [GatorChainId.EthereumMainnet]: '0xe41eb5a3f6e35f1a8c77113f372892d09820c3fd',
+  [GatorChainId.OpMainnet]: '0x5e4b49156D23D890e7DC264c378a443C2d22A80E',
+  [GatorChainId.Base]: '0x5e4b49156D23D890e7DC264c378a443C2d22A80E',
+  [GatorChainId.ArbitrumOne]: '0x5e4b49156D23D890e7DC264c378a443C2d22A80E',
+  [GatorChainId.LineaMainnet]: '0x5e4b49156D23D890e7DC264c378a443C2d22A80E',
+  [GatorChainId.BnbSmartChainMainnet]:
+    '0x9c06653D3f1A331eAf4C3833F7235156e47305F1',
+  [GatorChainId.PolygonMainnet]: '0x9c06653D3f1A331eAf4C3833F7235156e47305F1',
+};
+
+const DELEGATION_CONTRACTS: DelegationContracts = {
   delegationManager: '0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3',
   eip7702StatelessDeleGatorImpl: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
   limitedCallsEnforcer: '0x04658B29F6b82ed55274221a06Fc97D318E25416',
@@ -38,73 +81,9 @@ const contracts: DelegationContracts = {
   nonceEnforcer: '0xDE4f2FAC4B3D87A1d9953Ca5FC09FCa7F366254f',
   allowedCalldataEnforcer: '0xc2b0d624c1c4319760C96503BA27C347F3260f55',
   argsEqualityEnforcer: '0x44B8C6ae3C304213c3e298495e12497Ed3E56E41',
-  nativeTokenTransferAmountEnforcer: '0xF71af580b9c3078fbc2BBF16FbB8EEd82b330320',
+  nativeTokenTransferAmountEnforcer:
+    '0xF71af580b9c3078fbc2BBF16FbB8EEd82b330320',
   redeemerEnforcer: '0xE144b0b2618071B4E56f746313528a669c7E65c5',
-};
-
-// derived from https://chainid.network/chains.json
-export const nameAndExplorerUrlByChainId: Record<
-  number,
-  Pick<ChainMetadata, 'name' | 'explorerUrl'>
-> = {
-  // mainnets
-  0x1: { name: 'Ethereum Mainnet', explorerUrl: 'https://etherscan.io' },
-  0xa: { name: 'OP Mainnet', explorerUrl: 'https://optimistic.etherscan.io' },
-  0x38: { name: 'BNB Smart Chain Mainnet', explorerUrl: 'https://bscscan.com' },
-  0x64: { name: 'Gnosis', explorerUrl: 'https://gnosisscan.io' },
-  0x82: { name: 'Unichain', explorerUrl: 'https://uniscan.xyz' },
-  0x89: { name: 'Polygon Mainnet', explorerUrl: 'https://polygonscan.com' },
-  0x2105: { name: 'Base', explorerUrl: 'https://basescan.org' },
-  0xa4b1: { name: 'Arbitrum One', explorerUrl: 'https://arbiscan.io' },
-  0xa4ba: {
-    name: 'Arbitrum Nova',
-    explorerUrl: 'https://nova.arbiscan.io',
-  },
-  0xe708: {
-    name: 'Linea Mainnet',
-    explorerUrl: 'https://lineascan.build',
-  },
-  0x13882: { name: 'Amoy', explorerUrl: 'https://amoy.polygonscan.com' },
-  0x138de: { name: 'Berachain', explorerUrl: 'https://berascan.com' },
-
-  // testnets
-  0x61: {
-    name: 'BNB Smart Chain Testnet',
-    explorerUrl: 'https://testnet.bscscan.com',
-  },
-  0x515: {
-    name: 'Unichain Sepolia Testnet',
-    explorerUrl: 'https://unichain-sepolia.blockscout.com',
-  },
-  0x18c6: { name: 'MegaETH Testnet', explorerUrl: undefined },
-  0x27d8: {
-    name: 'Gnosis Chiado Testnet',
-    explorerUrl: 'https://gnosis-chiado.blockscout.com',
-  },
-  0xe705: {
-    name: 'Linea Sepolia Testnet',
-    explorerUrl: 'https://sepolia.lineascan.build',
-  },
-  0x138c5: {
-    name: 'Berachain Bepolia Testnet',
-    explorerUrl: 'https://bepolia.beratrail.io',
-  },
-  0x14a34: {
-    name: 'Base Sepolia Testnet',
-    explorerUrl: 'https://sepolia.basescan.org',
-  },
-  0x66eee: {
-    name: 'Arbitrum Sepolia Testnet',
-    explorerUrl: 'https://sepolia.arbiscan.io',
-  },
-  0xaa36a7: {
-    name: 'Ethereum Sepolia Testnet',
-    explorerUrl: 'https://sepolia.etherscan.io',
-  },
-  0xaa37dc: {
-    name: 'OP Sepolia Testnet',
-    explorerUrl: 'https://sepolia-optimism.etherscan.io',
-  },
 };
 
 export type ChainMetadata = {
@@ -113,15 +92,140 @@ export type ChainMetadata = {
   explorerUrl: string | undefined;
 };
 
+// derived from https://chainid.network/chains.json
+export const nameAndExplorerUrlByChainId: Record<
+  GatorChainId,
+  Pick<ChainMetadata, 'name' | 'explorerUrl'>
+> = {
+  // mainnets
+  [GatorChainId.EthereumMainnet]: {
+    name: 'Ethereum Mainnet',
+    explorerUrl: 'https://etherscan.io',
+  },
+  [GatorChainId.OpMainnet]: {
+    name: 'OP Mainnet',
+    explorerUrl: 'https://optimistic.etherscan.io',
+  },
+  [GatorChainId.BnbSmartChainMainnet]: {
+    name: 'BNB Smart Chain Mainnet',
+    explorerUrl: 'https://bscscan.com',
+  },
+  [GatorChainId.Gnosis]: {
+    name: 'Gnosis',
+    explorerUrl: 'https://gnosisscan.io',
+  },
+  [GatorChainId.Unichain]: {
+    name: 'Unichain',
+    explorerUrl: 'https://uniscan.xyz',
+  },
+  [GatorChainId.PolygonMainnet]: {
+    name: 'Polygon Mainnet',
+    explorerUrl: 'https://polygonscan.com',
+  },
+  [GatorChainId.Base]: {
+    name: 'Base',
+    explorerUrl: 'https://basescan.org',
+  },
+  [GatorChainId.ArbitrumOne]: {
+    name: 'Arbitrum One',
+    explorerUrl: 'https://arbiscan.io',
+  },
+  [GatorChainId.ArbitrumNova]: {
+    name: 'Arbitrum Nova',
+    explorerUrl: 'https://nova.arbiscan.io',
+  },
+  [GatorChainId.LineaMainnet]: {
+    name: 'Linea Mainnet',
+    explorerUrl: 'https://lineascan.build',
+  },
+  [GatorChainId.Amoy]: {
+    name: 'Amoy',
+    explorerUrl: 'https://amoy.polygonscan.com',
+  },
+  [GatorChainId.Berachain]: {
+    name: 'Berachain',
+    explorerUrl: 'https://berascan.com',
+  },
+
+  // testnets
+  [GatorChainId.BnbSmartChainTestnet]: {
+    name: 'BNB Smart Chain Testnet',
+    explorerUrl: 'https://testnet.bscscan.com',
+  },
+  [GatorChainId.UnichainSepoliaTestnet]: {
+    name: 'Unichain Sepolia Testnet',
+    explorerUrl: 'https://unichain-sepolia.blockscout.com',
+  },
+  [GatorChainId.MegaEthTestnet]: {
+    name: 'MegaETH Testnet',
+    explorerUrl: undefined,
+  },
+  [GatorChainId.GnosisChiadoTestnet]: {
+    name: 'Gnosis Chiado Testnet',
+    explorerUrl: 'https://gnosis-chiado.blockscout.com',
+  },
+  [GatorChainId.LineaSepoliaTestnet]: {
+    name: 'Linea Sepolia Testnet',
+    explorerUrl: 'https://sepolia.lineascan.build',
+  },
+  [GatorChainId.BerachainBepoliaTestnet]: {
+    name: 'Berachain Bepolia Testnet',
+    explorerUrl: 'https://bepolia.beratrail.io',
+  },
+  [GatorChainId.BaseSepoliaTestnet]: {
+    name: 'Base Sepolia Testnet',
+    explorerUrl: 'https://sepolia.basescan.org',
+  },
+  [GatorChainId.ArbitrumSepoliaTestnet]: {
+    name: 'Arbitrum Sepolia Testnet',
+    explorerUrl: 'https://sepolia.arbiscan.io',
+  },
+  [GatorChainId.EthereumSepoliaTestnet]: {
+    name: 'Ethereum Sepolia Testnet',
+    explorerUrl: 'https://sepolia.etherscan.io',
+  },
+  [GatorChainId.OpSepoliaTestnet]: {
+    name: 'OP Sepolia Testnet',
+    explorerUrl: 'https://sepolia-optimism.etherscan.io',
+  },
+};
+
+/**
+ * Chain IDs with a deployed token-swap adapter, sorted ascending.
+ *
+ * @returns Numeric chain IDs.
+ */
+export function getTokenSwapSupportedChainIds(): number[] {
+  return Object.keys(TOKEN_SWAP_ADAPTER_BY_CHAIN_ID)
+    .map((key) => Number(key))
+    .sort((a, b) => a - b);
+}
+
+/**
+ * Chain IDs listed in {@link nameAndExplorerUrlByChainId}, sorted ascending.
+ *
+ * @returns Numeric chain IDs.
+ */
+export function getConfiguredChainIds(): number[] {
+  const ids = Object.values(GatorChainId).filter(
+    (value): value is GatorChainId => typeof value === 'number',
+  );
+
+  return ids.sort((a, b) => a - b);
+}
+
 export const getChainMetadata = ({
   chainId,
 }: {
   chainId: number;
 }): ChainMetadata => {
-  const { explorerUrl, name } = nameAndExplorerUrlByChainId[chainId] ?? {};
+  const { explorerUrl, name } =
+    nameAndExplorerUrlByChainId[chainId as GatorChainId] ?? {};
+  const tokenSwapAdapter =
+    TOKEN_SWAP_ADAPTER_BY_CHAIN_ID[chainId as GatorChainId];
 
-  const metadata = {
-    contracts,
+  const metadata: ChainMetadata = {
+    contracts: { ...DELEGATION_CONTRACTS, tokenSwapAdapter },
     name: name ?? t('unknownChain', [numberToHex(chainId)]),
     explorerUrl,
   };

--- a/packages/gator-permissions-snap/src/core/chainMetadata.ts
+++ b/packages/gator-permissions-snap/src/core/chainMetadata.ts
@@ -18,6 +18,9 @@ export type DelegationContracts = {
   exactCalldataEnforcer: Hex;
   nonceEnforcer: Hex;
   allowedCalldataEnforcer: Hex;
+  argsEqualityEnforcer: Hex;
+  nativeTokenTransferAmountEnforcer: Hex;
+  redeemerEnforcer: Hex;
 };
 
 const contracts: DelegationContracts = {
@@ -34,6 +37,9 @@ const contracts: DelegationContracts = {
   exactCalldataEnforcer: '0x99F2e9bF15ce5eC84685604836F71aB835DBBdED',
   nonceEnforcer: '0xDE4f2FAC4B3D87A1d9953Ca5FC09FCa7F366254f',
   allowedCalldataEnforcer: '0xc2b0d624c1c4319760C96503BA27C347F3260f55',
+  argsEqualityEnforcer: '0x44B8C6ae3C304213c3e298495e12497Ed3E56E41',
+  nativeTokenTransferAmountEnforcer: '0xF71af580b9c3078fbc2BBF16FbB8EEd82b330320',
+  redeemerEnforcer: '0xE144b0b2618071B4E56f746313528a669c7E65c5',
 };
 
 // derived from https://chainid.network/chains.json

--- a/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
@@ -139,6 +139,30 @@ function extractPermissionDetails(
           value: String(justification),
         };
       }
+    } else if (permissionType === 'native-token-swap') {
+      const { maxNativeSwapAmount, justification } = permissionData;
+      const whitelistedOnly = permissionData.whitelistedTokensOnly === true;
+
+      if (maxNativeSwapAmount !== undefined && maxNativeSwapAmount !== null) {
+        details.maxNativeSwapAmount = {
+          label: t('nativeTokenSwapMaxAmountDetailLabel'),
+          value: String(maxNativeSwapAmount),
+        };
+      }
+
+      details.tokenSwapPolicy = {
+        label: t('nativeTokenSwapTokenPolicyDetailLabel'),
+        value: whitelistedOnly
+          ? t('tokenSwapModeWhitelistedOnly')
+          : t('tokenSwapModeAnyToken'),
+      };
+
+      if (justification !== undefined && justification !== null) {
+        details.justification = {
+          label: t('justificationLabel'),
+          value: String(justification),
+        };
+      }
     }
     // For stream-type permissions
     else if (
@@ -235,7 +259,9 @@ export async function formatPermissionWithTokenMetadata(
 
   // Check if this permission has token amount fields that need formatting
   const hasTokenAmountFields =
-    'maxAmount' in permissionData || 'periodAmount' in permissionData;
+    'maxAmount' in permissionData ||
+    'periodAmount' in permissionData ||
+    'maxNativeSwapAmount' in permissionData;
 
   if (!hasTokenAmountFields) {
     return permission;
@@ -285,6 +311,14 @@ export async function formatPermissionWithTokenMetadata(
     if ('periodAmount' in permissionData) {
       formattedData.periodAmount = formatTokenAmountWithMetadata(
         permissionData.periodAmount as Hex | null | undefined,
+        decimals,
+        symbol,
+      );
+    }
+
+    if ('maxNativeSwapAmount' in permissionData) {
+      formattedData.maxNativeSwapAmount = formatTokenAmountWithMetadata(
+        permissionData.maxNativeSwapAmount as Hex | null | undefined,
         decimals,
         symbol,
       );

--- a/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
@@ -140,13 +140,13 @@ function extractPermissionDetails(
         };
       }
     } else if (permissionType === 'native-token-swap') {
-      const { maxNativeSwapAmount, justification } = permissionData;
+      const { allowance, justification } = permissionData;
       const whitelistedOnly = permissionData.whitelistedTokensOnly === true;
 
-      if (maxNativeSwapAmount !== undefined && maxNativeSwapAmount !== null) {
-        details.maxNativeSwapAmount = {
-          label: t('nativeTokenSwapMaxAmountDetailLabel'),
-          value: String(maxNativeSwapAmount),
+      if (allowance !== undefined && allowance !== null) {
+        details.allowance = {
+          label: t('nativeTokenSwapAllowanceDetailLabel'),
+          value: String(allowance),
         };
       }
 
@@ -261,7 +261,7 @@ export async function formatPermissionWithTokenMetadata(
   const hasTokenAmountFields =
     'maxAmount' in permissionData ||
     'periodAmount' in permissionData ||
-    'maxNativeSwapAmount' in permissionData;
+    'allowance' in permissionData;
 
   if (!hasTokenAmountFields) {
     return permission;
@@ -316,9 +316,9 @@ export async function formatPermissionWithTokenMetadata(
       );
     }
 
-    if ('maxNativeSwapAmount' in permissionData) {
-      formattedData.maxNativeSwapAmount = formatTokenAmountWithMetadata(
-        permissionData.maxNativeSwapAmount as Hex | null | undefined,
+    if ('allowance' in permissionData) {
+      formattedData.allowance = formatTokenAmountWithMetadata(
+        permissionData.allowance as Hex | null | undefined,
         decimals,
         symbol,
       );

--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -91,12 +91,6 @@ export class PermissionHandlerFactory {
 
     const permissionDefinition = getPermissionDefinition(type);
 
-    if (!permissionDefinition) {
-      throw new InvalidParamsError(
-        `Permission definition not found for permission type: ${type}`,
-      );
-    }
-
     if (
       !permissionDefinition
         .getSupportedChains()

--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -16,6 +16,7 @@ import type {
   PermissionHandlerType,
 } from './types';
 import { getPermissionDefinition } from '../permissions/permissionDefinitionsRegistry';
+
 /**
  * Factory for creating permission-specific orchestrators.
  * Each permission type has its own orchestrator that handles the specific logic for that permission.

--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -8,6 +8,7 @@ import { erc20TokenRevocationPermissionDefinition } from '../permissions/erc20To
 import { erc20TokenStreamPermissionDefinition } from '../permissions/erc20TokenStream';
 import { nativeTokenPeriodicPermissionDefinition } from '../permissions/nativeTokenPeriodic';
 import { nativeTokenStreamPermissionDefinition } from '../permissions/nativeTokenStream';
+import { nativeTokenSwapPermissionDefinition } from '../permissions/nativeTokenSwap';
 import type { TokenMetadataService } from '../services/tokenMetadataService';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { UserEventDispatcher } from '../userEventDispatcher';
@@ -103,6 +104,9 @@ export class PermissionHandlerFactory {
         handler = createPermissionHandler(
           nativeTokenPeriodicPermissionDefinition,
         );
+        break;
+      case 'native-token-swap':
+        handler = createPermissionHandler(nativeTokenSwapPermissionDefinition);
         break;
       case 'erc20-token-periodic':
         handler = createPermissionHandler(

--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -1,14 +1,9 @@
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
-import { InvalidInputError } from '@metamask/snaps-sdk';
+import { InvalidParamsError } from '@metamask/snaps-sdk';
+import { hexToNumber } from '@metamask/utils';
 
 import type { AccountController } from './accountController';
-import { erc20TokenPeriodicPermissionDefinition } from '../permissions/erc20TokenPeriodic';
-import { erc20TokenRevocationPermissionDefinition } from '../permissions/erc20TokenRevocation';
-import { erc20TokenStreamPermissionDefinition } from '../permissions/erc20TokenStream';
-import { nativeTokenPeriodicPermissionDefinition } from '../permissions/nativeTokenPeriodic';
-import { nativeTokenStreamPermissionDefinition } from '../permissions/nativeTokenStream';
-import { nativeTokenSwapPermissionDefinition } from '../permissions/nativeTokenSwap';
 import type { TokenMetadataService } from '../services/tokenMetadataService';
 import type { TokenPricesService } from '../services/tokenPricesService';
 import type { UserEventDispatcher } from '../userEventDispatcher';
@@ -20,7 +15,7 @@ import type {
   PermissionDefinition,
   PermissionHandlerType,
 } from './types';
-
+import { getPermissionDefinition } from '../permissions/permissionDefinitionsRegistry';
 /**
  * Factory for creating permission-specific orchestrators.
  * Each permission type has its own orchestrator that handles the specific logic for that permission.
@@ -92,39 +87,25 @@ export class PermissionHandlerFactory {
         tokenMetadataService: this.#tokenMetadataService,
       });
     };
-    let handler: PermissionHandlerType;
 
-    switch (type) {
-      case 'native-token-stream':
-        handler = createPermissionHandler(
-          nativeTokenStreamPermissionDefinition,
-        );
-        break;
-      case 'native-token-periodic':
-        handler = createPermissionHandler(
-          nativeTokenPeriodicPermissionDefinition,
-        );
-        break;
-      case 'native-token-swap':
-        handler = createPermissionHandler(nativeTokenSwapPermissionDefinition);
-        break;
-      case 'erc20-token-periodic':
-        handler = createPermissionHandler(
-          erc20TokenPeriodicPermissionDefinition,
-        );
-        break;
-      case 'erc20-token-revocation':
-        handler = createPermissionHandler(
-          erc20TokenRevocationPermissionDefinition,
-        );
-        break;
-      case 'erc20-token-stream':
-        handler = createPermissionHandler(erc20TokenStreamPermissionDefinition);
-        break;
-      default:
-        throw new InvalidInputError(`Unsupported permission type: ${type}`);
+    const permissionDefinition = getPermissionDefinition(type);
+
+    if (!permissionDefinition) {
+      throw new InvalidParamsError(
+        `Permission definition not found for permission type: ${type}`,
+      );
     }
 
-    return handler;
+    if (
+      !permissionDefinition
+        .getSupportedChains()
+        .includes(hexToNumber(permissionRequest.chainId))
+    ) {
+      throw new InvalidParamsError(
+        `Unsupported chain ${permissionRequest.chainId} for permission type ${type}`,
+      );
+    }
+
+    return createPermissionHandler(permissionDefinition);
   }
 }

--- a/packages/gator-permissions-snap/src/core/permissionIntroduction/permissionIntroductionContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionIntroduction/permissionIntroductionContent.tsx
@@ -91,6 +91,19 @@ const revocationPage1Content: PermissionIntroductionPageConfig = {
   ],
 };
 
+const nativeTokenSwapPage1Content: PermissionIntroductionPageConfig = {
+  headerImageSvg: permissionRequestImage,
+  title: 'introNativeTokenSwapTitle',
+  bulletPoints: [
+    {
+      description: 'introNativeTokenSwapDescription',
+    },
+    {
+      description: 'introPermissionInControlDescription',
+    },
+  ],
+};
+
 /**
  * Map of permission types to their introduction configurations.
  * Note: Keys must match the permission type descriptor names (kebab-case).
@@ -117,6 +130,10 @@ export const permissionIntroductionConfigs: Record<
   },
   'native-token-stream': {
     page1: streamPage1Content,
+    page2: fixedPage2Content,
+  },
+  'native-token-swap': {
+    page1: nativeTokenSwapPage1Content,
     page2: fixedPage2Content,
   },
 };

--- a/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
+++ b/packages/gator-permissions-snap/src/core/permissionRequestLifecycleOrchestrator.ts
@@ -14,7 +14,7 @@ import {
   encodeDelegations,
   ROOT_AUTHORITY,
 } from '@metamask/delegation-core';
-import { InvalidInputError, InvalidParamsError } from '@metamask/snaps-sdk';
+import { InvalidInputError } from '@metamask/snaps-sdk';
 import {
   bigIntToHex,
   bytesToHex,
@@ -96,26 +96,6 @@ export class PermissionRequestLifecycleOrchestrator {
   }
 
   /**
-   * Asserts that the specified chain ID is supported.
-   * @param chainId - The chain ID to validate.
-   * @throws If the chain ID is not supported.
-   */
-  #assertIsSupportedChainId(chainId: number): void {
-    try {
-      getChainMetadata({ chainId });
-    } catch (error) {
-      logger.error(
-        'PermissionRequestLifecycleOrchestrator:assertIsSupportedChainId() - unsupported chainId',
-        {
-          chainId,
-          error,
-        },
-      );
-      throw new InvalidParamsError(`Unsupported ChainId: ${chainId}`);
-    }
-  }
-
-  /**
    * Orchestrates the permission request lifecycle.
    * @param origin - The origin of the permission request.
    * @param permissionRequest - The permission request to orchestrate.
@@ -143,8 +123,6 @@ export class PermissionRequestLifecycleOrchestrator {
     const permissionType = extractDescriptorName(
       permissionRequest.permission.type,
     );
-
-    this.#assertIsSupportedChainId(chainId);
 
     // Track permission request started
     await this.#snapsMetricsService.trackPermissionRequestStarted({

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -277,6 +277,10 @@ export type PermissionDefinition<
     TPermission,
     TPopulatedPermission
   >;
+  /**
+   * Chain IDs (EIP-155) on which this permission may be granted.
+   */
+  getSupportedChains: () => number[];
 };
 
 /**

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/index.ts
@@ -14,7 +14,7 @@ import type {
   Erc20TokenPeriodicPermissionRequest,
   PopulatedErc20TokenPeriodicPermission,
 } from './types';
-import { parseAndValidatePermission } from './validation';
+import { getSupportedChains, parseAndValidatePermission } from './validation';
 import type { PermissionDefinition } from '../../core/types';
 
 export const erc20TokenPeriodicPermissionDefinition: PermissionDefinition<
@@ -27,6 +27,7 @@ export const erc20TokenPeriodicPermissionDefinition: PermissionDefinition<
   rules: allRules,
   title: 'permissionRequestTitle',
   subtitle: 'permissionRequestSubtitle',
+  getSupportedChains,
   dependencies: {
     parseAndValidatePermission,
     buildContext,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/validation.ts
@@ -2,12 +2,22 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
+import { getConfiguredChainIds } from '../../core/chainMetadata';
 import { validateHexInteger, validateStartTime } from '../validation';
 import type {
   Erc20TokenPeriodicPermission,
   Erc20TokenPeriodicPermissionRequest,
 } from './types';
 import { zErc20TokenPeriodicPermission } from './types';
+
+/**
+ * Returns chain IDs on which erc20-token-periodic is supported.
+ *
+ * @returns Sorted configured chain IDs.
+ */
+export function getSupportedChains(): number[] {
+  return getConfiguredChainIds();
+}
 
 /**
  * Validates a permission object data specific to the permission type.

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenRevocation/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenRevocation/index.ts
@@ -14,7 +14,7 @@ import type {
   Erc20TokenRevocationPermissionRequest,
   PopulatedErc20TokenRevocationPermission,
 } from './types';
-import { parseAndValidatePermission } from './validation';
+import { getSupportedChains, parseAndValidatePermission } from './validation';
 import type { PermissionDefinition } from '../../core/types';
 
 export const erc20TokenRevocationPermissionDefinition: PermissionDefinition<
@@ -27,6 +27,7 @@ export const erc20TokenRevocationPermissionDefinition: PermissionDefinition<
   rules: allRules,
   title: 'permissionRequestTitle',
   subtitle: 'permissionRequestSubtitleRevocation',
+  getSupportedChains,
   dependencies: {
     parseAndValidatePermission,
     buildContext,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenRevocation/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenRevocation/validation.ts
@@ -4,6 +4,16 @@ import { InvalidInputError } from '@metamask/snaps-sdk';
 
 import type { Erc20TokenRevocationPermissionRequest } from './types';
 import { zErc20TokenRevocationPermission } from './types';
+import { getConfiguredChainIds } from '../../core/chainMetadata';
+
+/**
+ * Returns chain IDs on which erc20-token-revocation is supported.
+ *
+ * @returns Sorted configured chain IDs.
+ */
+export function getSupportedChains(): number[] {
+  return getConfiguredChainIds();
+}
 
 /**
  * Parses and validates a permission request for ERC20 token approval revocation.

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/index.ts
@@ -14,7 +14,7 @@ import type {
   Erc20TokenStreamPermissionRequest,
   PopulatedErc20TokenStreamPermission,
 } from './types';
-import { parseAndValidatePermission } from './validation';
+import { getSupportedChains, parseAndValidatePermission } from './validation';
 import type { PermissionDefinition } from '../../core/types';
 
 export const erc20TokenStreamPermissionDefinition: PermissionDefinition<
@@ -27,6 +27,7 @@ export const erc20TokenStreamPermissionDefinition: PermissionDefinition<
   rules: allRules,
   title: 'permissionRequestTitle',
   subtitle: 'permissionRequestSubtitle',
+  getSupportedChains,
   dependencies: {
     parseAndValidatePermission,
     buildContext,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
@@ -2,12 +2,22 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
+import { getConfiguredChainIds } from '../../core/chainMetadata';
 import { validateHexInteger, validateStartTime } from '../validation';
 import type {
   Erc20TokenStreamPermission,
   Erc20TokenStreamPermissionRequest,
 } from './types';
 import { zErc20TokenStreamPermission } from './types';
+
+/**
+ * Returns chain IDs on which erc20-token-stream is supported.
+ *
+ * @returns Sorted configured chain IDs.
+ */
+export function getSupportedChains(): number[] {
+  return getConfiguredChainIds();
+}
 
 /**
  * Validates a permission object data specific to the permission type.

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/index.ts
@@ -14,7 +14,7 @@ import type {
   NativeTokenPeriodicPermissionRequest,
   PopulatedNativeTokenPeriodicPermission,
 } from './types';
-import { parseAndValidatePermission } from './validation';
+import { getSupportedChains, parseAndValidatePermission } from './validation';
 import type { PermissionDefinition } from '../../core/types';
 
 export const nativeTokenPeriodicPermissionDefinition: PermissionDefinition<
@@ -27,6 +27,7 @@ export const nativeTokenPeriodicPermissionDefinition: PermissionDefinition<
   rules: allRules,
   title: 'permissionRequestTitle',
   subtitle: 'permissionRequestSubtitle',
+  getSupportedChains,
   dependencies: {
     parseAndValidatePermission,
     buildContext,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenPeriodic/validation.ts
@@ -2,12 +2,22 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
+import { getConfiguredChainIds } from '../../core/chainMetadata';
 import { validateHexInteger, validateStartTime } from '../validation';
 import type {
   NativeTokenPeriodicPermission,
   NativeTokenPeriodicPermissionRequest,
 } from './types';
 import { zNativeTokenPeriodicPermission } from './types';
+
+/**
+ * Returns chain IDs on which native-token-periodic is supported.
+ *
+ * @returns Sorted configured chain IDs.
+ */
+export function getSupportedChains(): number[] {
+  return getConfiguredChainIds();
+}
 
 /**
  * Validates a permission object data specific to the permission type.

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/index.ts
@@ -14,7 +14,7 @@ import type {
   NativeTokenStreamPermissionRequest,
   PopulatedNativeTokenStreamPermission,
 } from './types';
-import { parseAndValidatePermission } from './validation';
+import { getSupportedChains, parseAndValidatePermission } from './validation';
 import type { PermissionDefinition } from '../../core/types';
 
 export const nativeTokenStreamPermissionDefinition: PermissionDefinition<
@@ -27,6 +27,7 @@ export const nativeTokenStreamPermissionDefinition: PermissionDefinition<
   rules: allRules,
   title: 'permissionRequestTitle',
   subtitle: 'permissionRequestSubtitle',
+  getSupportedChains,
   dependencies: {
     parseAndValidatePermission,
     buildContext,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenStream/validation.ts
@@ -2,12 +2,22 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
+import { getConfiguredChainIds } from '../../core/chainMetadata';
 import { validateHexInteger, validateStartTime } from '../validation';
 import type {
   NativeTokenStreamPermission,
   NativeTokenStreamPermissionRequest,
 } from './types';
 import { zNativeTokenStreamPermission } from './types';
+
+/**
+ * Returns chain IDs on which native-token-stream is supported.
+ *
+ * @returns Sorted configured chain IDs.
+ */
+export function getSupportedChains(): number[] {
+  return getConfiguredChainIds();
+}
 
 /**
  * Validates a permission object data specific to the permission type.

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
@@ -1,0 +1,21 @@
+import type { Caveat } from '@metamask/delegation-core';
+
+import type { PopulatedNativeTokenSwapPermission } from './types';
+import type { DelegationContracts } from '../../core/chainMetadata';
+
+/**
+ * Native token swap permission currently attaches no delegation caveats.
+ * Callers should treat swap limits and token policy as off-chain / wallet semantics until
+ * matching enforcers exist.
+ */
+
+/**
+ * Returns no caveats for native token swap.
+ * @returns Empty caveat list.
+ */
+export async function createPermissionCaveats(_: {
+  permission: PopulatedNativeTokenSwapPermission;
+  contracts: DelegationContracts;
+}): Promise<Caveat[]> {
+  return [];
+}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
@@ -5,7 +5,7 @@ import {
 } from '@metamask/delegation-core';
 import type { Caveat, Hex } from '@metamask/delegation-core';
 import { InternalError } from '@metamask/snaps-sdk';
-import { bigIntToHex, hexToBigInt, numberToHex } from '@metamask/utils';
+import { hexToBigInt } from '@metamask/utils';
 
 import type { PopulatedNativeTokenSwapPermission } from './types';
 import type { DelegationContracts } from '../../core/chainMetadata';
@@ -34,6 +34,29 @@ export const PERIOD_DURATION =
  * the configured native token allowance.
  * RedeemerEnforcer: only the swap adapter contract can redeem the permission.
  */
+
+/**
+ * Converts a numeric value to a hexadecimal string with zero-padding, without 0x prefix.
+ *
+ * @param options - The options for the conversion.
+ * @param options.value - The numeric value to convert to hex (bigint or number).
+ * @param options.size - The size in bytes for the resulting hex string (each byte = 2 hex characters).
+ * @returns A hexadecimal string prefixed with zeros to match the specified size.
+ * @example
+ * ```typescript
+ * toHexString({ value: 255, size: 2 }) // Returns "00ff"
+ * toHexString({ value: 16n, size: 1 }) // Returns "10"
+ * ```
+ */
+export const toHexString = ({
+  value,
+  size,
+}: {
+  value: bigint | number;
+  size: number;
+}): string => {
+  return value.toString(16).padStart(size * 2, '0');
+};
 
 /**
  * Creates terms for a NativeTokenPeriodTransfer caveat that validates that native token (ETH) transfers
@@ -66,9 +89,9 @@ function createNativeTokenPeriodTransferTerms(terms: {
     throw new Error('Invalid startDate: must be a positive number');
   }
 
-  const periodAmountHex = bigIntToHex(periodAmount);
-  const periodDurationHex = bigIntToHex(periodDuration);
-  const startDateHex = numberToHex(startDate);
+  const periodAmountHex = toHexString({ value: periodAmount, size: 32 });
+  const periodDurationHex = toHexString({ value: periodDuration, size: 32 });
+  const startDateHex = toHexString({ value: startDate, size: 32 });
 
   return `0x${periodAmountHex}${periodDurationHex}${startDateHex}`;
 }

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
@@ -1,21 +1,72 @@
-import type { Caveat } from '@metamask/delegation-core';
+import { createArgsEqualityCheckTerms, createLimitedCallsTerms, createNativeTokenTransferAmountTerms, createRedeemerTerms, type Caveat } from '@metamask/delegation-core';
 
 import type { PopulatedNativeTokenSwapPermission } from './types';
 import type { DelegationContracts } from '../../core/chainMetadata';
 
+const SWAP_ADAPTER_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+// abiEncode("Token-Whitelist-Enforced");
+const WHITELIST_ENFORCED = "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000018546f6b656e2d57686974656c6973742d456e666f726365640000000000000000";
+
+// abiEncode("Token-Whitelist-Not-Enforced");
+const WHITELIST_NOT_ENFORCED = "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001c546f6b656e2d57686974656c6973742d4e6f742d456e666f7263656400000000";
+
 /**
- * Native token swap permission currently attaches no delegation caveats.
- * Callers should treat swap limits and token policy as off-chain / wallet semantics until
- * matching enforcers exist.
- */
+ * Native token swap permission
+ * ------------------------------
+ * This permission allows a delegate to swap the grantor's native token for a specified token up to a cap.
+ * The caveats below enforce the swap limit and token policy.
+ *
+ * Caveats and enforcers
+ * ---------------------
+ * ArgsEqualityEnforcer: args specifying whether only whitelisted tokens are allowed.
+ * NativeTokenTransferAmountEnforcer: defines the max amount of native token that can be swapped.
+ * RedeemerEnforcer: only the swap adapter contract can redeem the permission.
+*/
 
 /**
  * Returns no caveats for native token swap.
  * @returns Empty caveat list.
  */
-export async function createPermissionCaveats(_: {
+export async function createPermissionCaveats({permission, contracts}: {
   permission: PopulatedNativeTokenSwapPermission;
   contracts: DelegationContracts;
 }): Promise<Caveat[]> {
-  return [];
+  const { maxNativeSwapAmount, whitelistedTokensOnly } = permission.data;
+
+  const expectedArgs = whitelistedTokensOnly ? WHITELIST_ENFORCED: WHITELIST_NOT_ENFORCED;
+
+  const argsEqualityCaveat: Caveat = {
+    enforcer: contracts.argsEqualityEnforcer,
+    terms: createArgsEqualityCheckTerms({
+      args: expectedArgs
+    }),
+    args: expectedArgs,
+  };
+
+  const nativeTokenTransferAmountCaveat: Caveat = {
+    enforcer: contracts.nativeTokenTransferAmountEnforcer,
+    terms: createNativeTokenTransferAmountTerms({
+      maxAmount: BigInt(maxNativeSwapAmount),
+    }),
+    args: '0x',
+  };
+
+  const redeemerCaveat: Caveat = {
+    enforcer: contracts.redeemerEnforcer,
+    terms: createRedeemerTerms({
+      redeemers: [SWAP_ADAPTER_ADDRESS],
+    }),
+    args: '0x',
+  };
+
+  const limitedCallsCaveat: Caveat = {
+    enforcer: contracts.limitedCallsEnforcer,
+    terms: createLimitedCallsTerms({
+      limit: 1,
+    }),
+    args: '0x',
+  };
+
+  return [argsEqualityCaveat, nativeTokenTransferAmountCaveat, redeemerCaveat, limitedCallsCaveat];
 }

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
@@ -1,15 +1,22 @@
-import { createArgsEqualityCheckTerms, createLimitedCallsTerms, createNativeTokenTransferAmountTerms, createRedeemerTerms, type Caveat } from '@metamask/delegation-core';
+import {
+  createArgsEqualityCheckTerms,
+  createLimitedCallsTerms,
+  createNativeTokenTransferAmountTerms,
+  createRedeemerTerms,
+} from '@metamask/delegation-core';
+import type { Caveat } from '@metamask/delegation-core';
+import { InternalError } from '@metamask/snaps-sdk';
 
 import type { PopulatedNativeTokenSwapPermission } from './types';
 import type { DelegationContracts } from '../../core/chainMetadata';
 
-const SWAP_ADAPTER_ADDRESS = '0x0000000000000000000000000000000000000000';
-
 // abiEncode("Token-Whitelist-Enforced");
-const WHITELIST_ENFORCED = "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000018546f6b656e2d57686974656c6973742d456e666f726365640000000000000000";
+const WHITELIST_ENFORCED =
+  '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000018546f6b656e2d57686974656c6973742d456e666f726365640000000000000000';
 
 // abiEncode("Token-Whitelist-Not-Enforced");
-const WHITELIST_NOT_ENFORCED = "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001c546f6b656e2d57686974656c6973742d4e6f742d456e666f7263656400000000";
+const WHITELIST_NOT_ENFORCED =
+  '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001c546f6b656e2d57686974656c6973742d4e6f742d456e666f7263656400000000';
 
 /**
  * Native token swap permission
@@ -22,24 +29,33 @@ const WHITELIST_NOT_ENFORCED = "0x0000000000000000000000000000000000000000000000
  * ArgsEqualityEnforcer: args specifying whether only whitelisted tokens are allowed.
  * NativeTokenTransferAmountEnforcer: defines the max amount of native token that can be swapped.
  * RedeemerEnforcer: only the swap adapter contract can redeem the permission.
-*/
+ */
 
 /**
- * Returns no caveats for native token swap.
- * @returns Empty caveat list.
+ * Builds caveats for a native-token-swap delegation.
+ *
+ * @param args - Caveat inputs.
+ * @param args.permission - Populated swap permission.
+ * @param args.contracts - Chain contracts; must include `tokenSwapAdapter` when supported.
+ * @returns Caveats attached to the delegation.
  */
-export async function createPermissionCaveats({permission, contracts}: {
+export async function createPermissionCaveats({
+  permission,
+  contracts,
+}: {
   permission: PopulatedNativeTokenSwapPermission;
   contracts: DelegationContracts;
 }): Promise<Caveat[]> {
   const { maxNativeSwapAmount, whitelistedTokensOnly } = permission.data;
 
-  const expectedArgs = whitelistedTokensOnly ? WHITELIST_ENFORCED: WHITELIST_NOT_ENFORCED;
+  const expectedArgs = whitelistedTokensOnly
+    ? WHITELIST_ENFORCED
+    : WHITELIST_NOT_ENFORCED;
 
   const argsEqualityCaveat: Caveat = {
     enforcer: contracts.argsEqualityEnforcer,
     terms: createArgsEqualityCheckTerms({
-      args: expectedArgs
+      args: expectedArgs,
     }),
     args: expectedArgs,
   };
@@ -52,10 +68,18 @@ export async function createPermissionCaveats({permission, contracts}: {
     args: '0x',
   };
 
+  const swapAdapterAddress = contracts.tokenSwapAdapter;
+
+  if (swapAdapterAddress === undefined) {
+    throw new InternalError(
+      'Token swap adapter is not configured for this chain',
+    );
+  }
+
   const redeemerCaveat: Caveat = {
     enforcer: contracts.redeemerEnforcer,
     terms: createRedeemerTerms({
-      redeemers: [SWAP_ADAPTER_ADDRESS],
+      redeemers: [swapAdapterAddress],
     }),
     args: '0x',
   };
@@ -68,5 +92,10 @@ export async function createPermissionCaveats({permission, contracts}: {
     args: '0x',
   };
 
-  return [argsEqualityCaveat, nativeTokenTransferAmountCaveat, redeemerCaveat, limitedCallsCaveat];
+  return [
+    argsEqualityCaveat,
+    nativeTokenTransferAmountCaveat,
+    redeemerCaveat,
+    limitedCallsCaveat,
+  ];
 }

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
@@ -1,14 +1,15 @@
 import {
   createArgsEqualityCheckTerms,
-  createLimitedCallsTerms,
-  createNativeTokenTransferAmountTerms,
+  createExactCalldataTerms,
   createRedeemerTerms,
 } from '@metamask/delegation-core';
-import type { Caveat } from '@metamask/delegation-core';
+import type { Caveat, Hex } from '@metamask/delegation-core';
 import { InternalError } from '@metamask/snaps-sdk';
 
 import type { PopulatedNativeTokenSwapPermission } from './types';
 import type { DelegationContracts } from '../../core/chainMetadata';
+import { bigIntToHex } from '@metamask/utils';
+import { numberToHex } from '@metamask/utils';
 
 // abiEncode("Token-Whitelist-Enforced");
 const WHITELIST_ENFORCED =
@@ -17,6 +18,8 @@ const WHITELIST_ENFORCED =
 // abiEncode("Token-Whitelist-Not-Enforced");
 const WHITELIST_NOT_ENFORCED =
   '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001c546f6b656e2d57686974656c6973742d4e6f742d456e666f7263656400000000';
+
+export const PERIOD_DURATION = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn;
 
 /**
  * Native token swap permission
@@ -27,9 +30,46 @@ const WHITELIST_NOT_ENFORCED =
  * Caveats and enforcers
  * ---------------------
  * ArgsEqualityEnforcer: args specifying whether only whitelisted tokens are allowed.
- * NativeTokenTransferAmountEnforcer: defines the max amount of native token that can be swapped.
+ * NativeTokenPeriodTransferEnforcer: encodes a period duration of UINT256_MAX, to enforce a single period with
+ * allowance of maxNativeSwapAmount.
  * RedeemerEnforcer: only the swap adapter contract can redeem the permission.
  */
+
+/**
+ * Creates terms for a NativeTokenPeriodTransfer caveat that validates that native token (ETH) transfers
+ * do not exceed a specified amount within a given time period. This differs from @metamask/delegation-core's
+ * implementation in that it accepts periodDuration as bigint.
+ *
+ * @param terms - The terms for the NativeTokenPeriodTransfer caveat.
+ * @param terms.periodAmount - The amount of native token that can be swapped.
+ * @param terms.periodDuration - The duration of the time period.
+ * @param terms.startDate - The start date of the time period.
+ * @returns The terms as a 96-byte hex string (32 bytes for each parameter).
+ * @throws Error if any of the numeric parameters are invalid.
+ */
+function createNativeTokenPeriodTransferTerms(
+  terms: { periodAmount: bigint; periodDuration: bigint; startDate: number },
+): Hex {
+  const { periodAmount, periodDuration, startDate } = terms;
+
+  if (periodAmount <= 0n) {
+    throw new Error('Invalid periodAmount: must be a positive number');
+  }
+
+  if (periodDuration <= 0) {
+    throw new Error('Invalid periodDuration: must be a positive number');
+  }
+
+  if (startDate <= 0) {
+    throw new Error('Invalid startDate: must be a positive number');
+  }
+
+  const periodAmountHex = bigIntToHex(periodAmount);
+  const periodDurationHex = bigIntToHex(periodDuration);
+  const startDateHex = numberToHex(startDate);
+
+  return `0x${periodAmountHex}${periodDurationHex}${startDateHex}`;
+}
 
 /**
  * Builds caveats for a native-token-swap delegation.
@@ -60,10 +100,20 @@ export async function createPermissionCaveats({
     args: expectedArgs,
   };
 
-  const nativeTokenTransferAmountCaveat: Caveat = {
-    enforcer: contracts.nativeTokenTransferAmountEnforcer,
-    terms: createNativeTokenTransferAmountTerms({
-      maxAmount: BigInt(maxNativeSwapAmount),
+  const nativeTokenPeriodTransferCaveat: Caveat = {
+    enforcer: contracts.nativeTokenPeriodTransferEnforcer,
+    terms: createNativeTokenPeriodTransferTerms({
+      periodAmount: BigInt(maxNativeSwapAmount),
+      periodDuration: PERIOD_DURATION,
+      startDate: Date.now() / 1000,
+    }),
+    args: '0x',
+  };
+
+  const exactCalldataCaveat: Caveat = {
+    enforcer: contracts.exactCalldataEnforcer,
+    terms: createExactCalldataTerms({
+      calldata: '0x',
     }),
     args: '0x',
   };
@@ -84,18 +134,10 @@ export async function createPermissionCaveats({
     args: '0x',
   };
 
-  const limitedCallsCaveat: Caveat = {
-    enforcer: contracts.limitedCallsEnforcer,
-    terms: createLimitedCallsTerms({
-      limit: 1,
-    }),
-    args: '0x',
-  };
-
   return [
     argsEqualityCaveat,
-    nativeTokenTransferAmountCaveat,
+    nativeTokenPeriodTransferCaveat,
+    exactCalldataCaveat,
     redeemerCaveat,
-    limitedCallsCaveat,
   ];
 }

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/caveats.ts
@@ -5,11 +5,10 @@ import {
 } from '@metamask/delegation-core';
 import type { Caveat, Hex } from '@metamask/delegation-core';
 import { InternalError } from '@metamask/snaps-sdk';
+import { bigIntToHex, hexToBigInt, numberToHex } from '@metamask/utils';
 
 import type { PopulatedNativeTokenSwapPermission } from './types';
 import type { DelegationContracts } from '../../core/chainMetadata';
-import { bigIntToHex } from '@metamask/utils';
-import { numberToHex } from '@metamask/utils';
 
 // abiEncode("Token-Whitelist-Enforced");
 const WHITELIST_ENFORCED =
@@ -19,19 +18,20 @@ const WHITELIST_ENFORCED =
 const WHITELIST_NOT_ENFORCED =
   '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001c546f6b656e2d57686974656c6973742d4e6f742d456e666f7263656400000000';
 
-export const PERIOD_DURATION = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn;
+export const PERIOD_DURATION =
+  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn;
 
 /**
  * Native token swap permission
  * ------------------------------
- * This permission allows a delegate to swap the grantor's native token for a specified token up to a cap.
- * The caveats below enforce the swap limit and token policy.
+ * This permission allows a delegate to swap the grantor's native token for a specified token within an allowance.
+ * The caveats below enforce the allowance and token policy.
  *
  * Caveats and enforcers
  * ---------------------
  * ArgsEqualityEnforcer: args specifying whether only whitelisted tokens are allowed.
  * NativeTokenPeriodTransferEnforcer: encodes a period duration of UINT256_MAX, to enforce a single period with
- * allowance of maxNativeSwapAmount.
+ * the configured native token allowance.
  * RedeemerEnforcer: only the swap adapter contract can redeem the permission.
  */
 
@@ -47,9 +47,11 @@ export const PERIOD_DURATION = 0xfffffffffffffffffffffffffffffffffffffffffffffff
  * @returns The terms as a 96-byte hex string (32 bytes for each parameter).
  * @throws Error if any of the numeric parameters are invalid.
  */
-function createNativeTokenPeriodTransferTerms(
-  terms: { periodAmount: bigint; periodDuration: bigint; startDate: number },
-): Hex {
+function createNativeTokenPeriodTransferTerms(terms: {
+  periodAmount: bigint;
+  periodDuration: bigint;
+  startDate: number;
+}): Hex {
   const { periodAmount, periodDuration, startDate } = terms;
 
   if (periodAmount <= 0n) {
@@ -86,7 +88,7 @@ export async function createPermissionCaveats({
   permission: PopulatedNativeTokenSwapPermission;
   contracts: DelegationContracts;
 }): Promise<Caveat[]> {
-  const { maxNativeSwapAmount, whitelistedTokensOnly } = permission.data;
+  const { allowance, whitelistedTokensOnly } = permission.data;
 
   const expectedArgs = whitelistedTokensOnly
     ? WHITELIST_ENFORCED
@@ -103,9 +105,9 @@ export async function createPermissionCaveats({
   const nativeTokenPeriodTransferCaveat: Caveat = {
     enforcer: contracts.nativeTokenPeriodTransferEnforcer,
     terms: createNativeTokenPeriodTransferTerms({
-      periodAmount: BigInt(maxNativeSwapAmount),
+      periodAmount: hexToBigInt(allowance),
       periodDuration: PERIOD_DURATION,
-      startDate: Date.now() / 1000,
+      startDate: Math.floor(Date.now() / 1000),
     }),
     args: '0x',
   };

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/content.tsx
@@ -1,19 +1,18 @@
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
-import { Box, Link, Section, Text } from '@metamask/snaps-sdk/jsx';
+import { Box, Link, Section } from '@metamask/snaps-sdk/jsx';
 
-import {
-  maxSwapAmountRule,
-  tokenRestrictionRule,
-  expiryRule,
-} from './rules';
+import { maxSwapAmountRule, tokenRestrictionRule, expiryRule } from './rules';
 import type { NativeTokenSwapContext, NativeTokenSwapMetadata } from './types';
 import { renderRules } from '../../core/rules';
 import { t } from '../../utils/i18n';
 
-const WHITELIST_LINK_PLACEHOLDER_HREF = 'https://example.com/whitelisted-tokens';
+const WHITELIST_LINK_PLACEHOLDER_HREF =
+  'https://example.com/whitelisted-tokens';
 
 /**
  * Builds confirmation UI for a native token swap permission.
+ *
+ * @param args - Dialog content inputs.
  * @param args.context - Permission context including swap cap and token policy.
  * @param args.metadata - Validation metadata.
  * @returns Snap dialog content.

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/content.tsx
@@ -1,13 +1,9 @@
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
-import { Box, Link, Section } from '@metamask/snaps-sdk/jsx';
+import { Box, Section } from '@metamask/snaps-sdk/jsx';
 
 import { allowanceRule, tokenRestrictionRule, expiryRule } from './rules';
 import type { NativeTokenSwapContext, NativeTokenSwapMetadata } from './types';
 import { renderRules } from '../../core/rules';
-import { t } from '../../utils/i18n';
-
-const WHITELIST_LINK_PLACEHOLDER_HREF =
-  'https://example.com/whitelisted-tokens';
 
 /**
  * Builds confirmation UI for a native token swap permission.
@@ -32,11 +28,6 @@ export async function createConfirmationContent({
           context,
           metadata,
         })}
-        <Box direction="vertical">
-          <Link href={WHITELIST_LINK_PLACEHOLDER_HREF}>
-            {t('whitelistedTokensListLinkLabel')}
-          </Link>
-        </Box>
         {renderRules({
           rules: [expiryRule],
           context,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/content.tsx
@@ -1,0 +1,49 @@
+import type { SnapElement } from '@metamask/snaps-sdk/jsx';
+import { Box, Link, Section, Text } from '@metamask/snaps-sdk/jsx';
+
+import {
+  maxSwapAmountRule,
+  tokenRestrictionRule,
+  expiryRule,
+} from './rules';
+import type { NativeTokenSwapContext, NativeTokenSwapMetadata } from './types';
+import { renderRules } from '../../core/rules';
+import { t } from '../../utils/i18n';
+
+const WHITELIST_LINK_PLACEHOLDER_HREF = 'https://example.com/whitelisted-tokens';
+
+/**
+ * Builds confirmation UI for a native token swap permission.
+ * @param args.context - Permission context including swap cap and token policy.
+ * @param args.metadata - Validation metadata.
+ * @returns Snap dialog content.
+ */
+export async function createConfirmationContent({
+  context,
+  metadata,
+}: {
+  context: NativeTokenSwapContext;
+  metadata: NativeTokenSwapMetadata;
+}): Promise<SnapElement> {
+  return (
+    <Box>
+      <Section>
+        {renderRules({
+          rules: [maxSwapAmountRule, tokenRestrictionRule],
+          context,
+          metadata,
+        })}
+        <Box direction="vertical">
+          <Link href={WHITELIST_LINK_PLACEHOLDER_HREF}>
+            {t('whitelistedTokensListLinkLabel')}
+          </Link>
+        </Box>
+        {renderRules({
+          rules: [expiryRule],
+          context,
+          metadata,
+        })}
+      </Section>
+    </Box>
+  );
+}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/content.tsx
@@ -1,7 +1,7 @@
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 import { Box, Link, Section } from '@metamask/snaps-sdk/jsx';
 
-import { maxSwapAmountRule, tokenRestrictionRule, expiryRule } from './rules';
+import { allowanceRule, tokenRestrictionRule, expiryRule } from './rules';
 import type { NativeTokenSwapContext, NativeTokenSwapMetadata } from './types';
 import { renderRules } from '../../core/rules';
 import { t } from '../../utils/i18n';
@@ -13,7 +13,7 @@ const WHITELIST_LINK_PLACEHOLDER_HREF =
  * Builds confirmation UI for a native token swap permission.
  *
  * @param args - Dialog content inputs.
- * @param args.context - Permission context including swap cap and token policy.
+ * @param args.context - Permission context including allowance and token policy.
  * @param args.metadata - Validation metadata.
  * @returns Snap dialog content.
  */
@@ -28,7 +28,7 @@ export async function createConfirmationContent({
     <Box>
       <Section>
         {renderRules({
-          rules: [maxSwapAmountRule, tokenRestrictionRule],
+          rules: [allowanceRule, tokenRestrictionRule],
           context,
           metadata,
         })}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/context.ts
@@ -47,16 +47,16 @@ export async function applyContext({
   const { rules } = applyExpiryRule(context, originalRequest);
 
   const { amount, error } = validateAndParseAmount(
-    permissionDetails.maxSwapAmount,
+    permissionDetails.allowance,
     decimals,
-    'max allowance',
+    'allowance',
   );
   if (error || amount === null) {
-    throw new InvalidInputError(error ?? 'Invalid max allowance');
+    throw new InvalidInputError(error ?? 'Invalid allowance');
   }
 
   const permissionData = {
-    maxNativeSwapAmount: bigIntToHex(amount),
+    allowance: bigIntToHex(amount),
     whitelistedTokensOnly: permissionDetails.whitelistedTokensOnly,
     justification: originalRequest.permission.data.justification,
   };
@@ -143,8 +143,8 @@ export async function buildContext({
       }
     : undefined;
 
-  const maxSwapAmount = formatUnitsFromHex({
-    value: data.maxNativeSwapAmount,
+  const allowanceFormatted = formatUnitsFromHex({
+    value: data.allowance,
     allowNull: false,
     decimals,
   });
@@ -174,7 +174,7 @@ export async function buildContext({
       iconDataBase64,
     },
     permissionDetails: {
-      maxSwapAmount,
+      allowance: allowanceFormatted,
       whitelistedTokensOnly: data.whitelistedTokensOnly,
     },
   };
@@ -200,13 +200,13 @@ export async function deriveMetadata({
 
   const validationErrors: NativeTokenSwapMetadata['validationErrors'] = {};
 
-  const maxAmountResult = validateAndParseAmount(
-    permissionDetails.maxSwapAmount,
+  const allowanceResult = validateAndParseAmount(
+    permissionDetails.allowance,
     decimals,
-    'max allowance',
+    'allowance',
   );
-  if (maxAmountResult.error) {
-    validationErrors.maxNativeSwapAmountError = maxAmountResult.error;
+  if (allowanceResult.error) {
+    validationErrors.allowanceError = allowanceResult.error;
   }
 
   if (expiry) {

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/context.ts
@@ -1,0 +1,217 @@
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
+import { InvalidInputError } from '@metamask/snaps-sdk';
+import {
+  bigIntToHex,
+  parseCaipAccountId,
+  toCaipAccountId,
+  toCaipAssetType,
+} from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
+
+import type { TokenMetadataService } from '../../services/tokenMetadataService';
+import { parseUnits, formatUnitsFromHex } from '../../utils/value';
+import {
+  validateAndParseAmount,
+  validateExpiry,
+} from '../contextValidation';
+import { applyExpiryRule } from '../rules';
+import type {
+  NativeTokenSwapContext,
+  NativeTokenSwapMetadata,
+  NativeTokenSwapPermission,
+  NativeTokenSwapPermissionRequest,
+  PopulatedNativeTokenSwapPermission,
+} from './types';
+
+const ASSET_NAMESPACE = 'slip44';
+const CHAIN_NAMESPACE = 'eip155';
+const ASSET_REFERENCE = '60';
+
+/**
+ * Applies UI context back onto the permission request.
+ * @param args.context - Context from the confirmation UI.
+ * @param args.originalRequest - Original request.
+ * @returns Updated permission request.
+ */
+export async function applyContext({
+  context,
+  originalRequest,
+}: {
+  context: NativeTokenSwapContext;
+  originalRequest: NativeTokenSwapPermissionRequest;
+}): Promise<NativeTokenSwapPermissionRequest> {
+  const {
+    permissionDetails,
+    tokenMetadata: { decimals },
+  } = context;
+
+  const { rules } = applyExpiryRule(context, originalRequest);
+
+  const { amount, error } = validateAndParseAmount(
+    permissionDetails.maxSwapAmount,
+    decimals,
+    'max allowance',
+  );
+  if (error || amount === null) {
+    throw new InvalidInputError(error ?? 'Invalid max allowance');
+  }
+
+  const permissionData = {
+    maxNativeSwapAmount: bigIntToHex(amount),
+    whitelistedTokensOnly: permissionDetails.whitelistedTokensOnly,
+    justification: originalRequest.permission.data.justification,
+  };
+
+  const { address } = parseCaipAccountId(context.accountAddressCaip10);
+
+  return {
+    ...originalRequest,
+    from: address as Hex,
+    permission: {
+      type: 'native-token-swap',
+      data: permissionData,
+      isAdjustmentAllowed: originalRequest.permission.isAdjustmentAllowed,
+    },
+    rules,
+  };
+}
+
+/**
+ * Populates defaults on the permission before caveat creation.
+ * @param args.permission - Permission to populate.
+ * @returns Populated permission.
+ */
+export async function populatePermission({
+  permission,
+}: {
+  permission: NativeTokenSwapPermission;
+}): Promise<PopulatedNativeTokenSwapPermission> {
+  return {
+    ...permission,
+  };
+}
+
+/**
+ * Builds dialog context from a validated permission request.
+ * @param args.permissionRequest - Validated request.
+ * @param args.tokenMetadataService - Token metadata (native asset).
+ * @returns Context for confirmation UI.
+ */
+export async function buildContext({
+  permissionRequest,
+  tokenMetadataService,
+}: {
+  permissionRequest: NativeTokenSwapPermissionRequest;
+  tokenMetadataService: TokenMetadataService;
+}): Promise<NativeTokenSwapContext> {
+  const chainId = Number(permissionRequest.chainId);
+
+  const {
+    from,
+    permission: { data, isAdjustmentAllowed },
+  } = permissionRequest;
+
+  if (!from) {
+    throw new InvalidInputError(
+      'PermissionRequest.address was not found. This should be resolved within the buildContextHandler function in PermissionHandler.',
+    );
+  }
+
+  const { decimals, symbol, iconUrl } =
+    await tokenMetadataService.getTokenBalanceAndMetadata({
+      chainId,
+      account: from,
+    });
+
+  const iconDataResponse =
+    await tokenMetadataService.fetchIconDataAsBase64(iconUrl);
+
+  const iconDataBase64 = iconDataResponse.success
+    ? iconDataResponse.imageDataBase64
+    : null;
+
+  const expiryRule = permissionRequest.rules?.find(
+    (rule) => extractDescriptorName(rule.type) === 'expiry',
+  );
+
+  const expiry = expiryRule
+    ? {
+        timestamp: expiryRule.data.timestamp,
+      }
+    : undefined;
+
+  const maxSwapAmount = formatUnitsFromHex({
+    value: data.maxNativeSwapAmount,
+    allowNull: false,
+    decimals,
+  });
+
+  const tokenAddressCaip19 = toCaipAssetType(
+    CHAIN_NAMESPACE,
+    chainId.toString(),
+    ASSET_NAMESPACE,
+    ASSET_REFERENCE,
+  );
+
+  const accountAddressCaip10 = toCaipAccountId(
+    CHAIN_NAMESPACE,
+    chainId.toString(),
+    from,
+  );
+
+  return {
+    expiry,
+    justification: data.justification,
+    isAdjustmentAllowed,
+    accountAddressCaip10,
+    tokenAddressCaip19,
+    tokenMetadata: {
+      symbol,
+      decimals,
+      iconDataBase64,
+    },
+    permissionDetails: {
+      maxSwapAmount,
+      whitelistedTokensOnly: data.whitelistedTokensOnly,
+    },
+  };
+}
+
+/**
+ * Derives validation metadata for the confirmation UI.
+ * @param args.context - Current context.
+ * @returns Metadata including field errors.
+ */
+export async function deriveMetadata({
+  context,
+}: {
+  context: NativeTokenSwapContext;
+}): Promise<NativeTokenSwapMetadata> {
+  const {
+    permissionDetails,
+    expiry,
+    tokenMetadata: { decimals },
+  } = context;
+
+  const validationErrors: NativeTokenSwapMetadata['validationErrors'] = {};
+
+  const maxAmountResult = validateAndParseAmount(
+    permissionDetails.maxSwapAmount,
+    decimals,
+    'max allowance',
+  );
+  if (maxAmountResult.error) {
+    validationErrors.maxNativeSwapAmountError = maxAmountResult.error;
+  }
+
+  if (expiry) {
+    const expiryError = validateExpiry(expiry.timestamp);
+    if (expiryError) {
+      validationErrors.expiryError = expiryError;
+    }
+  }
+
+  return {
+    validationErrors,
+  };
+}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/context.ts
@@ -9,11 +9,8 @@ import {
 import type { Hex } from '@metamask/utils';
 
 import type { TokenMetadataService } from '../../services/tokenMetadataService';
-import { parseUnits, formatUnitsFromHex } from '../../utils/value';
-import {
-  validateAndParseAmount,
-  validateExpiry,
-} from '../contextValidation';
+import { formatUnitsFromHex } from '../../utils/value';
+import { validateAndParseAmount, validateExpiry } from '../contextValidation';
 import { applyExpiryRule } from '../rules';
 import type {
   NativeTokenSwapContext,
@@ -29,6 +26,8 @@ const ASSET_REFERENCE = '60';
 
 /**
  * Applies UI context back onto the permission request.
+ *
+ * @param args - Arguments for applying the context.
  * @param args.context - Context from the confirmation UI.
  * @param args.originalRequest - Original request.
  * @returns Updated permission request.
@@ -78,6 +77,8 @@ export async function applyContext({
 
 /**
  * Populates defaults on the permission before caveat creation.
+ *
+ * @param args - Arguments for populating the permission.
  * @param args.permission - Permission to populate.
  * @returns Populated permission.
  */
@@ -93,6 +94,8 @@ export async function populatePermission({
 
 /**
  * Builds dialog context from a validated permission request.
+ *
+ * @param args - Arguments for building the context.
  * @param args.permissionRequest - Validated request.
  * @param args.tokenMetadataService - Token metadata (native asset).
  * @returns Context for confirmation UI.
@@ -179,6 +182,8 @@ export async function buildContext({
 
 /**
  * Derives validation metadata for the confirmation UI.
+ *
+ * @param args - Arguments for deriving the metadata.
  * @param args.context - Current context.
  * @returns Metadata including field errors.
  */

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/index.ts
@@ -1,0 +1,39 @@
+import { createPermissionCaveats } from './caveats';
+import { createConfirmationContent } from './content';
+import {
+  applyContext,
+  buildContext,
+  deriveMetadata,
+  populatePermission,
+} from './context';
+import { allRules } from './rules';
+import type {
+  NativeTokenSwapContext,
+  NativeTokenSwapMetadata,
+  NativeTokenSwapPermission,
+  NativeTokenSwapPermissionRequest,
+  PopulatedNativeTokenSwapPermission,
+} from './types';
+import { parseAndValidatePermission } from './validation';
+import type { PermissionDefinition } from '../../core/types';
+
+export const nativeTokenSwapPermissionDefinition: PermissionDefinition<
+  NativeTokenSwapPermissionRequest,
+  NativeTokenSwapContext,
+  NativeTokenSwapMetadata,
+  NativeTokenSwapPermission,
+  PopulatedNativeTokenSwapPermission
+> = {
+  rules: allRules,
+  title: 'permissionRequestTitle',
+  subtitle: 'permissionRequestSubtitleNativeTokenSwap',
+  dependencies: {
+    parseAndValidatePermission,
+    buildContext,
+    deriveMetadata,
+    createConfirmationContent,
+    applyContext,
+    populatePermission,
+    createPermissionCaveats,
+  },
+};

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/index.ts
@@ -14,7 +14,7 @@ import type {
   NativeTokenSwapPermissionRequest,
   PopulatedNativeTokenSwapPermission,
 } from './types';
-import { parseAndValidatePermission } from './validation';
+import { getSupportedChains, parseAndValidatePermission } from './validation';
 import type { PermissionDefinition } from '../../core/types';
 
 export const nativeTokenSwapPermissionDefinition: PermissionDefinition<
@@ -27,6 +27,7 @@ export const nativeTokenSwapPermissionDefinition: PermissionDefinition<
   rules: allRules,
   title: 'permissionRequestTitle',
   subtitle: 'permissionRequestSubtitleNativeTokenSwap',
+  getSupportedChains,
   dependencies: {
     parseAndValidatePermission,
     buildContext,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/rules.ts
@@ -4,7 +4,7 @@ import { t } from '../../utils/i18n';
 import { createExpiryRule } from '../rules';
 import type { NativeTokenSwapContext, NativeTokenSwapMetadata } from './types';
 
-export const MAX_SWAP_AMOUNT_ELEMENT = 'native-token-swap-max-amount';
+export const ALLOWANCE_ELEMENT = 'native-token-swap-allowance';
 export const TOKEN_RESTRICTION_ELEMENT = 'native-token-swap-token-restriction';
 export const EXPIRY_ELEMENT = 'native-token-swap-expiry';
 
@@ -13,16 +13,16 @@ type NativeTokenSwapRuleDefinition = RuleDefinition<
   NativeTokenSwapMetadata
 >;
 
-export const maxSwapAmountRule: NativeTokenSwapRuleDefinition = {
-  name: MAX_SWAP_AMOUNT_ELEMENT,
-  label: 'maxNativeSwapAmountLabel',
+export const allowanceRule: NativeTokenSwapRuleDefinition = {
+  name: ALLOWANCE_ELEMENT,
+  label: 'allowanceLabel',
   type: 'number',
   isOptional: false,
   getRuleData: ({ context, metadata }) => ({
-    value: context.permissionDetails.maxSwapAmount,
+    value: context.permissionDetails.allowance,
     isVisible: true,
-    tooltip: t('maxNativeSwapAmountTooltip'),
-    error: metadata.validationErrors.maxNativeSwapAmountError,
+    tooltip: t('allowanceTooltip'),
+    error: metadata.validationErrors.allowanceError,
     isEditable: context.isAdjustmentAllowed,
   }),
   updateContext: (
@@ -32,7 +32,7 @@ export const maxSwapAmountRule: NativeTokenSwapRuleDefinition = {
     ...swapContext,
     permissionDetails: {
       ...swapContext.permissionDetails,
-      maxSwapAmount: value ?? '',
+      allowance: value ?? '',
     },
   }),
 };
@@ -69,4 +69,4 @@ export const expiryRule = createExpiryRule<
   NativeTokenSwapMetadata
 >({ elementName: EXPIRY_ELEMENT, translate: t });
 
-export const allRules = [maxSwapAmountRule, tokenRestrictionRule, expiryRule];
+export const allRules = [allowanceRule, tokenRestrictionRule, expiryRule];

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/rules.ts
@@ -69,8 +69,4 @@ export const expiryRule = createExpiryRule<
   NativeTokenSwapMetadata
 >({ elementName: EXPIRY_ELEMENT, translate: t });
 
-export const allRules = [
-  maxSwapAmountRule,
-  tokenRestrictionRule,
-  expiryRule,
-];
+export const allRules = [maxSwapAmountRule, tokenRestrictionRule, expiryRule];

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/rules.ts
@@ -1,0 +1,76 @@
+import type { RuleDefinition } from '../../core/types';
+import type { MessageKey } from '../../utils/i18n';
+import { t } from '../../utils/i18n';
+import { createExpiryRule } from '../rules';
+import type { NativeTokenSwapContext, NativeTokenSwapMetadata } from './types';
+
+export const MAX_SWAP_AMOUNT_ELEMENT = 'native-token-swap-max-amount';
+export const TOKEN_RESTRICTION_ELEMENT = 'native-token-swap-token-restriction';
+export const EXPIRY_ELEMENT = 'native-token-swap-expiry';
+
+type NativeTokenSwapRuleDefinition = RuleDefinition<
+  NativeTokenSwapContext,
+  NativeTokenSwapMetadata
+>;
+
+export const maxSwapAmountRule: NativeTokenSwapRuleDefinition = {
+  name: MAX_SWAP_AMOUNT_ELEMENT,
+  label: 'maxNativeSwapAmountLabel',
+  type: 'number',
+  isOptional: false,
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.maxSwapAmount,
+    isVisible: true,
+    tooltip: t('maxNativeSwapAmountTooltip'),
+    error: metadata.validationErrors.maxNativeSwapAmountError,
+    isEditable: context.isAdjustmentAllowed,
+  }),
+  updateContext: (
+    swapContext: NativeTokenSwapContext,
+    value: string | null,
+  ) => ({
+    ...swapContext,
+    permissionDetails: {
+      ...swapContext.permissionDetails,
+      maxSwapAmount: value ?? '',
+    },
+  }),
+};
+
+const TOKEN_RESTRICTION_OPTIONS: MessageKey[] = [
+  'tokenSwapModeWhitelistedOnly',
+  'tokenSwapModeAnyToken',
+];
+
+export const tokenRestrictionRule: NativeTokenSwapRuleDefinition = {
+  name: TOKEN_RESTRICTION_ELEMENT,
+  label: 'tokenSwapRestrictionLabel',
+  type: 'dropdown',
+  getRuleData: ({ context }) => ({
+    value: context.permissionDetails.whitelistedTokensOnly
+      ? 'tokenSwapModeWhitelistedOnly'
+      : 'tokenSwapModeAnyToken',
+    isVisible: true,
+    tooltip: t('tokenSwapRestrictionTooltip'),
+    options: TOKEN_RESTRICTION_OPTIONS,
+    isEditable: context.isAdjustmentAllowed,
+  }),
+  updateContext: (swapContext: NativeTokenSwapContext, value: string) => ({
+    ...swapContext,
+    permissionDetails: {
+      ...swapContext.permissionDetails,
+      whitelistedTokensOnly: value === 'tokenSwapModeWhitelistedOnly',
+    },
+  }),
+};
+
+export const expiryRule = createExpiryRule<
+  NativeTokenSwapContext,
+  NativeTokenSwapMetadata
+>({ elementName: EXPIRY_ELEMENT, translate: t });
+
+export const allRules = [
+  maxSwapAmountRule,
+  tokenRestrictionRule,
+  expiryRule,
+];

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/types.ts
@@ -14,15 +14,15 @@ import type {
 
 export type NativeTokenSwapMetadata = BaseMetadata & {
   validationErrors: {
-    maxNativeSwapAmountError?: string;
+    allowanceError?: string;
     expiryError?: string;
   };
 };
 
 export type NativeTokenSwapContext = BaseContext & {
   permissionDetails: {
-    /** Human-readable max allowance for the swap cap (native token units). */
-    maxSwapAmount: string;
+    /** Human-readable native token allowance (swap limit). */
+    allowance: string;
     whitelistedTokensOnly: boolean;
   };
 };
@@ -32,7 +32,7 @@ export const zNativeTokenSwapPermission = zPermission.extend({
   data: z.intersection(
     zMetaMaskPermissionData,
     z.object({
-      maxNativeSwapAmount: zHexStr,
+      allowance: zHexStr,
       whitelistedTokensOnly: z.boolean(),
     }),
   ),

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/types.ts
@@ -38,7 +38,9 @@ export const zNativeTokenSwapPermission = zPermission.extend({
   ),
 });
 
-export type NativeTokenSwapPermission = z.infer<typeof zNativeTokenSwapPermission>;
+export type NativeTokenSwapPermission = z.infer<
+  typeof zNativeTokenSwapPermission
+>;
 
 export type NativeTokenSwapPermissionRequest =
   TypedPermissionRequest<NativeTokenSwapPermission>;

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/types.ts
@@ -1,0 +1,47 @@
+import {
+  zPermission,
+  zMetaMaskPermissionData,
+  zHexStr,
+} from '@metamask/7715-permissions-shared/types';
+import { z } from 'zod';
+
+import type {
+  DeepRequired,
+  TypedPermissionRequest,
+  BaseContext,
+  BaseMetadata,
+} from '../../core/types';
+
+export type NativeTokenSwapMetadata = BaseMetadata & {
+  validationErrors: {
+    maxNativeSwapAmountError?: string;
+    expiryError?: string;
+  };
+};
+
+export type NativeTokenSwapContext = BaseContext & {
+  permissionDetails: {
+    /** Human-readable max allowance for the swap cap (native token units). */
+    maxSwapAmount: string;
+    whitelistedTokensOnly: boolean;
+  };
+};
+
+export const zNativeTokenSwapPermission = zPermission.extend({
+  type: z.literal('native-token-swap'),
+  data: z.intersection(
+    zMetaMaskPermissionData,
+    z.object({
+      maxNativeSwapAmount: zHexStr,
+      whitelistedTokensOnly: z.boolean(),
+    }),
+  ),
+});
+
+export type NativeTokenSwapPermission = z.infer<typeof zNativeTokenSwapPermission>;
+
+export type NativeTokenSwapPermissionRequest =
+  TypedPermissionRequest<NativeTokenSwapPermission>;
+
+export type PopulatedNativeTokenSwapPermission =
+  DeepRequired<NativeTokenSwapPermission>;

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/validation.ts
@@ -2,6 +2,7 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
+import { getTokenSwapSupportedChainIds } from '../../core/chainMetadata';
 import { validateHexInteger } from '../validation';
 import type {
   NativeTokenSwapPermission,
@@ -10,8 +11,19 @@ import type {
 import { zNativeTokenSwapPermission } from './types';
 
 /**
+ * Returns chain IDs on which native-token-swap is supported (adapter deployed).
+ *
+ * @returns Sorted chain IDs.
+ */
+export function getSupportedChains(): number[] {
+  return getTokenSwapSupportedChainIds();
+}
+
+/**
  * Validates permission-specific data for native token swap.
+ *
  * @param permission - The parsed native token swap permission.
+ * @returns True when valid.
  */
 function validatePermissionData(permission: NativeTokenSwapPermission): true {
   validateHexInteger({

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/validation.ts
@@ -1,0 +1,51 @@
+import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
+import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+import { InvalidInputError } from '@metamask/snaps-sdk';
+
+import { validateHexInteger } from '../validation';
+import type {
+  NativeTokenSwapPermission,
+  NativeTokenSwapPermissionRequest,
+} from './types';
+import { zNativeTokenSwapPermission } from './types';
+
+/**
+ * Validates permission-specific data for native token swap.
+ * @param permission - The parsed native token swap permission.
+ */
+function validatePermissionData(permission: NativeTokenSwapPermission): true {
+  validateHexInteger({
+    name: 'maxNativeSwapAmount',
+    value: permission.data.maxNativeSwapAmount,
+    required: true,
+    allowZero: false,
+  });
+
+  return true;
+}
+
+/**
+ * Parses and validates a native token swap permission request.
+ * @param permissionRequest - The permission request to validate.
+ * @returns The validated typed request.
+ */
+export function parseAndValidatePermission(
+  permissionRequest: PermissionRequest,
+): NativeTokenSwapPermissionRequest {
+  const {
+    data: validationResult,
+    error: validationError,
+    success,
+  } = zNativeTokenSwapPermission.safeParse(permissionRequest.permission);
+
+  if (!success) {
+    throw new InvalidInputError(extractZodError(validationError.errors));
+  }
+
+  validatePermissionData(validationResult);
+
+  return {
+    ...permissionRequest,
+    permission: validationResult,
+  };
+}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenSwap/validation.ts
@@ -27,8 +27,8 @@ export function getSupportedChains(): number[] {
  */
 function validatePermissionData(permission: NativeTokenSwapPermission): true {
   validateHexInteger({
-    name: 'maxNativeSwapAmount',
-    value: permission.data.maxNativeSwapAmount,
+    name: 'allowance',
+    value: permission.data.allowance,
     required: true,
     allowZero: false,
   });

--- a/packages/gator-permissions-snap/src/permissions/permissionDefinitionsRegistry.ts
+++ b/packages/gator-permissions-snap/src/permissions/permissionDefinitionsRegistry.ts
@@ -1,0 +1,53 @@
+import { InvalidInputError } from '@metamask/snaps-sdk';
+
+import { erc20TokenPeriodicPermissionDefinition } from './erc20TokenPeriodic';
+import { erc20TokenRevocationPermissionDefinition } from './erc20TokenRevocation';
+import { erc20TokenStreamPermissionDefinition } from './erc20TokenStream';
+import { nativeTokenPeriodicPermissionDefinition } from './nativeTokenPeriodic';
+import { nativeTokenStreamPermissionDefinition } from './nativeTokenStream';
+import { nativeTokenSwapPermissionDefinition } from './nativeTokenSwap';
+import type { PermissionDefinition } from '../core/types';
+
+export type SupportedGatorPermissionType =
+  | 'native-token-stream'
+  | 'native-token-periodic'
+  | 'native-token-swap'
+  | 'erc20-token-periodic'
+  | 'erc20-token-revocation'
+  | 'erc20-token-stream';
+
+/**
+ * All Gator execution permission definitions keyed by permission type name.
+ */
+export const PERMISSION_DEFINITIONS_BY_TYPE = {
+  'native-token-stream': nativeTokenStreamPermissionDefinition,
+  'native-token-periodic': nativeTokenPeriodicPermissionDefinition,
+  'native-token-swap': nativeTokenSwapPermissionDefinition,
+  'erc20-token-periodic': erc20TokenPeriodicPermissionDefinition,
+  'erc20-token-revocation': erc20TokenRevocationPermissionDefinition,
+  'erc20-token-stream': erc20TokenStreamPermissionDefinition,
+} as unknown as Record<SupportedGatorPermissionType, PermissionDefinition>;
+
+/**
+ * Resolves the permission definition for a type string.
+ *
+ * @param permissionType - Extracted permission type name.
+ * @returns The definition.
+ * @throws InvalidInputError If the type is unknown.
+ */
+export function getPermissionDefinition(
+  permissionType: string,
+): PermissionDefinition {
+  const definition =
+    PERMISSION_DEFINITIONS_BY_TYPE[
+      permissionType as SupportedGatorPermissionType
+    ];
+
+  if (!definition) {
+    throw new InvalidInputError(
+      `Unsupported permission type: ${permissionType}`,
+    );
+  }
+
+  return definition;
+}

--- a/packages/gator-permissions-snap/src/permissions/permissionOffers.ts
+++ b/packages/gator-permissions-snap/src/permissions/permissionOffers.ts
@@ -13,6 +13,10 @@ export const DEFAULT_GATOR_PERMISSION_TO_OFFER: PermissionOffer[] = [
     proposedName: 'Native Token Periodic Transfer',
   },
   {
+    type: 'native-token-swap',
+    proposedName: 'Native Token Swap',
+  },
+  {
     type: 'erc20-token-stream',
     proposedName: 'ERC20 Token Stream',
   },

--- a/packages/gator-permissions-snap/src/rpc/rpcHandler.ts
+++ b/packages/gator-permissions-snap/src/rpc/rpcHandler.ts
@@ -13,8 +13,11 @@ import type { Json } from '@metamask/snaps-sdk';
 import { numberToHex } from '@metamask/utils';
 
 import type { BlockchainClient } from '../clients/blockchainClient';
-import { nameAndExplorerUrlByChainId } from '../core/chainMetadata';
 import type { PermissionHandlerFactory } from '../core/permissionHandlerFactory';
+import {
+  getPermissionDefinition,
+  SupportedGatorPermissionType,
+} from '../permissions/permissionDefinitionsRegistry';
 import { DEFAULT_GATOR_PERMISSION_TO_OFFER } from '../permissions/permissionOffers';
 import type {
   ProfileSyncManager,
@@ -306,18 +309,24 @@ export function createRpcHandler({
   const getSupportedPermissions = async (): Promise<Json> => {
     logger.debug('getSupportedPermissions()');
 
-    const chainIds = Object.keys(nameAndExplorerUrlByChainId).map((id) =>
-      numberToHex(Number(id)),
-    );
-
     const supportedPermissions: GetSupportedPermissionsResult = {};
 
     for (const offer of DEFAULT_GATOR_PERMISSION_TO_OFFER) {
-      const permissionType = extractDescriptorName(offer.type);
-      const ruleTypes =
-        SUPPORTED_RULE_TYPES[
-          permissionType as keyof typeof SUPPORTED_RULE_TYPES
-        ];
+      const permissionType = extractDescriptorName(
+        offer.type,
+      ) as SupportedGatorPermissionType;
+      const ruleTypes = SUPPORTED_RULE_TYPES[permissionType];
+
+      const permissionDefinition = getPermissionDefinition(permissionType);
+      if (!permissionDefinition) {
+        throw new InvalidInputError(
+          `Permission definition not found for permission type: ${permissionType}`,
+        );
+      }
+
+      const chainIds = permissionDefinition
+        .getSupportedChains()
+        .map(numberToHex);
 
       supportedPermissions[permissionType] = {
         chainIds,

--- a/packages/gator-permissions-snap/test/core/chainMetadata.test.ts
+++ b/packages/gator-permissions-snap/test/core/chainMetadata.test.ts
@@ -3,6 +3,7 @@ import { isHexString } from '@metamask/utils';
 import type { DelegationContracts } from '../../src/core/chainMetadata';
 import {
   getChainMetadata,
+  getConfiguredChainIds,
   nameAndExplorerUrlByChainId,
 } from '../../src/core/chainMetadata';
 
@@ -44,7 +45,7 @@ describe('chainMetadata', () => {
         (chainId) => {
           const metadata = getChainMetadata({ chainId });
 
-          expect(metadata).toStrictEqual(metadataSchema);
+          expect(metadata).toMatchObject(metadataSchema);
 
           // Name should not be the default "Unknown chain" format
           expect(metadata.name).not.toMatch(/^Unknown chain 0x/u);
@@ -58,7 +59,7 @@ describe('chainMetadata', () => {
         (chainId) => {
           const metadata = getChainMetadata({ chainId });
 
-          expect(metadata).toStrictEqual({
+          expect(metadata).toMatchObject({
             ...metadataSchema,
             explorerUrl: undefined,
           });
@@ -73,7 +74,7 @@ describe('chainMetadata', () => {
       it('returns metadata with default name for unknown chain', () => {
         const metadata = getChainMetadata({ chainId: 0x9999 });
 
-        expect(metadata).toStrictEqual({
+        expect(metadata).toMatchObject({
           ...metadataSchema,
           explorerUrl: undefined,
         });
@@ -83,6 +84,31 @@ describe('chainMetadata', () => {
 
         // Explorer URL should be undefined
         expect(metadata.explorerUrl).toBeUndefined();
+      });
+    });
+
+    describe('native token swap adapter', () => {
+      it('includes tokenSwapAdapter on Ethereum mainnet', () => {
+        const metadata = getChainMetadata({ chainId: 0x1 });
+        expect(metadata.contracts.tokenSwapAdapter).toBe(
+          '0xe41eb5a3f6e35f1a8c77113f372892d09820c3fd',
+        );
+      });
+
+      it('omits tokenSwapAdapter when not deployed on chain', () => {
+        const metadata = getChainMetadata({ chainId: 0xaa36a7 }); // Sepolia
+        expect(metadata.contracts.tokenSwapAdapter).toBeUndefined();
+      });
+    });
+
+    describe('getConfiguredChainIds', () => {
+      it('returns sorted chain ids from nameAndExplorerUrlByChainId', () => {
+        const ids = getConfiguredChainIds();
+        expect(ids).toStrictEqual(
+          Object.keys(nameAndExplorerUrlByChainId)
+            .map((k) => Number(k))
+            .sort((a, b) => a - b),
+        );
       });
     });
 

--- a/packages/gator-permissions-snap/test/core/permissionHandlerFactory.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionHandlerFactory.test.ts
@@ -87,6 +87,29 @@ describe('PermissionHandlerFactory', () => {
       expect(handler).toBeInstanceOf(PermissionHandler);
     });
 
+    it('should create a PermissionHandler when given native-token-swap permission type', () => {
+      const swapRequest: PermissionRequest = {
+        chainId: '0x1',
+        to: TEST_ADDRESS,
+        permission: {
+          type: 'native-token-swap',
+          isAdjustmentAllowed: true,
+          data: {
+            justification: 'test',
+            maxNativeSwapAmount: '0x1',
+            whitelistedTokensOnly: true,
+          },
+        },
+        rules: [],
+      };
+
+      const handler =
+        permissionHandlerFactory.createPermissionHandler(swapRequest);
+
+      expect(handler).toBeDefined();
+      expect(handler).toBeInstanceOf(PermissionHandler);
+    });
+
     it('should throw an error when given an unsupported permission type', () => {
       expect(() =>
         permissionHandlerFactory.createPermissionHandler(

--- a/packages/gator-permissions-snap/test/core/permissionHandlerFactory.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionHandlerFactory.test.ts
@@ -96,7 +96,7 @@ describe('PermissionHandlerFactory', () => {
           isAdjustmentAllowed: true,
           data: {
             justification: 'test',
-            maxNativeSwapAmount: '0x1',
+            allowance: '0x1',
             whitelistedTokensOnly: true,
           },
         },

--- a/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
+++ b/packages/gator-permissions-snap/test/core/permissionRequestLifecycleOrchestrator.test.ts
@@ -70,7 +70,7 @@ const mockPermissionRequest: PermissionRequest = {
   chainId: '0x1',
   to: requestingAccountAddress,
   permission: {
-    type: 'test-permission',
+    type: 'native-token-stream',
     data: {},
     isAdjustmentAllowed: true,
   },
@@ -518,21 +518,6 @@ describe('PermissionRequestLifecycleOrchestrator', () => {
 
         expect(delegationsArray).toStrictEqual([expectedDelegation]);
         expect(delegationsArray[0]?.salt).not.toBe(0n);
-      });
-
-      it('does not reject permission request for unknown chain', async () => {
-        const chainRequestWithUnknownChain = {
-          ...mockPermissionRequest,
-          chainId: '0x9999999' as Hex, // non-existent chain
-        };
-
-        const result = await permissionRequestLifecycleOrchestrator.orchestrate(
-          'test-origin',
-          chainRequestWithUnknownChain,
-          lifecycleHandlerMocks,
-        );
-
-        expect(result).toBeDefined();
       });
 
       it('does not throw an error when expiry rule is not present', async () => {

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/caveats.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/caveats.test.ts
@@ -1,18 +1,15 @@
 import { describe, expect, it } from '@jest/globals';
 import { bigIntToHex } from '@metamask/utils';
 
-import type { DelegationContracts } from '../../../src/core/chainMetadata';
+import { getChainMetadata } from '../../../src/core/chainMetadata';
 import { createPermissionCaveats } from '../../../src/permissions/nativeTokenSwap/caveats';
 import type { PopulatedNativeTokenSwapPermission } from '../../../src/permissions/nativeTokenSwap/types';
 import { parseUnits } from '../../../src/utils/value';
 
-const contracts = {
-  valueLteEnforcer: '0x1234567890123456789012345678901234567891',
-} as unknown as DelegationContracts;
-
 describe('nativeTokenSwap:caveats', () => {
   describe('createPermissionCaveats()', () => {
-    it('returns an empty caveat list', async () => {
+    it('returns caveats including redeemer for the chain swap adapter', async () => {
+      const { contracts } = getChainMetadata({ chainId: 0x1 });
       const maxWei = parseUnits({ formatted: '0.5', decimals: 18 });
       const permission: PopulatedNativeTokenSwapPermission = {
         type: 'native-token-swap',
@@ -26,7 +23,8 @@ describe('nativeTokenSwap:caveats', () => {
 
       const caveats = await createPermissionCaveats({ permission, contracts });
 
-      expect(caveats).toStrictEqual([]);
+      expect(caveats).toHaveLength(4);
+      expect(contracts.tokenSwapAdapter).toBeDefined();
     });
   });
 });

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/caveats.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/caveats.test.ts
@@ -15,7 +15,7 @@ describe('nativeTokenSwap:caveats', () => {
         type: 'native-token-swap',
         data: {
           justification: 'Swap cap',
-          maxNativeSwapAmount: bigIntToHex(maxWei),
+          allowance: bigIntToHex(maxWei),
           whitelistedTokensOnly: false,
         },
         isAdjustmentAllowed: true,

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/caveats.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/caveats.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+import { bigIntToHex } from '@metamask/utils';
+
+import type { DelegationContracts } from '../../../src/core/chainMetadata';
+import { createPermissionCaveats } from '../../../src/permissions/nativeTokenSwap/caveats';
+import type { PopulatedNativeTokenSwapPermission } from '../../../src/permissions/nativeTokenSwap/types';
+import { parseUnits } from '../../../src/utils/value';
+
+const contracts = {
+  valueLteEnforcer: '0x1234567890123456789012345678901234567891',
+} as unknown as DelegationContracts;
+
+describe('nativeTokenSwap:caveats', () => {
+  describe('createPermissionCaveats()', () => {
+    it('returns an empty caveat list', async () => {
+      const maxWei = parseUnits({ formatted: '0.5', decimals: 18 });
+      const permission: PopulatedNativeTokenSwapPermission = {
+        type: 'native-token-swap',
+        data: {
+          justification: 'Swap cap',
+          maxNativeSwapAmount: bigIntToHex(maxWei),
+          whitelistedTokensOnly: false,
+        },
+        isAdjustmentAllowed: true,
+      };
+
+      const caveats = await createPermissionCaveats({ permission, contracts });
+
+      expect(caveats).toStrictEqual([]);
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/validation.test.ts
@@ -24,9 +24,7 @@ const validPermissionRequest: NativeTokenSwapPermissionRequest = {
     type: 'native-token-swap',
     data: {
       justification: 'test',
-      maxNativeSwapAmount: bigIntToHex(
-        parseUnits({ formatted: '1', decimals: 18 }),
-      ),
+      allowance: bigIntToHex(parseUnits({ formatted: '1', decimals: 18 })),
       whitelistedTokensOnly: true,
     },
     isAdjustmentAllowed: true,
@@ -79,20 +77,20 @@ describe('nativeTokenSwap:validation', () => {
       );
     });
 
-    it('should reject zero maxNativeSwapAmount', () => {
+    it('should reject zero allowance', () => {
       const zeroAmount = {
         ...validPermissionRequest,
         permission: {
           ...validPermissionRequest.permission,
           data: {
             ...validPermissionRequest.permission.data,
-            maxNativeSwapAmount: '0x0',
+            allowance: '0x0',
           },
         },
       };
 
       expect(() => parseAndValidatePermission(zeroAmount as any)).toThrow(
-        'Invalid maxNativeSwapAmount: must be greater than 0',
+        'Invalid allowance: must be greater than 0',
       );
     });
   });

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/validation.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from '@jest/globals';
+import { bigIntToHex } from '@metamask/utils';
+
+import type { NativeTokenSwapPermissionRequest } from '../../../src/permissions/nativeTokenSwap/types';
+import { parseAndValidatePermission } from '../../../src/permissions/nativeTokenSwap/validation';
+import { parseUnits } from '../../../src/utils/value';
+
+const validPermissionRequest: NativeTokenSwapPermissionRequest = {
+  chainId: '0x1',
+  rules: [
+    {
+      type: 'expiry',
+      data: {
+        timestamp: Math.floor(Date.now() / 1000) + 86400 * 7,
+      },
+    },
+  ],
+  to: '0x1',
+  permission: {
+    type: 'native-token-swap',
+    data: {
+      justification: 'test',
+      maxNativeSwapAmount: bigIntToHex(
+        parseUnits({ formatted: '1', decimals: 18 }),
+      ),
+      whitelistedTokensOnly: true,
+    },
+    isAdjustmentAllowed: true,
+  },
+};
+
+describe('nativeTokenSwap:validation', () => {
+  describe('parseAndValidatePermission()', () => {
+    it('should validate a valid permission request', () => {
+      expect(() =>
+        parseAndValidatePermission(validPermissionRequest),
+      ).not.toThrow();
+
+      const result = parseAndValidatePermission(validPermissionRequest);
+      expect(result).toStrictEqual(validPermissionRequest);
+    });
+
+    it('allows missing expiry', () => {
+      const missingExpiryRequest = {
+        ...validPermissionRequest,
+        rules: [],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(missingExpiryRequest as any),
+      ).not.toThrow();
+    });
+
+    it('should throw for invalid permission type', () => {
+      const invalidTypeRequest = {
+        ...validPermissionRequest,
+        permission: {
+          ...validPermissionRequest.permission,
+          type: 'invalid-type',
+        },
+      };
+
+      expect(() =>
+        parseAndValidatePermission(invalidTypeRequest as any),
+      ).toThrow(
+        'Failed type validation: type: Invalid literal value, expected "native-token-swap"',
+      );
+    });
+
+    it('should reject zero maxNativeSwapAmount', () => {
+      const zeroAmount = {
+        ...validPermissionRequest,
+        permission: {
+          ...validPermissionRequest.permission,
+          data: {
+            ...validPermissionRequest.permission.data,
+            maxNativeSwapAmount: '0x0',
+          },
+        },
+      };
+
+      expect(() => parseAndValidatePermission(zeroAmount as any)).toThrow(
+        'Invalid maxNativeSwapAmount: must be greater than 0',
+      );
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenSwap/validation.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from '@jest/globals';
 import { bigIntToHex } from '@metamask/utils';
 
+import { getTokenSwapSupportedChainIds } from '../../../src/core/chainMetadata';
 import type { NativeTokenSwapPermissionRequest } from '../../../src/permissions/nativeTokenSwap/types';
-import { parseAndValidatePermission } from '../../../src/permissions/nativeTokenSwap/validation';
+import {
+  getSupportedChains,
+  parseAndValidatePermission,
+} from '../../../src/permissions/nativeTokenSwap/validation';
 import { parseUnits } from '../../../src/utils/value';
 
 const validPermissionRequest: NativeTokenSwapPermissionRequest = {
@@ -30,6 +34,14 @@ const validPermissionRequest: NativeTokenSwapPermissionRequest = {
 };
 
 describe('nativeTokenSwap:validation', () => {
+  describe('getSupportedChains()', () => {
+    it('returns sorted chain IDs with a deployed swap adapter', () => {
+      expect(getSupportedChains()).toStrictEqual(
+        getTokenSwapSupportedChainIds(),
+      );
+    });
+  });
+
   describe('parseAndValidatePermission()', () => {
     it('should validate a valid permission request', () => {
       expect(() =>

--- a/packages/gator-permissions-snap/test/permissions/permissionDefinitionsRegistry.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/permissionDefinitionsRegistry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from '@jest/globals';
+import { InvalidInputError } from '@metamask/snaps-sdk';
+
+import {
+  getPermissionDefinition,
+  PERMISSION_DEFINITIONS_BY_TYPE,
+} from '../../src/permissions/permissionDefinitionsRegistry';
+
+describe('permissionDefinitionsRegistry', () => {
+  it('getPermissionDefinition returns a definition for each registered type', () => {
+    for (const type of Object.keys(
+      PERMISSION_DEFINITIONS_BY_TYPE,
+    ) as (keyof typeof PERMISSION_DEFINITIONS_BY_TYPE)[]) {
+      const def = getPermissionDefinition(type);
+      expect(def.getSupportedChains).toBeInstanceOf(Function);
+    }
+  });
+
+  it('getPermissionDefinition throws for unknown type', () => {
+    expect(() => getPermissionDefinition('unknown-type')).toThrow(
+      InvalidInputError,
+    );
+  });
+});

--- a/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
+++ b/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
@@ -924,9 +924,10 @@ describe('RpcHandler', () => {
     it('should return all supported permission types with chainIds and ruleTypes', async () => {
       const result = await handler.getSupportedPermissions();
 
-      // Should return an object with all 5 permission types
+      // Should return an object with all supported permission types
       expect(result).toHaveProperty('native-token-stream');
       expect(result).toHaveProperty('native-token-periodic');
+      expect(result).toHaveProperty('native-token-swap');
       expect(result).toHaveProperty('erc20-token-stream');
       expect(result).toHaveProperty('erc20-token-periodic');
       expect(result).toHaveProperty('erc20-token-revocation');
@@ -961,6 +962,7 @@ describe('RpcHandler', () => {
       expect(typedResult['erc20-token-revocation']?.ruleTypes).toContain(
         'expiry',
       );
+      expect(typedResult['native-token-swap']?.ruleTypes).toContain('expiry');
     });
 
     it('should return the same chainIds for all permission types', async () => {
@@ -979,6 +981,9 @@ describe('RpcHandler', () => {
         nativeStreamChainIds,
       );
       expect(result['erc20-token-revocation']?.chainIds).toStrictEqual(
+        nativeStreamChainIds,
+      );
+      expect(result['native-token-swap']?.chainIds).toStrictEqual(
         nativeStreamChainIds,
       );
     });

--- a/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
+++ b/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
@@ -578,6 +578,10 @@ describe('RpcHandler', () => {
           type: 'native-token-periodic',
         },
         {
+          proposedName: 'Native Token Swap',
+          type: 'native-token-swap',
+        },
+        {
           proposedName: 'ERC20 Token Stream',
           type: 'erc20-token-stream',
         },
@@ -965,7 +969,7 @@ describe('RpcHandler', () => {
       expect(typedResult['native-token-swap']?.ruleTypes).toContain('expiry');
     });
 
-    it('should return the same chainIds for all permission types', async () => {
+    it('should return the same chainIds for non-swap permission types and a subset for native-token-swap', async () => {
       const result = (await handler.getSupportedPermissions()) as {
         [key: string]: { chainIds: string[]; ruleTypes: string[] };
       };
@@ -983,9 +987,14 @@ describe('RpcHandler', () => {
       expect(result['erc20-token-revocation']?.chainIds).toStrictEqual(
         nativeStreamChainIds,
       );
-      expect(result['native-token-swap']?.chainIds).toStrictEqual(
-        nativeStreamChainIds,
+
+      const swapChainIds = result['native-token-swap']?.chainIds;
+      expect(swapChainIds?.length).toBeLessThan(
+        nativeStreamChainIds?.length ?? 0,
       );
+      for (const id of swapChainIds ?? []) {
+        expect(nativeStreamChainIds).toContain(id);
+      }
     });
   });
 

--- a/packages/shared/src/types/7715-permissions-supported.ts
+++ b/packages/shared/src/types/7715-permissions-supported.ts
@@ -9,6 +9,7 @@ import { zHexStr } from './common';
 export const SUPPORTED_RULE_TYPES = {
   'native-token-stream': ['expiry'],
   'native-token-periodic': ['expiry'],
+  'native-token-swap': ['expiry'],
   'erc20-token-stream': ['expiry'],
   'erc20-token-periodic': ['expiry'],
   'erc20-token-revocation': ['expiry'],

--- a/packages/site/src/components/permissions/NativeTokenSwapForm.tsx
+++ b/packages/site/src/components/permissions/NativeTokenSwapForm.tsx
@@ -1,0 +1,147 @@
+import { bigIntToHex } from '@metamask/utils';
+import { useCallback, useEffect, useState } from 'react';
+import { parseUnits } from 'viem';
+
+import type { NativeTokenSwapPermissionRequest } from './types';
+
+type NativeTokenSwapFormProps = {
+  onChange: (request: NativeTokenSwapPermissionRequest) => void;
+};
+
+/**
+ * Demo form for requesting a native-token-swap permission (test site).
+ */
+export const NativeTokenSwapForm = ({
+  onChange,
+}: NativeTokenSwapFormProps) => {
+  const [maxNativeSwapAmount, setMaxNativeSwapAmount] = useState(
+    BigInt(bigIntToHex(parseUnits('0.1', 18))),
+  );
+  const [whitelistedTokensOnly, setWhitelistedTokensOnly] = useState(true);
+  const [expiry, setExpiry] = useState<number | null>(
+    Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30,
+  );
+  const [justification, setJustification] = useState(
+    'This site needs a capped native token swap allowance for testing.',
+  );
+  const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
+
+  const handleMaxNativeSwapAmountChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setMaxNativeSwapAmount(BigInt(inputValue));
+    },
+    [],
+  );
+
+  const handleWhitelistedOnlyChange = useCallback(
+    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+      setWhitelistedTokensOnly(checked);
+    },
+    [],
+  );
+
+  const handleJustificationChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setJustification(inputValue);
+    },
+    [],
+  );
+
+  const handleExpiryChange = useCallback(
+    ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+      if (value.trim() === '') {
+        setExpiry(null);
+      } else {
+        setExpiry(Number(value));
+      }
+    },
+    [],
+  );
+
+  const handleIsAdjustmentAllowedChange = useCallback(
+    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+      setIsAdjustmentAllowed(checked);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    onChange({
+      type: 'native-token-swap',
+      maxNativeSwapAmount: bigIntToHex(maxNativeSwapAmount),
+      whitelistedTokensOnly,
+      expiry,
+      justification,
+      isAdjustmentAllowed,
+      startTime: null,
+    });
+  }, [
+    onChange,
+    maxNativeSwapAmount,
+    whitelistedTokensOnly,
+    expiry,
+    justification,
+    isAdjustmentAllowed,
+  ]);
+
+  return (
+    <>
+      <div>
+        <label htmlFor="maxNativeSwapAmount">Max allowance:</label>
+        <input
+          type="text"
+          id="maxNativeSwapAmount"
+          name="maxNativeSwapAmount"
+          value={maxNativeSwapAmount.toString()}
+          onChange={handleMaxNativeSwapAmountChange}
+        />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <label htmlFor="whitelistedTokensOnly">Whitelisted tokens only:</label>
+        <input
+          type="checkbox"
+          id="whitelistedTokensOnly"
+          name="whitelistedTokensOnly"
+          checked={whitelistedTokensOnly}
+          onChange={handleWhitelistedOnlyChange}
+          style={{ width: 'auto', marginLeft: '1rem' }}
+        />
+      </div>
+      <div>
+        <label htmlFor="justification">Justification:</label>
+        <textarea
+          id="justification"
+          name="justification"
+          rows={3}
+          value={justification}
+          onChange={handleJustificationChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="expiry">Expiry:</label>
+        <input
+          type="number"
+          id="expiry"
+          name="expiry"
+          value={expiry ?? ''}
+          onChange={handleExpiryChange}
+        />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <label htmlFor="isAdjustmentAllowed">Allow adjustments:</label>
+        <input
+          type="checkbox"
+          id="isAdjustmentAllowed"
+          name="isAdjustmentAllowed"
+          checked={isAdjustmentAllowed}
+          onChange={handleIsAdjustmentAllowedChange}
+          style={{ width: 'auto', marginLeft: '1rem' }}
+        />
+      </div>
+    </>
+  );
+};

--- a/packages/site/src/components/permissions/NativeTokenSwapForm.tsx
+++ b/packages/site/src/components/permissions/NativeTokenSwapForm.tsx
@@ -15,7 +15,7 @@ type NativeTokenSwapFormProps = {
  * @returns A React component that renders the native-token-swap form.
  */
 export const NativeTokenSwapForm = ({ onChange }: NativeTokenSwapFormProps) => {
-  const [maxNativeSwapAmount, setMaxNativeSwapAmount] = useState(
+  const [allowance, setAllowance] = useState(
     BigInt(bigIntToHex(parseUnits('0.1', 18))),
   );
   const [whitelistedTokensOnly, setWhitelistedTokensOnly] = useState(true);
@@ -27,11 +27,11 @@ export const NativeTokenSwapForm = ({ onChange }: NativeTokenSwapFormProps) => {
   );
   const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
 
-  const handleMaxNativeSwapAmountChange = useCallback(
+  const handleAllowanceChange = useCallback(
     ({
       target: { value: inputValue },
     }: React.ChangeEvent<HTMLInputElement>) => {
-      setMaxNativeSwapAmount(BigInt(inputValue));
+      setAllowance(BigInt(inputValue));
     },
     [],
   );
@@ -73,7 +73,7 @@ export const NativeTokenSwapForm = ({ onChange }: NativeTokenSwapFormProps) => {
   useEffect(() => {
     onChange({
       type: 'native-token-swap',
-      maxNativeSwapAmount: bigIntToHex(maxNativeSwapAmount),
+      allowance: bigIntToHex(allowance),
       whitelistedTokensOnly,
       expiry,
       justification,
@@ -82,7 +82,7 @@ export const NativeTokenSwapForm = ({ onChange }: NativeTokenSwapFormProps) => {
     });
   }, [
     onChange,
-    maxNativeSwapAmount,
+    allowance,
     whitelistedTokensOnly,
     expiry,
     justification,
@@ -92,13 +92,13 @@ export const NativeTokenSwapForm = ({ onChange }: NativeTokenSwapFormProps) => {
   return (
     <>
       <div>
-        <label htmlFor="maxNativeSwapAmount">Max allowance:</label>
+        <label htmlFor="allowance">Allowance:</label>
         <input
           type="text"
-          id="maxNativeSwapAmount"
-          name="maxNativeSwapAmount"
-          value={maxNativeSwapAmount.toString()}
-          onChange={handleMaxNativeSwapAmountChange}
+          id="allowance"
+          name="allowance"
+          value={allowance.toString()}
+          onChange={handleAllowanceChange}
         />
       </div>
       <div style={{ display: 'flex', alignItems: 'center' }}>

--- a/packages/site/src/components/permissions/NativeTokenSwapForm.tsx
+++ b/packages/site/src/components/permissions/NativeTokenSwapForm.tsx
@@ -10,10 +10,11 @@ type NativeTokenSwapFormProps = {
 
 /**
  * Demo form for requesting a native-token-swap permission (test site).
+ * @param options0 - Form props.
+ * @param options0.onChange - Callback to invoke when form values change.
+ * @returns A React component that renders the native-token-swap form.
  */
-export const NativeTokenSwapForm = ({
-  onChange,
-}: NativeTokenSwapFormProps) => {
+export const NativeTokenSwapForm = ({ onChange }: NativeTokenSwapFormProps) => {
   const [maxNativeSwapAmount, setMaxNativeSwapAmount] = useState(
     BigInt(bigIntToHex(parseUnits('0.1', 18))),
   );

--- a/packages/site/src/components/permissions/index.ts
+++ b/packages/site/src/components/permissions/index.ts
@@ -3,3 +3,4 @@ export { ERC20TokenStreamForm } from './ERC20TokenStreamForm';
 export { NativeTokenPeriodicForm } from './NativeTokenPeriodicForm';
 export { ERC20TokenPeriodicForm } from './ERC20TokenPeriodicForm';
 export { ERC20TokenRevocationForm } from './ERC20TokenRevocationForm';
+export { NativeTokenSwapForm } from './NativeTokenSwapForm';

--- a/packages/site/src/components/permissions/types.ts
+++ b/packages/site/src/components/permissions/types.ts
@@ -39,9 +39,16 @@ export type ERC20TokenRevocationPermissionRequest = BasePermissionRequest & {
   type: 'erc20-token-revocation';
 };
 
+export type NativeTokenSwapPermissionRequest = BasePermissionRequest & {
+  type: 'native-token-swap';
+  maxNativeSwapAmount: Hex;
+  whitelistedTokensOnly: boolean;
+};
+
 export type PermissionRequest =
   | NativeTokenStreamPermissionRequest
   | NativeTokenPeriodicPermissionRequest
   | ERC20TokenPeriodicPermissionRequest
   | ERC20TokenRevocationPermissionRequest
-  | ERC20TokenStreamPermissionRequest;
+  | ERC20TokenStreamPermissionRequest
+  | NativeTokenSwapPermissionRequest;

--- a/packages/site/src/components/permissions/types.ts
+++ b/packages/site/src/components/permissions/types.ts
@@ -41,7 +41,7 @@ export type ERC20TokenRevocationPermissionRequest = BasePermissionRequest & {
 
 export type NativeTokenSwapPermissionRequest = BasePermissionRequest & {
   type: 'native-token-swap';
-  maxNativeSwapAmount: Hex;
+  allowance: Hex;
   whitelistedTokensOnly: boolean;
 };
 

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -25,6 +25,7 @@ import {
   NativeTokenPeriodicForm,
   ERC20TokenPeriodicForm,
   ERC20TokenRevocationForm,
+  NativeTokenSwapForm,
 } from '../components/permissions';
 import type {
   PermissionRequest,
@@ -33,6 +34,7 @@ import type {
   NativeTokenPeriodicPermissionRequest,
   ERC20TokenPeriodicPermissionRequest,
   ERC20TokenRevocationPermissionRequest,
+  NativeTokenSwapPermissionRequest,
 } from '../components/permissions/types';
 import { kernelSnapOrigin, gatorSnapOrigin } from '../config';
 import {
@@ -248,9 +250,9 @@ const Index = () => {
         chainId,
         to: delegateAccount.address,
         expiry,
-        isAdjustmentAllowed,
         permission: {
           type,
+          isAdjustmentAllowed,
           // permission types that are _not_ native token stream are using Hex for token amount types
           data: permissionData as any,
         },
@@ -353,7 +355,8 @@ const Index = () => {
         | ERC20TokenStreamPermissionRequest
         | NativeTokenPeriodicPermissionRequest
         | NativeTokenStreamPermissionRequest
-        | ERC20TokenRevocationPermissionRequest,
+        | ERC20TokenRevocationPermissionRequest
+        | NativeTokenSwapPermissionRequest,
     ) => {
       setPermissionRequest(request);
     },
@@ -503,6 +506,7 @@ const Index = () => {
                   <option value="erc20-token-revocation">
                     ERC20 Token Revocation
                   </option>
+                  <option value="native-token-swap">Native Token Swap</option>
                 </select>
               </div>
 
@@ -524,6 +528,10 @@ const Index = () => {
 
               {permissionType === 'erc20-token-revocation' && (
                 <ERC20TokenRevocationForm onChange={onFormChange} />
+              )}
+
+              {permissionType === 'native-token-swap' && (
+                <NativeTokenSwapForm onChange={onFormChange} />
               )}
             </StyledForm>
             <CustomMessageButton

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,7 +2967,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-core@npm:0.3.0, @metamask/delegation-core@npm:^0.3.0":
+"@metamask/delegation-core@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/delegation-core@npm:1.0.0"
+  dependencies:
+    "@metamask/abi-utils": "npm:^3.0.0"
+    "@metamask/utils": "npm:^11.4.0"
+    "@noble/hashes": "npm:^1.8.0"
+  checksum: 10/715c818eaf11f0c8ef0bd15dd46ed95ec6f27069df6d315c577a9379ce02ee5510871865ce44ec98bbe84daa8409e24314d2b23644ae5434364c33c68e26d4e6
+  languageName: node
+  linkType: hard
+
+"@metamask/delegation-core@npm:^0.3.0":
   version: 0.3.0
   resolution: "@metamask/delegation-core@npm:0.3.0"
   dependencies:
@@ -3078,7 +3089,7 @@ __metadata:
     "@metamask/7715-permissions-shared": "workspace:*"
     "@metamask/abi-utils": "npm:3.0.0"
     "@metamask/auto-changelog": "npm:5.0.2"
-    "@metamask/delegation-core": "npm:0.3.0"
+    "@metamask/delegation-core": "npm:1.0.0"
     "@metamask/eslint-config": "npm:15.0.0"
     "@metamask/eslint-config-jest": "npm:15.0.0"
     "@metamask/eslint-config-nodejs": "npm:15.0.0"


### PR DESCRIPTION
## **Description**

This PR adds a new `native-token-swap` permission type, that defines an allowance of native token that the recipient may swap for other tokens.

The permission context received must be redelegated to the DelegationMetaSwapAdapter contract, and passed as an argument to `swapByDelegation()`.

## **Future changes**

- It might be possible to redelegate this authority to the recipient so that they may simply call `swapByDelegation` with appropriately encoded data - this will likely still be a sub-optimal developer experience, as they will need to encode the internal delegation.
- Information about which tokens are whitelisted should be presented to the user.

**Note:** Still needs validation that the granted permission is able to be used to swap as expected.

## **Screenshots/Recordings**

Only chains with the swap adapter deployed are supported:
<img width="668" height="125" alt="image" src="https://github.com/user-attachments/assets/2213151c-74ad-444e-bcc6-a468f9220834" />

Introduction page explaining the permission:
<img width="491" height="520" alt="image" src="https://github.com/user-attachments/assets/ed4fb590-08ae-4a62-8a63-fa60e4042881" />

Permission confirmation:
<img width="475" height="856" alt="image" src="https://github.com/user-attachments/assets/0e505cb1-e435-4f13-84a3-6a1fce7e0692" />

`IsAdjustmentAllowed: false`:

<img width="475" height="856" alt="image" src="https://github.com/user-attachments/assets/9f5b6233-9ecb-4f62-bedf-1dbb5beb2ca0" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new on-chain permission type that creates delegation caveats and restricts redemption via a swap adapter, plus upgrades `@metamask/delegation-core` to `1.0.0`; mistakes here could grant broader spend/swap authority than intended or break supported-chain enforcement.
> 
> **Overview**
> Implements a new `native-token-swap` permission end-to-end: validation, context/metadata derivation, confirmation UI (allowance + token-policy + optional expiry), and delegation caveat construction that enforces an allowance, token-policy argument, and *redeemer-only* execution via a per-chain swap adapter.
> 
> Refactors permission plumbing to be registry-driven (`permissionDefinitionsRegistry`) and adds per-permission `getSupportedChains()` gating; `getSupportedPermissions` now returns chain IDs per permission (swap is a subset), and the factory rejects unsupported chain/type combinations.
> 
> Extends chain metadata with a typed `GatorChainId` enum, new enforcer contract addresses, optional `tokenSwapAdapter` addresses per chain, and helper APIs for configured vs swap-supported chain sets; updates i18n strings, permission offers, and the demo site to request `native-token-swap`, with new/updated tests throughout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8931116021c479e04f75bdd0cdc476f73b9144bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->