### PR TITLE
fix: change potentially malicious warning color from red to orange

### DIFF
--- a/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerContent.tsx
@@ -162,6 +162,9 @@ export const PermissionHandlerContent = ({
       value={origin}
       tooltip={t('requestFromTooltip')}
       warningLabel={dappUrlWarningLabel}
+      warningSeverity={
+        recommendedAction === RecommendedAction.WARN ? 'warning' : 'error'
+      }
     />
   );
 
@@ -186,6 +189,9 @@ export const PermissionHandlerContent = ({
       address={delegateAddress}
       tooltip={t('recipientTooltip')}
       warningLabel={addressWarningLabel}
+      warningSeverity={
+        resultType === AddressScanResultType.Warning ? 'warning' : 'error'
+      }
     />
   );
 

--- a/packages/gator-permissions-snap/src/ui/components/AddressField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/AddressField.tsx
@@ -11,6 +11,8 @@ export type AddressFieldParams = Pick<
   address: string;
   /** When set, shows a danger icon and this label below the address. */
   warningLabel?: string | undefined;
+  /** Severity level for the warning: 'warning' (orange) for potential issues, 'error' (red) for definite issues. Defaults to 'error'. */
+  warningSeverity?: 'warning' | 'error';
 };
 
 /**
@@ -24,6 +26,7 @@ export type AddressFieldParams = Pick<
  * @param props.tooltip - The tooltip text for the field label.
  * @param props.iconData - Optional icon data.
  * @param props.warningLabel - When set, shows a danger icon and this label below the address.
+ * @param props.warningSeverity - Severity level: 'warning' (orange) or 'error' (red). Defaults to 'error'.
  * @returns A JSX element containing an address field with optional warning.
  */
 export const AddressField = ({
@@ -32,6 +35,7 @@ export const AddressField = ({
   tooltip,
   iconData,
   warningLabel,
+  warningSeverity = 'error',
 }: AddressFieldParams): JSX.Element => {
   const addressContent = (
     <Tooltip content={address}>
@@ -52,8 +56,8 @@ export const AddressField = ({
             {addressContent}
           </Box>
           <Box direction="horizontal" alignment="end">
-            <Icon name="danger" size="md" color="error" />
-            <Text alignment="end" color="error">
+            <Icon name="danger" size="md" color={warningSeverity} />
+            <Text alignment="end" color={warningSeverity}>
               {warningLabel}
             </Text>
           </Box>

--- a/packages/gator-permissions-snap/src/ui/components/TextField.tsx
+++ b/packages/gator-permissions-snap/src/ui/components/TextField.tsx
@@ -14,6 +14,8 @@ export type TextFieldParams = Pick<
   value: string;
   /** When set, shows a danger icon and this label below the value. */
   warningLabel?: string | undefined;
+  /** Severity level for the warning: 'warning' (orange) for potential issues, 'error' (red) for definite issues. Defaults to 'error'. */
+  warningSeverity?: 'warning' | 'error';
 };
 
 /**
@@ -26,6 +28,7 @@ export type TextFieldParams = Pick<
  * @param props.tooltip - The tooltip text for the field label.
  * @param props.iconData - Optional icon data.
  * @param props.warningLabel - When set, shows a danger icon and this label below the value.
+ * @param props.warningSeverity - Severity level: 'warning' (orange) or 'error' (red). Defaults to 'error'.
  * @param props.direction - The direction to stack the label and value elements. Default is 'horizontal'.
  * @returns A JSX element containing a text field with optional warning.
  */
@@ -35,14 +38,15 @@ export const TextField = ({
   tooltip,
   iconData,
   warningLabel,
+  warningSeverity = 'error',
   direction = 'horizontal',
 }: TextFieldParams): JSX.Element => {
   const content = warningLabel ? (
     <Box direction="vertical">
       <Text alignment="end">{value}</Text>
       <Box direction="horizontal" alignment="end">
-        <Icon name="danger" size="md" color="error" />
-        <Text color="error">{warningLabel}</Text>
+        <Icon name="danger" size="md" color={warningSeverity} />
+        <Text color={warningSeverity}>{warningLabel}</Text>
       </Box>
     </Box>
   ) : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR changes the color of "potentially malicious" warnings from red to orange (warning level) to help users distinguish between different alert severity levels.

## Problem

Currently, both "potentially malicious" (WARN level) and "definitely malicious" (BLOCK/Malicious level) warnings are displayed in red. This makes it difficult for users to differentiate between the two severity levels and can lead to confusion about the actual risk level.

## Solution

- Added a `warningSeverity` prop to `TextField` and `AddressField` components that accepts either `'warning'` (orange) or `'error'` (red)
- Updated `permissionHandlerContent.tsx` to pass the appropriate severity level based on scan results:
  - `RecommendedAction.WARN` → `'warning'` (orange) for potentially malicious websites
  - `RecommendedAction.BLOCK` → `'error'` (red) for definitely malicious websites
  - `AddressScanResultType.Warning` → `'warning'` (orange) for potentially malicious addresses
  - `AddressScanResultType.Malicious` → `'error'` (red) for definitely malicious addresses

## Testing

- ✅ All existing tests pass
- ✅ Build succeeds without errors
- ✅ ESLint passes with no issues
- The changes are backward compatible - all warnings default to `'error'` (red) if no severity is specified

## Screenshots

These were produced with hardcoded scanning results:

### Malicious
<img width="458" height="521" alt="image" src="https://github.com/user-attachments/assets/a10f7adb-d89d-4a07-8dd1-c2c4e7770464" />

### Potentially Malicious
<img width="462" height="521" alt="image" src="https://github.com/user-attachments/assets/d7b38a49-4e71-4221-989f-12c4523d2651" />


## Impact

This change improves the user experience by helping users better understand the severity of security warnings and make more informed decisions about granting permissions.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C089Z7KQPS9/p1775680515239299?thread_ts=1775680515.239299&cid=C089Z7KQPS9)

<div><a href="https://cursor.com/agents/bc-e1a0a9e6-fd65-57b2-bf4c-3c25f967afbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1a0a9e6-fd65-57b2-bf4c-3c25f967afbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

