### PR TITLE
`permissionsProvider_getSupportedPermissions` no longer includes chainIds

### DIFF
--- a/packages/gator-permissions-snap/src/rpc/rpcHandler.ts
+++ b/packages/gator-permissions-snap/src/rpc/rpcHandler.ts
@@ -10,10 +10,8 @@ import {
   UserRejectedRequestError,
 } from '@metamask/snaps-sdk';
 import type { Json } from '@metamask/snaps-sdk';
-import { numberToHex } from '@metamask/utils';
 
 import type { BlockchainClient } from '../clients/blockchainClient';
-import { nameAndExplorerUrlByChainId } from '../core/chainMetadata';
 import type { PermissionHandlerFactory } from '../core/permissionHandlerFactory';
 import { DEFAULT_GATOR_PERMISSION_TO_OFFER } from '../permissions/permissionOffers';
 import type {
@@ -306,10 +304,6 @@ export function createRpcHandler({
   const getSupportedPermissions = async (): Promise<Json> => {
     logger.debug('getSupportedPermissions()');
 
-    const chainIds = Object.keys(nameAndExplorerUrlByChainId).map((id) =>
-      numberToHex(Number(id)),
-    );
-
     const supportedPermissions: GetSupportedPermissionsResult = {};
 
     for (const offer of DEFAULT_GATOR_PERMISSION_TO_OFFER) {
@@ -320,7 +314,9 @@ export function createRpcHandler({
         ];
 
       supportedPermissions[permissionType] = {
-        chainIds,
+        // chainIds is not specified here, as all chains are supported.
+        // if a permission type is added that is supported on a subset of chains,
+        // the chainIds should be specified here.
         ruleTypes: ruleTypes ? [...ruleTypes] : [],
       };
     }

--- a/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
+++ b/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
@@ -940,14 +940,10 @@ describe('RpcHandler', () => {
       const nativeTokenStream = typedResult['native-token-stream']!;
 
       // Verify structure for one permission type
-      expect(nativeTokenStream).toHaveProperty('chainIds');
+      // chainIds is excluded - indicating all chains are supported
+      expect(nativeTokenStream).not.toHaveProperty('chainIds');
       expect(nativeTokenStream).toHaveProperty('ruleTypes');
-      expect(Array.isArray(nativeTokenStream.chainIds)).toBe(true);
       expect(Array.isArray(nativeTokenStream.ruleTypes)).toBe(true);
-
-      // Chain IDs should be hex strings
-      expect(nativeTokenStream.chainIds.length).toBeGreaterThan(0);
-      expect(nativeTokenStream.chainIds[0]).toMatch(/^0x/u);
 
       // All permission types should support 'expiry' rule
       expect(nativeTokenStream.ruleTypes).toContain('expiry');

--- a/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
+++ b/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
@@ -921,7 +921,7 @@ describe('RpcHandler', () => {
   });
 
   describe('getSupportedPermissions', () => {
-    it('should return all supported permission types with chainIds and ruleTypes', async () => {
+    it('should return all supported permission types with ruleTypes', async () => {
       const result = await handler.getSupportedPermissions();
 
       // Should return an object with all 5 permission types
@@ -931,9 +931,9 @@ describe('RpcHandler', () => {
       expect(result).toHaveProperty('erc20-token-periodic');
       expect(result).toHaveProperty('erc20-token-revocation');
 
-      // Each permission type should have chainIds and ruleTypes
+      // Each permission type should expose ruleTypes.
       const typedResult = result as {
-        [key: string]: { chainIds: string[]; ruleTypes: string[] };
+        [key: string]: { ruleTypes: string[] };
       };
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -959,24 +959,14 @@ describe('RpcHandler', () => {
       );
     });
 
-    it('should return the same chainIds for all permission types', async () => {
+    it('should omit chainIds for all permission types', async () => {
       const result = (await handler.getSupportedPermissions()) as {
-        [key: string]: { chainIds: string[]; ruleTypes: string[] };
+        [key: string]: { ruleTypes: string[] };
       };
 
-      const nativeStreamChainIds = result['native-token-stream']?.chainIds;
-      expect(result['native-token-periodic']?.chainIds).toStrictEqual(
-        nativeStreamChainIds,
-      );
-      expect(result['erc20-token-stream']?.chainIds).toStrictEqual(
-        nativeStreamChainIds,
-      );
-      expect(result['erc20-token-periodic']?.chainIds).toStrictEqual(
-        nativeStreamChainIds,
-      );
-      expect(result['erc20-token-revocation']?.chainIds).toStrictEqual(
-        nativeStreamChainIds,
-      );
+      for (const permissionType of Object.keys(result)) {
+        expect(result[permissionType]).not.toHaveProperty('chainIds');
+      }
     });
   });
 

--- a/packages/shared/src/types/7715-permissions-supported.ts
+++ b/packages/shared/src/types/7715-permissions-supported.ts
@@ -19,9 +19,9 @@ export const SUPPORTED_RULE_TYPES = {
  */
 export const zSupportedPermissionInfo = z.object({
   /**
-   * The chain IDs where this permission type is supported.
+   * The chain IDs where this permission type is supported. If not specified, all chains are supported.
    */
-  chainIds: z.array(zHexStr),
+  chainIds: z.array(zHexStr).optional(),
 
   /**
    * The rule types that can be applied to this permission.


### PR DESCRIPTION
## **Description**

The client is now responsible for resolving the supported chains. If `permissionsProvider_getSupportedPermissions` returns `chainIds`, it should be considered a filter to be applied to the chains supported by the client.

- `SupportedPermissionInfo.chainIds` is now optional
- `getSupportedPermissions` now excludes `chainIds`, indicating that all `chainIds` are supported


## **Manual testing steps**

Test in conjunction with https://github.com/MetaMask/metamask-extension/pull/41643

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `permissionsProvider_getSupportedPermissions` response shape by omitting `chainIds`, which can break or alter behavior in clients that previously relied on this field for chain filtering.
> 
> **Overview**
> Updates `permissionsProvider_getSupportedPermissions` to **stop returning `chainIds`** and instead imply *all chains are supported*, leaving chain resolution/filtering to the client.
> 
> Makes `SupportedPermissionInfo.chainIds` optional in the shared Zod schema and updates unit tests to assert `chainIds` is absent while preserving `ruleTypes` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffdcde817a034c9054ae0558a3a3a1674cfd66a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->