### PR TITLE
Add new simple allowance permission types

### DIFF
--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -55,6 +55,9 @@
     "startTimeTooltip": {
       "message": "The time at which the first period begins"
     },
+    "allowanceStartTimeTooltip": {
+      "message": "The earliest time at which the allowance can be used (UTC)"
+    },
     "streamStartTimeTooltip": {
       "message": "The start time of the stream"
     },
@@ -105,6 +108,9 @@
     },
     "amountTooltip": {
       "message": "The amount of tokens granted during each period"
+    },
+    "allowanceAmountTooltip": {
+      "message": "The amount of tokens granted with this permission"
     },
     "periodDurationLabel": {
       "message": "Frequency"
@@ -246,6 +252,12 @@
     },
     "introManageTokenApprovalsDescription": {
       "message": "Token revocation allows sites to revoke token approvals on your behalf."
+    },
+    "introAllowanceTitle": {
+      "message": "Token allowance request"
+    },
+    "introTokenAllowanceDescription": {
+      "message": "Token allowances let a site spend from your wallet up to a single total you set, rather than a recurring schedule like a subscription."
     },
     "introPermissionInControlDescription": {
       "message": "You can revoke this permission at any time in advanced permissions."

--- a/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/existingPermissionsService.ts
@@ -30,12 +30,15 @@ export { ExistingPermissionsState } from './existingPermissionsState';
  */
 function extractPermissionCategory(
   permissionTypeName: string,
-): 'stream' | 'periodic' | null {
+): 'stream' | 'periodic' | 'allowance' | null {
   if (permissionTypeName.endsWith('-periodic')) {
     return 'periodic';
   }
   if (permissionTypeName.endsWith('-stream')) {
     return 'stream';
+  }
+  if (permissionTypeName.endsWith('-allowance')) {
+    return 'allowance';
   }
   return null;
 }

--- a/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
@@ -139,6 +139,39 @@ function extractPermissionDetails(
           value: String(justification),
         };
       }
+    } else if (
+      permissionType === 'erc20-token-allowance' ||
+      permissionType === 'native-token-allowance'
+    ) {
+      const { allowanceAmount, startTime, justification } = permissionData;
+
+      if (allowanceAmount !== undefined && allowanceAmount !== null) {
+        const amountLabel = t('amountLabel');
+        details.allowanceAmount = {
+          label: amountLabel,
+          value: String(allowanceAmount),
+        };
+      }
+
+      if (startTime !== undefined && startTime !== null) {
+        const startTimeLabel = t('startTimeLabel');
+        const date = new Date(Number(startTime) * 1000);
+        const startTimeValue = date.toLocaleString(undefined, {
+          timeZone: 'UTC',
+        });
+        details.startTime = {
+          label: startTimeLabel,
+          value: startTimeValue,
+        };
+      }
+
+      if (justification !== undefined && justification !== null) {
+        const justificationLabel = t('justificationLabel');
+        details.justification = {
+          label: justificationLabel,
+          value: String(justification),
+        };
+      }
     }
     // For stream-type permissions
     else if (
@@ -235,7 +268,9 @@ export async function formatPermissionWithTokenMetadata(
 
   // Check if this permission has token amount fields that need formatting
   const hasTokenAmountFields =
-    'maxAmount' in permissionData || 'periodAmount' in permissionData;
+    'maxAmount' in permissionData ||
+    'periodAmount' in permissionData ||
+    'allowanceAmount' in permissionData;
 
   if (!hasTokenAmountFields) {
     return permission;
@@ -285,6 +320,14 @@ export async function formatPermissionWithTokenMetadata(
     if ('periodAmount' in permissionData) {
       formattedData.periodAmount = formatTokenAmountWithMetadata(
         permissionData.periodAmount as Hex | null | undefined,
+        decimals,
+        symbol,
+      );
+    }
+
+    if ('allowanceAmount' in permissionData) {
+      formattedData.allowanceAmount = formatTokenAmountWithMetadata(
+        permissionData.allowanceAmount as Hex | null | undefined,
         decimals,
         symbol,
       );

--- a/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
+++ b/packages/gator-permissions-snap/src/core/existingpermissions/permissionFormatter.ts
@@ -77,6 +77,16 @@ function extractPermissionDetails(
   const permissionData = permission.permission.data;
 
   if (permissionData && typeof permissionData === 'object') {
+    if ('justification' in permissionData) {
+      const { justification } = permissionData;
+      if (typeof justification === 'string') {
+        details.justification = {
+          label: t('justificationLabel'),
+          value: justification,
+        };
+      }
+    }
+
     // For revocation-type permissions
     if (permissionType === 'erc20-token-revocation') {
       const revokeLabel = t('revokeTokenApprovalsLabel');
@@ -85,25 +95,13 @@ function extractPermissionDetails(
         label: revokeLabel,
         value: revokeValue,
       };
-
-      // Add justification if available
-      if ('justification' in permissionData) {
-        const { justification } = permissionData;
-        if (justification !== undefined && justification !== null) {
-          const justificationLabel = t('justificationLabel');
-          details.justification = {
-            label: justificationLabel,
-            value: String(justification),
-          };
-        }
-      }
     }
     // For periodic-type permissions
     else if (
       permissionType === 'erc20-token-periodic' ||
       permissionType === 'native-token-periodic'
     ) {
-      const { periodAmount, periodDuration, justification } = permissionData;
+      const { periodAmount, periodDuration } = permissionData;
 
       if (periodAmount !== undefined && periodAmount !== null) {
         const amountLabel = t('amountLabel');
@@ -131,19 +129,11 @@ function extractPermissionDetails(
           value: durationValue,
         };
       }
-
-      if (justification !== undefined && justification !== null) {
-        const justificationLabel = t('justificationLabel');
-        details.justification = {
-          label: justificationLabel,
-          value: String(justification),
-        };
-      }
     } else if (
       permissionType === 'erc20-token-allowance' ||
       permissionType === 'native-token-allowance'
     ) {
-      const { allowanceAmount, startTime, justification } = permissionData;
+      const { allowanceAmount, startTime } = permissionData;
 
       if (allowanceAmount !== undefined && allowanceAmount !== null) {
         const amountLabel = t('amountLabel');
@@ -164,21 +154,13 @@ function extractPermissionDetails(
           value: startTimeValue,
         };
       }
-
-      if (justification !== undefined && justification !== null) {
-        const justificationLabel = t('justificationLabel');
-        details.justification = {
-          label: justificationLabel,
-          value: String(justification),
-        };
-      }
     }
     // For stream-type permissions
     else if (
       permissionType === 'erc20-token-stream' ||
       permissionType === 'native-token-stream'
     ) {
-      const { maxAmount, startTime, justification } = permissionData;
+      const { maxAmount, startTime } = permissionData;
 
       if (maxAmount !== undefined && maxAmount !== null) {
         const maxAmountLabel = t('maxAmountLabel');
@@ -198,14 +180,6 @@ function extractPermissionDetails(
         details.startTime = {
           label: startTimeLabel,
           value: startTimeValue,
-        };
-      }
-
-      if (justification !== undefined && justification !== null) {
-        const justificationLabel = t('justificationLabel');
-        details.justification = {
-          label: justificationLabel,
-          value: String(justification),
         };
       }
     }

--- a/packages/gator-permissions-snap/src/core/payeeCaveat.ts
+++ b/packages/gator-permissions-snap/src/core/payeeCaveat.ts
@@ -13,11 +13,13 @@ import { MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR } from '../permissions/validati
 const ERC20_PERMISSION_TYPES = new Set([
   'erc20-token-stream',
   'erc20-token-periodic',
+  'erc20-token-allowance',
 ]);
 
 const NATIVE_PERMISSION_TYPES = new Set([
   'native-token-stream',
   'native-token-periodic',
+  'native-token-allowance',
 ]);
 
 /**

--- a/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
+++ b/packages/gator-permissions-snap/src/core/permissionHandlerFactory.ts
@@ -3,9 +3,11 @@ import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
 import type { AccountController } from './accountController';
+import { erc20TokenAllowancePermissionDefinition } from '../permissions/erc20TokenAllowance';
 import { erc20TokenPeriodicPermissionDefinition } from '../permissions/erc20TokenPeriodic';
 import { erc20TokenRevocationPermissionDefinition } from '../permissions/erc20TokenRevocation';
 import { erc20TokenStreamPermissionDefinition } from '../permissions/erc20TokenStream';
+import { nativeTokenAllowancePermissionDefinition } from '../permissions/nativeTokenAllowance';
 import { nativeTokenPeriodicPermissionDefinition } from '../permissions/nativeTokenPeriodic';
 import { nativeTokenStreamPermissionDefinition } from '../permissions/nativeTokenStream';
 import type { TokenMetadataService } from '../services/tokenMetadataService';
@@ -104,9 +106,19 @@ export class PermissionHandlerFactory {
           nativeTokenPeriodicPermissionDefinition,
         );
         break;
+      case 'native-token-allowance':
+        handler = createPermissionHandler(
+          nativeTokenAllowancePermissionDefinition,
+        );
+        break;
       case 'erc20-token-periodic':
         handler = createPermissionHandler(
           erc20TokenPeriodicPermissionDefinition,
+        );
+        break;
+      case 'erc20-token-allowance':
+        handler = createPermissionHandler(
+          erc20TokenAllowancePermissionDefinition,
         );
         break;
       case 'erc20-token-revocation':

--- a/packages/gator-permissions-snap/src/core/permissionIntroduction/permissionIntroductionContent.tsx
+++ b/packages/gator-permissions-snap/src/core/permissionIntroduction/permissionIntroductionContent.tsx
@@ -91,6 +91,19 @@ const revocationPage1Content: PermissionIntroductionPageConfig = {
   ],
 };
 
+const allowancePage1Content: PermissionIntroductionPageConfig = {
+  headerImageSvg: permissionRequestImage,
+  title: 'introAllowanceTitle',
+  bulletPoints: [
+    {
+      description: 'introTokenAllowanceDescription',
+    },
+    {
+      description: 'introPermissionInControlDescription',
+    },
+  ],
+};
+
 /**
  * Map of permission types to their introduction configurations.
  * Note: Keys must match the permission type descriptor names (kebab-case).
@@ -103,6 +116,10 @@ export const permissionIntroductionConfigs: Record<
     page1: subscriptionPage1Content,
     page2: fixedPage2Content,
   },
+  'erc20-token-allowance': {
+    page1: allowancePage1Content,
+    page2: fixedPage2Content,
+  },
   'erc20-token-revocation': {
     page1: revocationPage1Content,
     page2: fixedPage2Content,
@@ -113,6 +130,10 @@ export const permissionIntroductionConfigs: Record<
   },
   'native-token-periodic': {
     page1: subscriptionPage1Content,
+    page2: fixedPage2Content,
+  },
+  'native-token-allowance': {
+    page1: allowancePage1Content,
     page2: fixedPage2Content,
   },
   'native-token-stream': {

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/caveats.ts
@@ -1,0 +1,57 @@
+import type { Caveat } from '@metamask/delegation-core';
+import {
+  createERC20TokenPeriodTransferTerms,
+  createValueLteTerms,
+} from '@metamask/delegation-core';
+
+import type { DelegationContracts } from '../../core/chainMetadata';
+import { PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX } from '../shared';
+import type { PopulatedErc20TokenAllowancePermission } from './types';
+
+/**
+ * ERC-20 token allowance uses ERC20PeriodTransferEnforcer with max uint256 period duration
+ * (unbounded on-chain period). Optional `expiry` on the request adds a timestamp enforcer
+ * like other permissions. ValueLteEnforcer forbids native value.
+ */
+
+/**
+ * Builds delegation caveats for erc20-token-allowance.
+ * @param args - The options object containing the permission and contracts.
+ * @param args.permission - Populated permission.
+ * @param args.contracts - Chain enforcer addresses.
+ * @returns Caveats for the delegation.
+ */
+export async function createPermissionCaveats({
+  permission,
+  contracts,
+}: {
+  permission: PopulatedErc20TokenAllowancePermission;
+  contracts: DelegationContracts;
+}): Promise<Caveat[]> {
+  const { allowanceAmount, startTime, tokenAddress } = permission.data;
+
+  const erc20PeriodCaveat: Caveat = {
+    enforcer: contracts.erc20PeriodTransferEnforcer,
+    terms: createERC20TokenPeriodTransferTerms({
+      tokenAddress,
+      periodAmount: BigInt(allowanceAmount),
+      // @metamask/delegation-core uses toHexString to encode period duration, which accepts bigint. We
+      // should update delegation-core to accept bigint as well as number, but we just do a type
+      // assertion for now.
+      periodDuration:
+        PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX as unknown as number,
+      startDate: startTime,
+    }),
+    args: '0x',
+  };
+
+  const valueLteCaveat: Caveat = {
+    enforcer: contracts.valueLteEnforcer,
+    terms: createValueLteTerms({
+      maxValue: 0n,
+    }),
+    args: '0x',
+  };
+
+  return [erc20PeriodCaveat, valueLteCaveat];
+}

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/content.tsx
@@ -1,0 +1,42 @@
+import type { SnapElement } from '@metamask/snaps-sdk/jsx';
+import { Box, Divider, Section } from '@metamask/snaps-sdk/jsx';
+
+import { allowanceAmountRule, startTimeRule, expiryRule } from './rules';
+import type {
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowanceMetadata,
+} from './types';
+import { renderRules } from '../../core/rules';
+
+/**
+ * Creates UI content for an ERC-20 token allowance permission confirmation.
+ * @param args - The configuration for the confirmation content.
+ * @param args.context - Context with allowance and schedule fields.
+ * @param args.metadata - Validation state for rules.
+ * @returns Confirmation section content.
+ */
+export async function createConfirmationContent({
+  context,
+  metadata,
+}: {
+  context: Erc20TokenAllowanceContext;
+  metadata: Erc20TokenAllowanceMetadata;
+}): Promise<SnapElement> {
+  return (
+    <Box>
+      <Section>
+        {renderRules({
+          rules: [allowanceAmountRule],
+          context,
+          metadata,
+        })}
+        <Divider />
+        {renderRules({
+          rules: [startTimeRule, expiryRule],
+          context,
+          metadata,
+        })}
+      </Section>
+    </Box>
+  );
+}

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/context.ts
@@ -1,0 +1,241 @@
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
+import { InvalidInputError } from '@metamask/snaps-sdk';
+import {
+  bigIntToHex,
+  parseCaipAccountId,
+  toCaipAccountId,
+  toCaipAssetType,
+} from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
+
+import type { TokenMetadataService } from '../../services/tokenMetadataService';
+import { parseUnits, formatUnitsFromHex } from '../../utils/value';
+import {
+  validateAndParseAmount,
+  validateStartTime,
+  validateExpiry,
+  validateStartTimeVsExpiry,
+} from '../contextValidation';
+import { applyExpiryRule } from '../rules';
+import type {
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowancePermissionRequest,
+  Erc20TokenAllowanceMetadata,
+  PopulatedErc20TokenAllowancePermission,
+  Erc20TokenAllowancePermission,
+} from './types';
+
+const ASSET_NAMESPACE = 'erc20';
+const CHAIN_NAMESPACE = 'eip155';
+
+/**
+ * Construct an amended permission request from context edits.
+ * @param options - The options object containing the context and original request.
+ * @param options.context - Context with formatted allowance and times.
+ * @param options.originalRequest - Original request.
+ * @returns Request with hex allowance and merged expiry rule (optional, like other types).
+ */
+export async function applyContext({
+  context,
+  originalRequest,
+}: {
+  context: Erc20TokenAllowanceContext;
+  originalRequest: Erc20TokenAllowancePermissionRequest;
+}): Promise<Erc20TokenAllowancePermissionRequest> {
+  const {
+    permissionDetails,
+    tokenMetadata: { decimals },
+  } = context;
+
+  const { rules } = applyExpiryRule(context, originalRequest);
+
+  const permissionData = {
+    allowanceAmount: bigIntToHex(
+      parseUnits({ formatted: permissionDetails.allowanceAmount, decimals }),
+    ),
+    startTime: permissionDetails.startTime,
+    justification: originalRequest.permission.data.justification,
+    tokenAddress: originalRequest.permission.data.tokenAddress,
+  };
+
+  const { address } = parseCaipAccountId(context.accountAddressCaip10);
+
+  return {
+    ...originalRequest,
+    from: address as Hex,
+    permission: {
+      type: 'erc20-token-allowance',
+      data: permissionData,
+      isAdjustmentAllowed: originalRequest.permission.isAdjustmentAllowed,
+    },
+    rules,
+  };
+}
+
+/**
+ * Populate optional permission fields before signing.
+ * @param options - The options object containing the permission to populate.
+ * @param options.permission - Permission after applyContext.
+ * @returns Permission with defaulted start time when missing.
+ */
+export async function populatePermission({
+  permission,
+}: {
+  permission: Erc20TokenAllowancePermission;
+}): Promise<PopulatedErc20TokenAllowancePermission> {
+  return {
+    ...permission,
+    data: {
+      ...permission.data,
+      startTime: permission.data.startTime ?? Math.floor(Date.now() / 1000),
+    },
+  };
+}
+
+/**
+ * Build UI context from a validated permission request.
+ * @param args - The options object containing the request and required services.
+ * @param args.permissionRequest - Request for this permission type.
+ * @param args.tokenMetadataService - Token metadata service.
+ * @returns Context for confirmation UI and validation.
+ */
+export async function buildContext({
+  permissionRequest,
+  tokenMetadataService,
+}: {
+  permissionRequest: Erc20TokenAllowancePermissionRequest;
+  tokenMetadataService: TokenMetadataService;
+}): Promise<Erc20TokenAllowanceContext> {
+  const chainId = Number(permissionRequest.chainId);
+  const {
+    from,
+    permission: { data, isAdjustmentAllowed },
+  } = permissionRequest;
+
+  if (!from) {
+    throw new InvalidInputError(
+      'PermissionRequest.address was not found. This should be resolved within the buildContextHandler function in PermissionHandler.',
+    );
+  }
+
+  const { decimals, symbol, iconUrl } =
+    await tokenMetadataService.getTokenBalanceAndMetadata({
+      chainId,
+      account: from,
+      assetAddress: data.tokenAddress,
+    });
+
+  const iconDataResponse =
+    await tokenMetadataService.fetchIconDataAsBase64(iconUrl);
+
+  const iconDataBase64 = iconDataResponse.success
+    ? iconDataResponse.imageDataBase64
+    : null;
+
+  const expiryRule = permissionRequest.rules?.find(
+    (rule) => extractDescriptorName(rule.type) === 'expiry',
+  );
+
+  const expiry = expiryRule
+    ? {
+        timestamp: expiryRule.data.timestamp,
+      }
+    : undefined;
+
+  const allowanceAmount = formatUnitsFromHex({
+    value: data.allowanceAmount,
+    allowNull: false,
+    decimals,
+  });
+
+  const startTime = data.startTime ?? Math.floor(Date.now() / 1000);
+
+  const tokenAddressCaip19 = toCaipAssetType(
+    CHAIN_NAMESPACE,
+    chainId.toString(),
+    ASSET_NAMESPACE,
+    data.tokenAddress,
+  );
+
+  const accountAddressCaip10 = toCaipAccountId(
+    CHAIN_NAMESPACE,
+    chainId.toString(),
+    from,
+  );
+
+  return {
+    expiry,
+    justification: data.justification,
+    isAdjustmentAllowed,
+    accountAddressCaip10,
+    tokenAddressCaip19,
+    tokenMetadata: {
+      symbol,
+      decimals,
+      iconDataBase64,
+    },
+    permissionDetails: {
+      allowanceAmount,
+      startTime,
+    },
+  };
+}
+
+/**
+ * Derive validation metadata for the confirmation UI.
+ * @param options - The options object containing the context to create metadata for.
+ * @param options.context - Built context.
+ * @returns Metadata with validation errors for rules.
+ */
+export async function deriveMetadata({
+  context,
+}: {
+  context: Erc20TokenAllowanceContext;
+}): Promise<Erc20TokenAllowanceMetadata> {
+  const {
+    permissionDetails,
+    expiry,
+    tokenMetadata: { decimals },
+  } = context;
+
+  const validationErrors: Erc20TokenAllowanceMetadata['validationErrors'] = {};
+
+  const allowanceAmountResult = validateAndParseAmount(
+    permissionDetails.allowanceAmount,
+    decimals,
+    'allowance amount',
+  );
+  if (allowanceAmountResult.error) {
+    validationErrors.allowanceAmountError = allowanceAmountResult.error;
+  }
+
+  const startTimeError = validateStartTime(permissionDetails.startTime);
+  if (startTimeError) {
+    validationErrors.startTimeError = startTimeError;
+  }
+
+  if (expiry) {
+    const expiryError = validateExpiry(expiry.timestamp);
+    if (expiryError) {
+      validationErrors.expiryError = expiryError;
+    }
+  }
+
+  if (
+    expiry &&
+    !validationErrors.startTimeError &&
+    !validationErrors.expiryError
+  ) {
+    const startTimeVsExpiryError = validateStartTimeVsExpiry(
+      permissionDetails.startTime,
+      expiry.timestamp,
+    );
+    if (startTimeVsExpiryError) {
+      validationErrors.startTimeError = startTimeVsExpiryError;
+    }
+  }
+
+  return {
+    validationErrors,
+  };
+}

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/context.ts
@@ -16,7 +16,13 @@ import {
   validateExpiry,
   validateStartTimeVsExpiry,
 } from '../contextValidation';
-import { applyExpiryRule } from '../rules';
+import {
+  applyExpiryRule,
+  applyPayeeRule,
+  applyRedeemerRule,
+  getPayeeAddressesFromRulesIfPresent,
+  getRedeemerAddressesFromRules,
+} from '../rules';
 import type {
   Erc20TokenAllowanceContext,
   Erc20TokenAllowancePermissionRequest,
@@ -47,7 +53,9 @@ export async function applyContext({
     tokenMetadata: { decimals },
   } = context;
 
-  const { rules } = applyExpiryRule(context, originalRequest);
+  const expiryMerged = applyExpiryRule(context, originalRequest);
+  const redeemerMerged = applyRedeemerRule(originalRequest, expiryMerged);
+  const { rules } = applyPayeeRule(originalRequest, redeemerMerged);
 
   const permissionData = {
     allowanceAmount: bigIntToHex(
@@ -142,6 +150,14 @@ export async function buildContext({
       }
     : undefined;
 
+  const redeemerAddresses = getRedeemerAddressesFromRules(
+    permissionRequest.rules,
+  );
+
+  const payeeAddresses = getPayeeAddressesFromRulesIfPresent(
+    permissionRequest.rules,
+  );
+
   const allowanceAmount = formatUnitsFromHex({
     value: data.allowanceAmount,
     allowNull: false,
@@ -165,6 +181,8 @@ export async function buildContext({
 
   return {
     expiry,
+    ...(redeemerAddresses === undefined ? {} : { redeemerAddresses }),
+    ...(payeeAddresses === undefined ? {} : { payeeAddresses }),
     justification: data.justification,
     isAdjustmentAllowed,
     accountAddressCaip10,

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/index.ts
@@ -1,0 +1,39 @@
+import { createPermissionCaveats } from './caveats';
+import { createConfirmationContent } from './content';
+import {
+  applyContext,
+  buildContext,
+  deriveMetadata,
+  populatePermission,
+} from './context';
+import { allRules } from './rules';
+import type {
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowanceMetadata,
+  Erc20TokenAllowancePermission,
+  Erc20TokenAllowancePermissionRequest,
+  PopulatedErc20TokenAllowancePermission,
+} from './types';
+import { parseAndValidatePermission } from './validation';
+import type { PermissionDefinition } from '../../core/types';
+
+export const erc20TokenAllowancePermissionDefinition: PermissionDefinition<
+  Erc20TokenAllowancePermissionRequest,
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowanceMetadata,
+  Erc20TokenAllowancePermission,
+  PopulatedErc20TokenAllowancePermission
+> = {
+  rules: allRules,
+  title: 'permissionRequestTitle',
+  subtitle: 'permissionRequestSubtitle',
+  dependencies: {
+    parseAndValidatePermission,
+    buildContext,
+    deriveMetadata,
+    createConfirmationContent,
+    applyContext,
+    populatePermission,
+    createPermissionCaveats,
+  },
+};

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/rules.ts
@@ -1,0 +1,72 @@
+import type { RuleDefinition } from '../../core/types';
+import { t } from '../../utils/i18n';
+import {
+  timestampToISO8601,
+  iso8601ToTimestampIgnoreTimezone,
+} from '../../utils/time';
+import { getIconData } from '../iconUtil';
+import { createExpiryRule } from '../rules';
+import type {
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowanceMetadata,
+} from './types';
+
+export const ALLOWANCE_AMOUNT_ELEMENT =
+  'erc20-token-allowance-allowance-amount';
+export const START_TIME_ELEMENT = 'erc20-token-allowance-start-date';
+export const EXPIRY_ELEMENT = 'erc20-token-allowance-expiry';
+
+export const allowanceAmountRule: RuleDefinition<
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowanceMetadata
+> = {
+  name: ALLOWANCE_AMOUNT_ELEMENT,
+  label: 'amountLabel',
+  type: 'number',
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.allowanceAmount,
+    isVisible: true,
+    tooltip: t('allowanceAmountTooltip'),
+    error: metadata.validationErrors.allowanceAmountError,
+    iconData: getIconData(context),
+    isEditable: context.isAdjustmentAllowed,
+  }),
+  updateContext: (context: Erc20TokenAllowanceContext, value: string) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      allowanceAmount: value,
+    },
+  }),
+};
+
+export const startTimeRule: RuleDefinition<
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowanceMetadata
+> = {
+  name: START_TIME_ELEMENT,
+  label: 'startTimeLabel',
+  type: 'datetime',
+  getRuleData: ({ context, metadata }) => ({
+    value: timestampToISO8601(context.permissionDetails.startTime),
+    isVisible: true,
+    tooltip: t('allowanceStartTimeTooltip'),
+    error: metadata.validationErrors.startTimeError,
+    allowPastDate: true,
+    isEditable: context.isAdjustmentAllowed,
+  }),
+  updateContext: (context: Erc20TokenAllowanceContext, value: string) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      startTime: iso8601ToTimestampIgnoreTimezone(value),
+    },
+  }),
+};
+
+export const expiryRule = createExpiryRule<
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowanceMetadata
+>({ elementName: EXPIRY_ELEMENT, translate: t });
+
+export const allRules = [allowanceAmountRule, startTimeRule, expiryRule];

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/types.ts
@@ -1,0 +1,52 @@
+import {
+  zHexStr,
+  zPermission,
+  zMetaMaskPermissionData,
+  zStartTime,
+  zAddressNotZeroAddress,
+} from '@metamask/7715-permissions-shared/types';
+import { z } from 'zod';
+
+import type {
+  DeepRequired,
+  TypedPermissionRequest,
+  BaseContext,
+  BaseMetadata,
+} from '../../core/types';
+
+export type Erc20TokenAllowanceMetadata = BaseMetadata & {
+  validationErrors: {
+    allowanceAmountError?: string;
+    startTimeError?: string;
+    expiryError?: string;
+  };
+};
+
+export type Erc20TokenAllowanceContext = BaseContext & {
+  permissionDetails: {
+    allowanceAmount: string;
+    startTime: number;
+  };
+};
+
+export const zErc20TokenAllowancePermission = zPermission.extend({
+  type: z.literal('erc20-token-allowance'),
+  data: z.intersection(
+    zMetaMaskPermissionData,
+    z.object({
+      allowanceAmount: zHexStr,
+      startTime: zStartTime,
+      tokenAddress: zAddressNotZeroAddress,
+    }),
+  ),
+});
+
+export type Erc20TokenAllowancePermission = z.infer<
+  typeof zErc20TokenAllowancePermission
+>;
+
+export type Erc20TokenAllowancePermissionRequest =
+  TypedPermissionRequest<Erc20TokenAllowancePermission>;
+
+export type PopulatedErc20TokenAllowancePermission =
+  DeepRequired<Erc20TokenAllowancePermission>;

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/validation.ts
@@ -1,0 +1,62 @@
+import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
+import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+import { InvalidInputError } from '@metamask/snaps-sdk';
+
+import { validateHexInteger, validateStartTime } from '../validation';
+import type {
+  Erc20TokenAllowancePermission,
+  Erc20TokenAllowancePermissionRequest,
+} from './types';
+import { zErc20TokenAllowancePermission } from './types';
+
+/**
+ * Validates a permission object data specific to the ERC-20 token allowance permission type.
+ * @param permission - The permission object to validate.
+ * @param rules - The rules of the permission request.
+ * @returns True if the permission data is valid.
+ * @throws {InvalidInputError} If any validation check fails.
+ */
+function validatePermissionData(
+  permission: Erc20TokenAllowancePermission,
+  rules: Erc20TokenAllowancePermissionRequest['rules'],
+): true {
+  const { allowanceAmount, startTime } = permission.data;
+
+  validateHexInteger({
+    name: 'allowanceAmount',
+    value: allowanceAmount,
+    required: true,
+    allowZero: false,
+  });
+
+  validateStartTime(startTime, rules);
+
+  return true;
+}
+
+/**
+ * Parses and validates a permission request for ERC-20 token allowance.
+ * @param permissionRequest - The permission request object to validate.
+ * @returns A validated permission request object.
+ * @throws {InvalidInputError} If the permission request is invalid.
+ */
+export function parseAndValidatePermission(
+  permissionRequest: PermissionRequest,
+): Erc20TokenAllowancePermissionRequest {
+  const {
+    data: validationResult,
+    error: validationError,
+    success,
+  } = zErc20TokenAllowancePermission.safeParse(permissionRequest.permission);
+
+  if (!success) {
+    throw new InvalidInputError(extractZodError(validationError.errors));
+  }
+
+  validatePermissionData(validationResult, permissionRequest.rules);
+
+  return {
+    ...permissionRequest,
+    permission: validationResult,
+  };
+}

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenAllowance/validation.ts
@@ -2,7 +2,12 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
-import { validateHexInteger, validateStartTime } from '../validation';
+import {
+  validateHexInteger,
+  validatePayeeRule,
+  validateRedeemerRule,
+  validateStartTime,
+} from '../validation';
 import type {
   Erc20TokenAllowancePermission,
   Erc20TokenAllowancePermissionRequest,
@@ -30,6 +35,8 @@ function validatePermissionData(
   });
 
   validateStartTime(startTime, rules);
+  validateRedeemerRule(rules);
+  validatePayeeRule(rules, { allowMultiplePayees: false });
 
   return true;
 }

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/caveats.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/caveats.ts
@@ -1,0 +1,55 @@
+import {
+  createExactCalldataTerms,
+  createNativeTokenPeriodTransferTerms,
+} from '@metamask/delegation-core';
+import type { Caveat } from '@metamask/delegation-core';
+
+import type { DelegationContracts } from '../../core/chainMetadata';
+import { PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX } from '../shared';
+import type { PopulatedNativeTokenAllowancePermission } from './types';
+
+/**
+ * Native token allowance uses NativeTokenPeriodTransferEnforcer with max uint256 period
+ * duration, plus ExactCalldataEnforcer (empty calldata) like native-token-periodic.
+ */
+
+/**
+ * Builds delegation caveats for native-token-allowance.
+ * @param args - The options object containing the permission and contracts.
+ * @param args.permission - Populated permission.
+ * @param args.contracts - Chain enforcer addresses.
+ * @returns Caveats for the delegation.
+ */
+export async function createPermissionCaveats({
+  permission,
+  contracts,
+}: {
+  permission: PopulatedNativeTokenAllowancePermission;
+  contracts: DelegationContracts;
+}): Promise<Caveat[]> {
+  const { allowanceAmount, startTime } = permission.data;
+
+  const nativeTokenPeriodTransferCaveat: Caveat = {
+    enforcer: contracts.nativeTokenPeriodTransferEnforcer,
+    terms: createNativeTokenPeriodTransferTerms({
+      periodAmount: BigInt(allowanceAmount),
+      // @metamask/delegation-core uses toHexString to encode period duration, which accepts bigint. We
+      // should update delegation-core to accept bigint as well as number, but we just do a type
+      // assertion for now.
+      periodDuration:
+        PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX as unknown as number,
+      startDate: startTime,
+    }),
+    args: '0x',
+  };
+
+  const exactCalldataCaveat: Caveat = {
+    enforcer: contracts.exactCalldataEnforcer,
+    terms: createExactCalldataTerms({
+      calldata: '0x',
+    }),
+    args: '0x',
+  };
+
+  return [nativeTokenPeriodTransferCaveat, exactCalldataCaveat];
+}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/content.tsx
@@ -1,0 +1,42 @@
+import type { SnapElement } from '@metamask/snaps-sdk/jsx';
+import { Box, Divider, Section } from '@metamask/snaps-sdk/jsx';
+
+import { allowanceAmountRule, startTimeRule, expiryRule } from './rules';
+import type {
+  NativeTokenAllowanceContext,
+  NativeTokenAllowanceMetadata,
+} from './types';
+import { renderRules } from '../../core/rules';
+
+/**
+ * Creates UI content for a native token allowance permission confirmation.
+ * @param args - The configuration for the confirmation content.
+ * @param args.context - Context with allowance and schedule fields.
+ * @param args.metadata - Validation state for rules.
+ * @returns Confirmation section content.
+ */
+export async function createConfirmationContent({
+  context,
+  metadata,
+}: {
+  context: NativeTokenAllowanceContext;
+  metadata: NativeTokenAllowanceMetadata;
+}): Promise<SnapElement> {
+  return (
+    <Box>
+      <Section>
+        {renderRules({
+          rules: [allowanceAmountRule],
+          context,
+          metadata,
+        })}
+        <Divider />
+        {renderRules({
+          rules: [startTimeRule, expiryRule],
+          context,
+          metadata,
+        })}
+      </Section>
+    </Box>
+  );
+}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/context.ts
@@ -1,0 +1,240 @@
+import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
+import { InvalidInputError } from '@metamask/snaps-sdk';
+import {
+  bigIntToHex,
+  parseCaipAccountId,
+  toCaipAccountId,
+  toCaipAssetType,
+} from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
+
+import type { TokenMetadataService } from '../../services/tokenMetadataService';
+import { parseUnits, formatUnitsFromHex } from '../../utils/value';
+import {
+  validateAndParseAmount,
+  validateStartTime,
+  validateExpiry,
+  validateStartTimeVsExpiry,
+} from '../contextValidation';
+import { applyExpiryRule } from '../rules';
+import type {
+  NativeTokenAllowanceContext,
+  NativeTokenAllowancePermissionRequest,
+  NativeTokenAllowanceMetadata,
+  PopulatedNativeTokenAllowancePermission,
+  NativeTokenAllowancePermission,
+} from './types';
+
+const ASSET_NAMESPACE = 'slip44';
+const CHAIN_NAMESPACE = 'eip155';
+const ASSET_REFERENCE = '60';
+
+/**
+ * Construct an amended permission request from context edits.
+ * @param options - The options object containing the context and original request.
+ * @param options.context - Context with formatted allowance and times.
+ * @param options.originalRequest - Original request.
+ * @returns Request with hex allowance and merged expiry rule (optional, like other types).
+ */
+export async function applyContext({
+  context,
+  originalRequest,
+}: {
+  context: NativeTokenAllowanceContext;
+  originalRequest: NativeTokenAllowancePermissionRequest;
+}): Promise<NativeTokenAllowancePermissionRequest> {
+  const {
+    permissionDetails,
+    tokenMetadata: { decimals },
+  } = context;
+
+  const { rules } = applyExpiryRule(context, originalRequest);
+
+  const permissionData = {
+    allowanceAmount: bigIntToHex(
+      parseUnits({ formatted: permissionDetails.allowanceAmount, decimals }),
+    ),
+    startTime: permissionDetails.startTime,
+    justification: originalRequest.permission.data.justification,
+  };
+
+  const { address } = parseCaipAccountId(context.accountAddressCaip10);
+
+  return {
+    ...originalRequest,
+    from: address as Hex,
+    permission: {
+      type: 'native-token-allowance',
+      data: permissionData,
+      isAdjustmentAllowed: originalRequest.permission.isAdjustmentAllowed,
+    },
+    rules,
+  };
+}
+
+/**
+ * Populate optional permission fields before signing.
+ * @param options - The options object containing the permission to populate.
+ * @param options.permission - Permission after applyContext.
+ * @returns Permission with defaulted start time when missing.
+ */
+export async function populatePermission({
+  permission,
+}: {
+  permission: NativeTokenAllowancePermission;
+}): Promise<PopulatedNativeTokenAllowancePermission> {
+  return {
+    ...permission,
+    data: {
+      ...permission.data,
+      startTime: permission.data.startTime ?? Math.floor(Date.now() / 1000),
+    },
+  };
+}
+
+/**
+ * Build UI context from a validated permission request.
+ * @param args - The options object containing the request and required services.
+ * @param args.permissionRequest - Request for this permission type.
+ * @param args.tokenMetadataService - Token metadata service.
+ * @returns Context for confirmation UI and validation.
+ */
+export async function buildContext({
+  permissionRequest,
+  tokenMetadataService,
+}: {
+  permissionRequest: NativeTokenAllowancePermissionRequest;
+  tokenMetadataService: TokenMetadataService;
+}): Promise<NativeTokenAllowanceContext> {
+  const chainId = Number(permissionRequest.chainId);
+  const {
+    from,
+    permission: { data, isAdjustmentAllowed },
+  } = permissionRequest;
+
+  if (!from) {
+    throw new InvalidInputError(
+      'PermissionRequest.address was not found. This should be resolved within the buildContextHandler function in PermissionHandler.',
+    );
+  }
+
+  const { decimals, symbol, iconUrl } =
+    await tokenMetadataService.getTokenBalanceAndMetadata({
+      chainId,
+      account: from,
+    });
+
+  const iconDataResponse =
+    await tokenMetadataService.fetchIconDataAsBase64(iconUrl);
+
+  const iconDataBase64 = iconDataResponse.success
+    ? iconDataResponse.imageDataBase64
+    : null;
+
+  const expiryRule = permissionRequest.rules?.find(
+    (rule) => extractDescriptorName(rule.type) === 'expiry',
+  );
+
+  const expiry = expiryRule
+    ? {
+        timestamp: expiryRule.data.timestamp,
+      }
+    : undefined;
+
+  const allowanceAmount = formatUnitsFromHex({
+    value: data.allowanceAmount,
+    allowNull: false,
+    decimals,
+  });
+
+  const startTime = data.startTime ?? Math.floor(Date.now() / 1000);
+
+  const tokenAddressCaip19 = toCaipAssetType(
+    CHAIN_NAMESPACE,
+    chainId.toString(),
+    ASSET_NAMESPACE,
+    ASSET_REFERENCE,
+  );
+
+  const accountAddressCaip10 = toCaipAccountId(
+    CHAIN_NAMESPACE,
+    chainId.toString(),
+    from,
+  );
+
+  return {
+    expiry,
+    justification: data.justification,
+    isAdjustmentAllowed,
+    accountAddressCaip10,
+    tokenAddressCaip19,
+    tokenMetadata: {
+      symbol,
+      decimals,
+      iconDataBase64,
+    },
+    permissionDetails: {
+      allowanceAmount,
+      startTime,
+    },
+  };
+}
+
+/**
+ * Derive validation metadata for the confirmation UI.
+ * @param options - The options object containing the context to create metadata for.
+ * @param options.context - Built context.
+ * @returns Metadata with validation errors for rules.
+ */
+export async function deriveMetadata({
+  context,
+}: {
+  context: NativeTokenAllowanceContext;
+}): Promise<NativeTokenAllowanceMetadata> {
+  const {
+    permissionDetails,
+    expiry,
+    tokenMetadata: { decimals },
+  } = context;
+
+  const validationErrors: NativeTokenAllowanceMetadata['validationErrors'] = {};
+
+  const allowanceAmountResult = validateAndParseAmount(
+    permissionDetails.allowanceAmount,
+    decimals,
+    'allowance amount',
+  );
+  if (allowanceAmountResult.error) {
+    validationErrors.allowanceAmountError = allowanceAmountResult.error;
+  }
+
+  const startTimeError = validateStartTime(permissionDetails.startTime);
+  if (startTimeError) {
+    validationErrors.startTimeError = startTimeError;
+  }
+
+  if (expiry) {
+    const expiryError = validateExpiry(expiry.timestamp);
+    if (expiryError) {
+      validationErrors.expiryError = expiryError;
+    }
+  }
+
+  if (
+    expiry &&
+    !validationErrors.startTimeError &&
+    !validationErrors.expiryError
+  ) {
+    const startTimeVsExpiryError = validateStartTimeVsExpiry(
+      permissionDetails.startTime,
+      expiry.timestamp,
+    );
+    if (startTimeVsExpiryError) {
+      validationErrors.startTimeError = startTimeVsExpiryError;
+    }
+  }
+
+  return {
+    validationErrors,
+  };
+}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/context.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/context.ts
@@ -16,7 +16,13 @@ import {
   validateExpiry,
   validateStartTimeVsExpiry,
 } from '../contextValidation';
-import { applyExpiryRule } from '../rules';
+import {
+  applyExpiryRule,
+  applyPayeeRule,
+  applyRedeemerRule,
+  getPayeeAddressesFromRulesIfPresent,
+  getRedeemerAddressesFromRules,
+} from '../rules';
 import type {
   NativeTokenAllowanceContext,
   NativeTokenAllowancePermissionRequest,
@@ -48,7 +54,9 @@ export async function applyContext({
     tokenMetadata: { decimals },
   } = context;
 
-  const { rules } = applyExpiryRule(context, originalRequest);
+  const expiryMerged = applyExpiryRule(context, originalRequest);
+  const redeemerMerged = applyRedeemerRule(originalRequest, expiryMerged);
+  const { rules } = applyPayeeRule(originalRequest, redeemerMerged);
 
   const permissionData = {
     allowanceAmount: bigIntToHex(
@@ -141,6 +149,14 @@ export async function buildContext({
       }
     : undefined;
 
+  const redeemerAddresses = getRedeemerAddressesFromRules(
+    permissionRequest.rules,
+  );
+
+  const payeeAddresses = getPayeeAddressesFromRulesIfPresent(
+    permissionRequest.rules,
+  );
+
   const allowanceAmount = formatUnitsFromHex({
     value: data.allowanceAmount,
     allowNull: false,
@@ -164,6 +180,8 @@ export async function buildContext({
 
   return {
     expiry,
+    ...(redeemerAddresses === undefined ? {} : { redeemerAddresses }),
+    ...(payeeAddresses === undefined ? {} : { payeeAddresses }),
     justification: data.justification,
     isAdjustmentAllowed,
     accountAddressCaip10,

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/index.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/index.ts
@@ -1,0 +1,39 @@
+import { createPermissionCaveats } from './caveats';
+import { createConfirmationContent } from './content';
+import {
+  applyContext,
+  buildContext,
+  deriveMetadata,
+  populatePermission,
+} from './context';
+import { allRules } from './rules';
+import type {
+  NativeTokenAllowanceContext,
+  NativeTokenAllowanceMetadata,
+  NativeTokenAllowancePermission,
+  NativeTokenAllowancePermissionRequest,
+  PopulatedNativeTokenAllowancePermission,
+} from './types';
+import { parseAndValidatePermission } from './validation';
+import type { PermissionDefinition } from '../../core/types';
+
+export const nativeTokenAllowancePermissionDefinition: PermissionDefinition<
+  NativeTokenAllowancePermissionRequest,
+  NativeTokenAllowanceContext,
+  NativeTokenAllowanceMetadata,
+  NativeTokenAllowancePermission,
+  PopulatedNativeTokenAllowancePermission
+> = {
+  rules: allRules,
+  title: 'permissionRequestTitle',
+  subtitle: 'permissionRequestSubtitle',
+  dependencies: {
+    parseAndValidatePermission,
+    buildContext,
+    deriveMetadata,
+    createConfirmationContent,
+    applyContext,
+    populatePermission,
+    createPermissionCaveats,
+  },
+};

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/rules.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/rules.ts
@@ -1,0 +1,72 @@
+import type { RuleDefinition } from '../../core/types';
+import { t } from '../../utils/i18n';
+import {
+  timestampToISO8601,
+  iso8601ToTimestampIgnoreTimezone,
+} from '../../utils/time';
+import { getIconData } from '../iconUtil';
+import { createExpiryRule } from '../rules';
+import type {
+  NativeTokenAllowanceContext,
+  NativeTokenAllowanceMetadata,
+} from './types';
+
+export const ALLOWANCE_AMOUNT_ELEMENT =
+  'native-token-allowance-allowance-amount';
+export const START_TIME_ELEMENT = 'native-token-allowance-start-date';
+export const EXPIRY_ELEMENT = 'native-token-allowance-expiry';
+
+export const allowanceAmountRule: RuleDefinition<
+  NativeTokenAllowanceContext,
+  NativeTokenAllowanceMetadata
+> = {
+  name: ALLOWANCE_AMOUNT_ELEMENT,
+  label: 'amountLabel',
+  type: 'number',
+  getRuleData: ({ context, metadata }) => ({
+    value: context.permissionDetails.allowanceAmount,
+    isVisible: true,
+    tooltip: t('allowanceAmountTooltip'),
+    error: metadata.validationErrors.allowanceAmountError,
+    iconData: getIconData(context),
+    isEditable: context.isAdjustmentAllowed,
+  }),
+  updateContext: (context: NativeTokenAllowanceContext, value: string) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      allowanceAmount: value,
+    },
+  }),
+};
+
+export const startTimeRule: RuleDefinition<
+  NativeTokenAllowanceContext,
+  NativeTokenAllowanceMetadata
+> = {
+  name: START_TIME_ELEMENT,
+  label: 'startTimeLabel',
+  type: 'datetime',
+  getRuleData: ({ context, metadata }) => ({
+    value: timestampToISO8601(context.permissionDetails.startTime),
+    isVisible: true,
+    tooltip: t('allowanceStartTimeTooltip'),
+    error: metadata.validationErrors.startTimeError,
+    allowPastDate: true,
+    isEditable: context.isAdjustmentAllowed,
+  }),
+  updateContext: (context: NativeTokenAllowanceContext, value: string) => ({
+    ...context,
+    permissionDetails: {
+      ...context.permissionDetails,
+      startTime: iso8601ToTimestampIgnoreTimezone(value),
+    },
+  }),
+};
+
+export const expiryRule = createExpiryRule<
+  NativeTokenAllowanceContext,
+  NativeTokenAllowanceMetadata
+>({ elementName: EXPIRY_ELEMENT, translate: t });
+
+export const allRules = [allowanceAmountRule, startTimeRule, expiryRule];

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/types.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/types.ts
@@ -1,0 +1,50 @@
+import {
+  zHexStr,
+  zPermission,
+  zMetaMaskPermissionData,
+  zStartTime,
+} from '@metamask/7715-permissions-shared/types';
+import { z } from 'zod';
+
+import type {
+  DeepRequired,
+  TypedPermissionRequest,
+  BaseContext,
+  BaseMetadata,
+} from '../../core/types';
+
+export type NativeTokenAllowanceMetadata = BaseMetadata & {
+  validationErrors: {
+    allowanceAmountError?: string;
+    startTimeError?: string;
+    expiryError?: string;
+  };
+};
+
+export type NativeTokenAllowanceContext = BaseContext & {
+  permissionDetails: {
+    allowanceAmount: string;
+    startTime: number;
+  };
+};
+
+export const zNativeTokenAllowancePermission = zPermission.extend({
+  type: z.literal('native-token-allowance'),
+  data: z.intersection(
+    zMetaMaskPermissionData,
+    z.object({
+      allowanceAmount: zHexStr,
+      startTime: zStartTime,
+    }),
+  ),
+});
+
+export type NativeTokenAllowancePermission = z.infer<
+  typeof zNativeTokenAllowancePermission
+>;
+
+export type NativeTokenAllowancePermissionRequest =
+  TypedPermissionRequest<NativeTokenAllowancePermission>;
+
+export type PopulatedNativeTokenAllowancePermission =
+  DeepRequired<NativeTokenAllowancePermission>;

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/validation.ts
@@ -1,0 +1,62 @@
+import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
+import { extractZodError } from '@metamask/7715-permissions-shared/utils';
+import { InvalidInputError } from '@metamask/snaps-sdk';
+
+import { validateHexInteger, validateStartTime } from '../validation';
+import type {
+  NativeTokenAllowancePermission,
+  NativeTokenAllowancePermissionRequest,
+} from './types';
+import { zNativeTokenAllowancePermission } from './types';
+
+/**
+ * Validates a permission object data specific to the native token allowance permission type.
+ * @param permission - The permission object to validate.
+ * @param rules - The rules of the permission request.
+ * @returns True if the permission data is valid.
+ * @throws {InvalidInputError} If any validation check fails.
+ */
+function validatePermissionData(
+  permission: NativeTokenAllowancePermission,
+  rules: NativeTokenAllowancePermissionRequest['rules'],
+): true {
+  const { allowanceAmount, startTime } = permission.data;
+
+  validateHexInteger({
+    name: 'allowanceAmount',
+    value: allowanceAmount,
+    required: true,
+    allowZero: false,
+  });
+
+  validateStartTime(startTime, rules);
+
+  return true;
+}
+
+/**
+ * Parses and validates a permission request for native token allowance.
+ * @param permissionRequest - The permission request object to validate.
+ * @returns A validated permission request object.
+ * @throws {InvalidInputError} If the permission request is invalid.
+ */
+export function parseAndValidatePermission(
+  permissionRequest: PermissionRequest,
+): NativeTokenAllowancePermissionRequest {
+  const {
+    data: validationResult,
+    error: validationError,
+    success,
+  } = zNativeTokenAllowancePermission.safeParse(permissionRequest.permission);
+
+  if (!success) {
+    throw new InvalidInputError(extractZodError(validationError.errors));
+  }
+
+  validatePermissionData(validationResult, permissionRequest.rules);
+
+  return {
+    ...permissionRequest,
+    permission: validationResult,
+  };
+}

--- a/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/nativeTokenAllowance/validation.ts
@@ -2,7 +2,12 @@ import type { PermissionRequest } from '@metamask/7715-permissions-shared/types'
 import { extractZodError } from '@metamask/7715-permissions-shared/utils';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
-import { validateHexInteger, validateStartTime } from '../validation';
+import {
+  validateHexInteger,
+  validatePayeeRule,
+  validateRedeemerRule,
+  validateStartTime,
+} from '../validation';
 import type {
   NativeTokenAllowancePermission,
   NativeTokenAllowancePermissionRequest,
@@ -30,6 +35,8 @@ function validatePermissionData(
   });
 
   validateStartTime(startTime, rules);
+  validateRedeemerRule(rules);
+  validatePayeeRule(rules);
 
   return true;
 }

--- a/packages/gator-permissions-snap/src/permissions/permissionOffers.ts
+++ b/packages/gator-permissions-snap/src/permissions/permissionOffers.ts
@@ -13,12 +13,20 @@ export const DEFAULT_GATOR_PERMISSION_TO_OFFER: PermissionOffer[] = [
     proposedName: 'Native Token Periodic Transfer',
   },
   {
+    type: 'native-token-allowance',
+    proposedName: 'Native Token Allowance',
+  },
+  {
     type: 'erc20-token-stream',
     proposedName: 'ERC20 Token Stream',
   },
   {
     type: 'erc20-token-periodic',
     proposedName: 'ERC20 Token Periodic Transfer',
+  },
+  {
+    type: 'erc20-token-allowance',
+    proposedName: 'ERC20 Token Allowance',
   },
   {
     type: 'erc20-token-revocation',

--- a/packages/gator-permissions-snap/src/permissions/shared.ts
+++ b/packages/gator-permissions-snap/src/permissions/shared.ts
@@ -1,0 +1,7 @@
+/**
+ * Maximum uint256 value for `periodDuration` in {@link @metamask/delegation-core}
+ * period-transfer enforcer terms. The on-chain type is uint256; we encode a single
+ * "unbounded" period so optional `expiry` (timestamp enforcer) can bound the delegation
+ * like other permissions.
+ */
+export const PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX = 2n ** 256n - 1n;

--- a/packages/gator-permissions-snap/src/utils/time.ts
+++ b/packages/gator-permissions-snap/src/utils/time.ts
@@ -99,13 +99,15 @@ export const getClosestTimePeriod = (seconds: number): TimePeriod => {
   return closestPeriod;
 };
 
-const TEN_YEARS = 10 * 365 * 24 * 60 * 60; // 10 years in seconds
+/** Maximum period / allowance window duration in seconds (10 years). */
+export const MAX_PERIOD_DURATION_SECONDS = 10 * 365 * 24 * 60 * 60;
+
 /**
  * period duration in seconds, mapped to closest TransferWindow enum value
  */
 export const zPeriodDuration = zTimestamp
-  .max(TEN_YEARS, {
-    message: `Period duration must be less than or equal to ${TEN_YEARS} seconds (10 years).`,
+  .max(MAX_PERIOD_DURATION_SECONDS, {
+    message: `Period duration must be less than or equal to ${MAX_PERIOD_DURATION_SECONDS} seconds (10 years).`,
   })
   .transform((val) => {
     const periodType = getClosestTimePeriod(val);

--- a/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/existingPermissionsService.test.ts
@@ -409,6 +409,50 @@ describe('ExistingPermissionsService', () => {
         ),
       ).toBe(ExistingPermissionsState.DissimilarPermissions);
     });
+
+    it('returns SimilarPermissions for matching allowance categories', () => {
+      const permission = createMockStoredPermission();
+      permission.permissionResponse.permission = {
+        type: 'erc20-token-allowance',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      const requestedPermission: Permission = {
+        type: 'native-token-allowance',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      expect(
+        service.getExistingPermissionsStatusFromList(
+          [permission],
+          requestedPermission,
+        ),
+      ).toBe(ExistingPermissionsState.SimilarPermissions);
+    });
+
+    it('returns DissimilarPermissions for allowance vs stream categories', () => {
+      const permission = createMockStoredPermission();
+      permission.permissionResponse.permission = {
+        type: 'erc20-token-allowance',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      const requestedPermission: Permission = {
+        type: 'native-token-stream',
+        data: {},
+        isAdjustmentAllowed: true,
+      };
+
+      expect(
+        service.getExistingPermissionsStatusFromList(
+          [permission],
+          requestedPermission,
+        ),
+      ).toBe(ExistingPermissionsState.DissimilarPermissions);
+    });
   });
 
   describe('showExistingPermissions()', () => {

--- a/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
@@ -128,6 +128,29 @@ describe('formatPermissionWithTokenMetadata', () => {
     expect(mockTokenMetadataService.getTokenMetadata).not.toHaveBeenCalled();
   });
 
+  it('formats allowanceAmount using token metadata', async () => {
+    const permission = basePermission({
+      permission: {
+        type: 'erc20-token-allowance',
+        data: {
+          allowanceAmount: '0x38d7ea4c68000',
+          tokenAddress: '0x0000000000000000000000000000000000000001',
+          justification: 'j',
+        },
+        isAdjustmentAllowed: true,
+      },
+    });
+
+    const result = await formatPermissionWithTokenMetadata(
+      permission,
+      mockTokenMetadataService as unknown as TokenMetadataService,
+    );
+
+    expect(result.permission.data).toMatchObject({
+      allowanceAmount: expect.stringContaining('ETH') as unknown,
+    });
+  });
+
   it('formats maxAmount using token metadata', async () => {
     const permission = basePermission({
       permission: {

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenAllowance/caveats.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenAllowance/caveats.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from '@jest/globals';
+import { bigIntToHex } from '@metamask/utils';
+
+import type { DelegationContracts } from '../../../src/core/chainMetadata';
+import { createPermissionCaveats } from '../../../src/permissions/erc20TokenAllowance/caveats';
+import type { PopulatedErc20TokenAllowancePermission } from '../../../src/permissions/erc20TokenAllowance/types';
+import { PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX } from '../../../src/permissions/shared';
+import { parseUnits } from '../../../src/utils/value';
+
+const tokenDecimals = 6;
+
+const contracts = {
+  erc20PeriodTransferEnforcer: '0x1234567890123456789012345678901234567890',
+  valueLteEnforcer: '0x1234567890123456789012345678901234567891',
+} as unknown as DelegationContracts;
+
+const createExpectedTerms = (
+  permission: PopulatedErc20TokenAllowancePermission,
+): string => {
+  const amountHex = permission.data.allowanceAmount.slice(2).padStart(64, '0');
+  const periodDurationHex =
+    PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX.toString(16).padStart(64, '0');
+  const startTimeHex = permission.data.startTime.toString(16).padStart(64, '0');
+  const tokenAddressHex = permission.data.tokenAddress.slice(2);
+
+  return `0x${tokenAddressHex}${amountHex}${periodDurationHex}${startTimeHex}`;
+};
+
+describe('erc20TokenAllowance:caveats', () => {
+  describe('createPermissionCaveats()', () => {
+    it('should create period transfer and valueLte caveats', async () => {
+      const permission: PopulatedErc20TokenAllowancePermission = {
+        type: 'erc20-token-allowance',
+        data: {
+          allowanceAmount: bigIntToHex(
+            parseUnits({ formatted: '100', decimals: tokenDecimals }),
+          ),
+          startTime: 499132800,
+          tokenAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          justification: 'Permission to do something important',
+        },
+        isAdjustmentAllowed: true,
+      };
+
+      const caveats = await createPermissionCaveats({ permission, contracts });
+
+      const expectedTerms = createExpectedTerms(permission);
+
+      expect(caveats).toStrictEqual([
+        {
+          enforcer: contracts.erc20PeriodTransferEnforcer,
+          terms: expectedTerms,
+          args: '0x',
+        },
+        {
+          enforcer: contracts.valueLteEnforcer,
+          terms:
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+          args: '0x',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenAllowance/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenAllowance/context.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from '@jest/globals';
+import { bigIntToHex } from '@metamask/utils';
+
+import {
+  applyContext,
+  deriveMetadata,
+} from '../../../src/permissions/erc20TokenAllowance/context';
+import type {
+  Erc20TokenAllowanceContext,
+  Erc20TokenAllowancePermissionRequest,
+} from '../../../src/permissions/erc20TokenAllowance/types';
+import { parseUnits } from '../../../src/utils/value';
+
+const ACCOUNT_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+const tokenDecimals = 6;
+const tokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+const startTime = 1729900800;
+const expiryTimestamp = startTime + 86400 * 30;
+
+const permissionRequest: Erc20TokenAllowancePermissionRequest = {
+  from: ACCOUNT_ADDRESS,
+  chainId: '0x1',
+  rules: [
+    {
+      type: 'expiry',
+      data: {
+        timestamp: expiryTimestamp,
+      },
+    },
+  ],
+  to: '0x1',
+  permission: {
+    type: 'erc20-token-allowance',
+    data: {
+      allowanceAmount: bigIntToHex(
+        parseUnits({ formatted: '100', decimals: tokenDecimals }),
+      ),
+      startTime,
+      tokenAddress,
+      justification: 'Permission to do something important',
+    },
+    isAdjustmentAllowed: true,
+  },
+};
+
+const baseContext: Erc20TokenAllowanceContext = {
+  expiry: {
+    timestamp: expiryTimestamp,
+  },
+  isAdjustmentAllowed: true,
+  justification: 'Permission to do something important',
+  accountAddressCaip10: `eip155:1:${ACCOUNT_ADDRESS}`,
+  tokenAddressCaip19: `eip155:1/erc20:${tokenAddress}`,
+  tokenMetadata: {
+    symbol: 'USDC',
+    decimals: tokenDecimals,
+    iconDataBase64: null,
+  },
+  permissionDetails: {
+    allowanceAmount: '100',
+    startTime,
+  },
+};
+
+describe('erc20TokenAllowance:context', () => {
+  describe('applyContext()', () => {
+    it('writes allowance data without a derived period duration', async () => {
+      const result = await applyContext({
+        context: baseContext,
+        originalRequest: permissionRequest,
+      });
+
+      expect(result.permission.type).toBe('erc20-token-allowance');
+      expect(result.permission.data).not.toHaveProperty('periodDuration');
+      expect(result.permission.data.tokenAddress).toBe(tokenAddress);
+      expect(result.permission.data.allowanceAmount).toBe(
+        permissionRequest.permission.data.allowanceAmount,
+      );
+    });
+  });
+
+  describe('deriveMetadata()', () => {
+    it('does not require expiry when absent', async () => {
+      const contextNoExpiry: Erc20TokenAllowanceContext = {
+        ...baseContext,
+        expiry: undefined,
+      };
+
+      const metadata = await deriveMetadata({ context: contextNoExpiry });
+
+      expect(metadata.validationErrors.expiryError).toBeUndefined();
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenAllowance/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenAllowance/validation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from '@jest/globals';
+import { bigIntToHex } from '@metamask/utils';
+
+import type { Erc20TokenAllowancePermissionRequest } from '../../../src/permissions/erc20TokenAllowance/types';
+import { parseAndValidatePermission } from '../../../src/permissions/erc20TokenAllowance/validation';
+import { parseUnits } from '../../../src/utils/value';
+
+const tokenDecimals = 6;
+
+const startTime = Math.floor(Date.now() / 1000) + 86400;
+const expiryTimestamp = startTime + 86400 * 30;
+
+const validPermissionRequest: Erc20TokenAllowancePermissionRequest = {
+  chainId: '0x1',
+  rules: [
+    {
+      type: 'expiry',
+      data: {
+        timestamp: expiryTimestamp,
+      },
+    },
+  ],
+  to: '0x1',
+  permission: {
+    type: 'erc20-token-allowance',
+    data: {
+      allowanceAmount: bigIntToHex(
+        parseUnits({ formatted: '100', decimals: tokenDecimals }),
+      ),
+      startTime,
+      tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  },
+};
+
+describe('erc20TokenAllowance:validation', () => {
+  describe('parseAndValidatePermission()', () => {
+    it('should validate a valid permission request', () => {
+      expect(() =>
+        parseAndValidatePermission(validPermissionRequest),
+      ).not.toThrow();
+      expect(parseAndValidatePermission(validPermissionRequest)).toStrictEqual(
+        validPermissionRequest,
+      );
+    });
+
+    it('allows a missing expiry rule like other permissions', () => {
+      const missingExpiry = {
+        ...validPermissionRequest,
+        rules: [],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(missingExpiry as any),
+      ).not.toThrow();
+    });
+
+    it('should throw for invalid permission type', () => {
+      const invalidTypeRequest = {
+        ...validPermissionRequest,
+        permission: {
+          ...validPermissionRequest.permission,
+          type: 'erc20-token-periodic',
+        },
+      };
+
+      expect(() =>
+        parseAndValidatePermission(invalidTypeRequest as any),
+      ).toThrow(
+        'Failed type validation: type: Invalid literal value, expected "erc20-token-allowance"',
+      );
+    });
+
+    it('should throw for zero allowanceAmount', () => {
+      const zeroRequest = {
+        ...validPermissionRequest,
+        permission: {
+          ...validPermissionRequest.permission,
+          data: {
+            ...validPermissionRequest.permission.data,
+            allowanceAmount: '0x0' as `0x${string}`,
+          },
+        },
+      };
+
+      expect(() => parseAndValidatePermission(zeroRequest)).toThrow(
+        'Invalid allowanceAmount: must be greater than 0',
+      );
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenAllowance/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenAllowance/validation.test.ts
@@ -89,5 +89,69 @@ describe('erc20TokenAllowance:validation', () => {
         'Invalid allowanceAmount: must be greater than 0',
       );
     });
+
+    it('should throw when redeemer rule has no addresses', () => {
+      const invalidRedeemerRuleRequest = {
+        ...validPermissionRequest,
+        rules: [
+          ...(validPermissionRequest.rules ?? []),
+          {
+            type: 'redeemer',
+            data: {
+              addresses: [],
+            },
+          },
+        ],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(invalidRedeemerRuleRequest as any),
+      ).toThrow(
+        'Invalid redeemer rule: must include a non-empty addresses array',
+      );
+    });
+
+    it('should throw when payee rule has no addresses', () => {
+      const invalidPayeeRuleRequest = {
+        ...validPermissionRequest,
+        rules: [
+          ...(validPermissionRequest.rules ?? []),
+          {
+            type: 'payee',
+            data: {
+              addresses: [],
+            },
+          },
+        ],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(invalidPayeeRuleRequest as any),
+      ).toThrow('Invalid payee rule: must include a non-empty addresses array');
+    });
+
+    it('should throw when payee rule has multiple addresses', () => {
+      const multiplePayeesRequest = {
+        ...validPermissionRequest,
+        rules: [
+          ...(validPermissionRequest.rules ?? []),
+          {
+            type: 'payee',
+            data: {
+              addresses: [
+                '0x1111111111111111111111111111111111111111',
+                '0x2222222222222222222222222222222222222222',
+              ],
+            },
+          },
+        ],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(multiplePayeesRequest as any),
+      ).toThrow(
+        'Multiple payee addresses are not currently supported for ERC20 permissions.',
+      );
+    });
   });
 });

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenAllowance/caveats.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenAllowance/caveats.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from '@jest/globals';
+import { bigIntToHex } from '@metamask/utils';
+
+import type { DelegationContracts } from '../../../src/core/chainMetadata';
+import { createPermissionCaveats } from '../../../src/permissions/nativeTokenAllowance/caveats';
+import type { PopulatedNativeTokenAllowancePermission } from '../../../src/permissions/nativeTokenAllowance/types';
+import { PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX } from '../../../src/permissions/shared';
+import { parseUnits } from '../../../src/utils/value';
+
+const contracts = {
+  nativeTokenPeriodTransferEnforcer:
+    '0x726B9Dc7515524819365AC0Cf6464C683Ae61765',
+  exactCalldataEnforcer: '0x9Ec1216e9E98311bF49f7b644cEE7865672fF4B9',
+} as unknown as DelegationContracts;
+
+const createExpectedTerms = (
+  permission: PopulatedNativeTokenAllowancePermission,
+): string => {
+  const amountHex = permission.data.allowanceAmount.slice(2).padStart(64, '0');
+  const periodDurationHex =
+    PERIOD_TRANSFER_PERIOD_DURATION_UINT256_MAX.toString(16).padStart(64, '0');
+  const startTimeHex = permission.data.startTime.toString(16).padStart(64, '0');
+
+  return `0x${amountHex}${periodDurationHex}${startTimeHex}`;
+};
+
+describe('nativeTokenAllowance:caveats', () => {
+  describe('createPermissionCaveats()', () => {
+    it('should create native period transfer and exactCalldata caveats', async () => {
+      const permission: PopulatedNativeTokenAllowancePermission = {
+        type: 'native-token-allowance',
+        data: {
+          allowanceAmount: bigIntToHex(
+            parseUnits({ formatted: '1', decimals: 18 }),
+          ),
+          startTime: 499132800,
+          justification: 'Permission to do something important',
+        },
+        isAdjustmentAllowed: true,
+      };
+
+      const caveats = await createPermissionCaveats({ permission, contracts });
+
+      const expectedTerms = createExpectedTerms(permission);
+
+      expect(caveats).toStrictEqual([
+        {
+          enforcer: contracts.nativeTokenPeriodTransferEnforcer,
+          terms: expectedTerms,
+          args: '0x',
+        },
+        {
+          enforcer: contracts.exactCalldataEnforcer,
+          terms: '0x',
+          args: '0x',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenAllowance/context.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenAllowance/context.test.ts
@@ -4,23 +4,20 @@ import { bigIntToHex } from '@metamask/utils';
 import {
   applyContext,
   buildContext,
-  deriveMetadata,
-} from '../../../src/permissions/erc20TokenAllowance/context';
+} from '../../../src/permissions/nativeTokenAllowance/context';
 import type {
-  Erc20TokenAllowanceContext,
-  Erc20TokenAllowancePermissionRequest,
-} from '../../../src/permissions/erc20TokenAllowance/types';
+  NativeTokenAllowanceContext,
+  NativeTokenAllowancePermissionRequest,
+} from '../../../src/permissions/nativeTokenAllowance/types';
 import type { TokenMetadataService } from '../../../src/services/tokenMetadataService';
 import { parseUnits } from '../../../src/utils/value';
 
 const ACCOUNT_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
-const tokenDecimals = 6;
-const tokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 
 const startTime = 1729900800;
 const expiryTimestamp = startTime + 86400 * 30;
 
-const permissionRequest: Erc20TokenAllowancePermissionRequest = {
+const permissionRequest: NativeTokenAllowancePermissionRequest = {
   from: ACCOUNT_ADDRESS,
   chainId: '0x1',
   rules: [
@@ -45,39 +42,40 @@ const permissionRequest: Erc20TokenAllowancePermissionRequest = {
   ],
   to: '0x1',
   permission: {
-    type: 'erc20-token-allowance',
+    type: 'native-token-allowance',
     data: {
       allowanceAmount: bigIntToHex(
-        parseUnits({ formatted: '100', decimals: tokenDecimals }),
+        parseUnits({ formatted: '1', decimals: 18 }),
       ),
       startTime,
-      tokenAddress,
       justification: 'Permission to do something important',
     },
     isAdjustmentAllowed: true,
   },
 };
 
-const baseContext: Erc20TokenAllowanceContext = {
+const baseContext: NativeTokenAllowanceContext = {
   expiry: {
     timestamp: expiryTimestamp,
   },
+  redeemerAddresses: ['0x1111111111111111111111111111111111111111'],
+  payeeAddresses: ['0x2222222222222222222222222222222222222222'],
   isAdjustmentAllowed: true,
   justification: 'Permission to do something important',
   accountAddressCaip10: `eip155:1:${ACCOUNT_ADDRESS}`,
-  tokenAddressCaip19: `eip155:1/erc20:${tokenAddress}`,
+  tokenAddressCaip19: 'eip155:1/slip44:60',
   tokenMetadata: {
-    symbol: 'USDC',
-    decimals: tokenDecimals,
+    symbol: 'ETH',
+    decimals: 18,
     iconDataBase64: null,
   },
   permissionDetails: {
-    allowanceAmount: '100',
+    allowanceAmount: '1',
     startTime,
   },
 };
 
-describe('erc20TokenAllowance:context', () => {
+describe('nativeTokenAllowance:context', () => {
   let mockTokenMetadataService: jest.Mocked<TokenMetadataService>;
 
   beforeEach(() => {
@@ -85,7 +83,7 @@ describe('erc20TokenAllowance:context', () => {
       getTokenBalanceAndMetadata: jest.fn(() => ({
         balance: BigInt(0),
         symbol: baseContext.tokenMetadata.symbol,
-        decimals: tokenDecimals,
+        decimals: baseContext.tokenMetadata.decimals,
         iconUrl: 'https://example.com/icon.png',
       })),
       fetchIconDataAsBase64: jest.fn(async () =>
@@ -111,31 +109,13 @@ describe('erc20TokenAllowance:context', () => {
   });
 
   describe('applyContext()', () => {
-    it('writes allowance data without a derived period duration', async () => {
+    it('preserves redeemer and payee rules from the original request', async () => {
       const result = await applyContext({
         context: baseContext,
         originalRequest: permissionRequest,
       });
 
-      expect(result.permission.type).toBe('erc20-token-allowance');
-      expect(result.permission.data).not.toHaveProperty('periodDuration');
-      expect(result.permission.data.tokenAddress).toBe(tokenAddress);
-      expect(result.permission.data.allowanceAmount).toBe(
-        permissionRequest.permission.data.allowanceAmount,
-      );
-    });
-  });
-
-  describe('deriveMetadata()', () => {
-    it('does not require expiry when absent', async () => {
-      const contextNoExpiry: Erc20TokenAllowanceContext = {
-        ...baseContext,
-        expiry: undefined,
-      };
-
-      const metadata = await deriveMetadata({ context: contextNoExpiry });
-
-      expect(metadata.validationErrors.expiryError).toBeUndefined();
+      expect(result.rules).toStrictEqual(permissionRequest.rules);
     });
   });
 });

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenAllowance/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenAllowance/validation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from '@jest/globals';
+import { bigIntToHex } from '@metamask/utils';
+
+import type { NativeTokenAllowancePermissionRequest } from '../../../src/permissions/nativeTokenAllowance/types';
+import { parseAndValidatePermission } from '../../../src/permissions/nativeTokenAllowance/validation';
+import { parseUnits } from '../../../src/utils/value';
+
+const startTime = Math.floor(Date.now() / 1000) + 86400;
+const expiryTimestamp = startTime + 86400 * 30;
+
+const validPermissionRequest: NativeTokenAllowancePermissionRequest = {
+  chainId: '0x1',
+  rules: [
+    {
+      type: 'expiry',
+      data: {
+        timestamp: expiryTimestamp,
+      },
+    },
+  ],
+  to: '0x1',
+  permission: {
+    type: 'native-token-allowance',
+    data: {
+      allowanceAmount: bigIntToHex(
+        parseUnits({ formatted: '1', decimals: 18 }),
+      ),
+      startTime,
+      justification: 'test',
+    },
+    isAdjustmentAllowed: true,
+  },
+};
+
+describe('nativeTokenAllowance:validation', () => {
+  describe('parseAndValidatePermission()', () => {
+    it('should validate a valid permission request', () => {
+      expect(() =>
+        parseAndValidatePermission(validPermissionRequest),
+      ).not.toThrow();
+      expect(parseAndValidatePermission(validPermissionRequest)).toStrictEqual(
+        validPermissionRequest,
+      );
+    });
+
+    it('allows a missing expiry rule like other permissions', () => {
+      const missingExpiry = {
+        ...validPermissionRequest,
+        rules: [],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(missingExpiry as any),
+      ).not.toThrow();
+    });
+
+    it('should throw for invalid permission type', () => {
+      const invalidTypeRequest = {
+        ...validPermissionRequest,
+        permission: {
+          ...validPermissionRequest.permission,
+          type: 'native-token-periodic',
+        },
+      };
+
+      expect(() =>
+        parseAndValidatePermission(invalidTypeRequest as any),
+      ).toThrow(
+        'Failed type validation: type: Invalid literal value, expected "native-token-allowance"',
+      );
+    });
+  });
+});

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenAllowance/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenAllowance/validation.test.ts
@@ -69,5 +69,67 @@ describe('nativeTokenAllowance:validation', () => {
         'Failed type validation: type: Invalid literal value, expected "native-token-allowance"',
       );
     });
+
+    it('should throw when redeemer rule has no addresses', () => {
+      const invalidRedeemerRuleRequest = {
+        ...validPermissionRequest,
+        rules: [
+          ...(validPermissionRequest.rules ?? []),
+          {
+            type: 'redeemer',
+            data: {
+              addresses: [],
+            },
+          },
+        ],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(invalidRedeemerRuleRequest as any),
+      ).toThrow(
+        'Invalid redeemer rule: must include a non-empty addresses array',
+      );
+    });
+
+    it('should throw when payee rule has no addresses', () => {
+      const invalidPayeeRuleRequest = {
+        ...validPermissionRequest,
+        rules: [
+          ...(validPermissionRequest.rules ?? []),
+          {
+            type: 'payee',
+            data: {
+              addresses: [],
+            },
+          },
+        ],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(invalidPayeeRuleRequest as any),
+      ).toThrow('Invalid payee rule: must include a non-empty addresses array');
+    });
+
+    it('should allow multiple payee addresses for native token allowances', () => {
+      const multiplePayeesRequest = {
+        ...validPermissionRequest,
+        rules: [
+          ...(validPermissionRequest.rules ?? []),
+          {
+            type: 'payee',
+            data: {
+              addresses: [
+                '0x1111111111111111111111111111111111111111',
+                '0x2222222222222222222222222222222222222222',
+              ],
+            },
+          },
+        ],
+      };
+
+      expect(() =>
+        parseAndValidatePermission(multiplePayeesRequest as any),
+      ).not.toThrow();
+    });
   });
 });

--- a/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
+++ b/packages/gator-permissions-snap/test/rpc/rpcHandler.test.ts
@@ -578,12 +578,20 @@ describe('RpcHandler', () => {
           type: 'native-token-periodic',
         },
         {
+          proposedName: 'Native Token Allowance',
+          type: 'native-token-allowance',
+        },
+        {
           proposedName: 'ERC20 Token Stream',
           type: 'erc20-token-stream',
         },
         {
           proposedName: 'ERC20 Token Periodic Transfer',
           type: 'erc20-token-periodic',
+        },
+        {
+          proposedName: 'ERC20 Token Allowance',
+          type: 'erc20-token-allowance',
         },
         {
           proposedName: 'ERC20 Token Revocation',
@@ -924,11 +932,13 @@ describe('RpcHandler', () => {
     it('should return all supported permission types with ruleTypes', async () => {
       const result = await handler.getSupportedPermissions();
 
-      // Should return an object with all 5 permission types
+      // Should return an object with all supported permission types
       expect(result).toHaveProperty('native-token-stream');
       expect(result).toHaveProperty('native-token-periodic');
+      expect(result).toHaveProperty('native-token-allowance');
       expect(result).toHaveProperty('erc20-token-stream');
       expect(result).toHaveProperty('erc20-token-periodic');
+      expect(result).toHaveProperty('erc20-token-allowance');
       expect(result).toHaveProperty('erc20-token-revocation');
 
       // Each permission type should expose ruleTypes.
@@ -950,8 +960,14 @@ describe('RpcHandler', () => {
       expect(typedResult['native-token-periodic']?.ruleTypes).toContain(
         'expiry',
       );
+      expect(typedResult['native-token-allowance']?.ruleTypes).toContain(
+        'expiry',
+      );
       expect(typedResult['erc20-token-stream']?.ruleTypes).toContain('expiry');
       expect(typedResult['erc20-token-periodic']?.ruleTypes).toContain(
+        'expiry',
+      );
+      expect(typedResult['erc20-token-allowance']?.ruleTypes).toContain(
         'expiry',
       );
       expect(typedResult['erc20-token-revocation']?.ruleTypes).toContain(

--- a/packages/shared/src/types/7715-permissions-supported.ts
+++ b/packages/shared/src/types/7715-permissions-supported.ts
@@ -7,8 +7,10 @@ import { zHexStr } from './common';
  * This is the single source of truth for which rules can be applied to each permission.
  */
 export const SUPPORTED_RULE_TYPES = {
+  'native-token-allowance': ['expiry', 'redeemer', 'payee'],
   'native-token-stream': ['expiry', 'redeemer', 'payee'],
   'native-token-periodic': ['expiry', 'redeemer', 'payee'],
+  'erc20-token-allowance': ['expiry', 'redeemer', 'payee'],
   'erc20-token-stream': ['expiry', 'redeemer', 'payee'],
   'erc20-token-periodic': ['expiry', 'redeemer', 'payee'],
   'erc20-token-revocation': ['expiry', 'redeemer'],

--- a/packages/site/src/components/permissions/ERC20TokenAllowanceForm.tsx
+++ b/packages/site/src/components/permissions/ERC20TokenAllowanceForm.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useState } from 'react';
+import { parseUnits, toHex } from 'viem';
+import type { Hex } from 'viem';
+
+import type { ERC20TokenAllowancePermissionRequest } from './types';
+
+type ERC20TokenAllowanceFormProps = {
+  onChange: (request: ERC20TokenAllowancePermissionRequest) => void;
+};
+
+export const ERC20TokenAllowanceForm = ({
+  onChange,
+}: ERC20TokenAllowanceFormProps) => {
+  const decimals = 6; // e.g. USDC
+
+  const [allowanceAmount, setAllowanceAmount] = useState(
+    BigInt(toHex(parseUnits('1', decimals))),
+  );
+  const [startTime, setStartTime] = useState<number | null>(
+    Math.floor(Date.now() / 1000),
+  );
+  const [expiry, setExpiry] = useState<number | null>(
+    Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30, // 30 days from now
+  );
+  const [justification, setJustification] = useState(
+    'This is a request for a single ERC-20 token allowance',
+  );
+  const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
+  const [tokenAddress, setTokenAddress] = useState<Hex>(
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // Sepolia / mainnet USDC
+  );
+
+  const handleAllowanceAmountChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setAllowanceAmount(BigInt(inputValue));
+    },
+    [],
+  );
+
+  const handleStartTimeChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputValue.trim() === '') {
+        setStartTime(null);
+      } else {
+        setStartTime(Number(inputValue));
+      }
+    },
+    [],
+  );
+
+  const handleJustificationChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setJustification(inputValue);
+    },
+    [],
+  );
+
+  const handleExpiryChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputValue.trim() === '') {
+        setExpiry(null);
+      } else {
+        setExpiry(Number(inputValue));
+      }
+    },
+    [],
+  );
+
+  const handleIsAdjustmentAllowedChange = useCallback(
+    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+      setIsAdjustmentAllowed(checked);
+    },
+    [],
+  );
+
+  const handleTokenAddressChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setTokenAddress(inputValue as Hex);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    onChange({
+      type: 'erc20-token-allowance',
+      allowanceAmount: toHex(allowanceAmount),
+      startTime,
+      expiry,
+      justification,
+      isAdjustmentAllowed,
+      tokenAddress,
+    });
+  }, [
+    onChange,
+    allowanceAmount,
+    startTime,
+    expiry,
+    justification,
+    isAdjustmentAllowed,
+    tokenAddress,
+  ]);
+
+  return (
+    <>
+      <div>
+        <label htmlFor="tokenAddress">Token address:</label>
+        <input
+          type="text"
+          id="tokenAddress"
+          name="tokenAddress"
+          value={tokenAddress}
+          onChange={handleTokenAddressChange}
+          placeholder="0x..."
+        />
+      </div>
+      <div>
+        <label htmlFor="allowanceAmount">Allowance amount:</label>
+        <input
+          type="text"
+          id="allowanceAmount"
+          name="allowanceAmount"
+          value={allowanceAmount.toString()}
+          onChange={handleAllowanceAmountChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="startTime">Start time:</label>
+        <input
+          type="number"
+          id="startTime"
+          name="startTime"
+          value={startTime ?? ''}
+          onChange={handleStartTimeChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="justification">Justification:</label>
+        <textarea
+          id="justification"
+          name="justification"
+          rows={3}
+          value={justification}
+          onChange={handleJustificationChange}
+        ></textarea>
+      </div>
+      <div>
+        <label htmlFor="expiry">Expiry:</label>
+        <input
+          type="number"
+          id="expiry"
+          name="expiry"
+          value={expiry ?? ''}
+          onChange={handleExpiryChange}
+        />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <label htmlFor="isAdjustmentAllowed">Allow adjustments:</label>
+        <input
+          type="checkbox"
+          id="isAdjustmentAllowed"
+          name="isAdjustmentAllowed"
+          checked={isAdjustmentAllowed}
+          onChange={handleIsAdjustmentAllowedChange}
+          style={{ width: 'auto', marginLeft: '1rem' }}
+        />
+      </div>
+    </>
+  );
+};

--- a/packages/site/src/components/permissions/ERC20TokenAllowanceForm.tsx
+++ b/packages/site/src/components/permissions/ERC20TokenAllowanceForm.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { parseUnits, toHex } from 'viem';
 import type { Hex } from 'viem';
 
+import { PayeeAddressesField } from './PayeeAddressesField';
+import { RedeemerAddressesField } from './RedeemerAddressesField';
 import type { ERC20TokenAllowancePermissionRequest } from './types';
 
 type ERC20TokenAllowanceFormProps = {
@@ -29,6 +31,8 @@ export const ERC20TokenAllowanceForm = ({
   const [tokenAddress, setTokenAddress] = useState<Hex>(
     '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // Sepolia / mainnet USDC
   );
+  const [redeemerAddresses, setRedeemerAddresses] = useState<Hex[]>([]);
+  const [payeeAddresses, setPayeeAddresses] = useState<Hex[]>([]);
 
   const handleAllowanceAmountChange = useCallback(
     ({
@@ -97,6 +101,8 @@ export const ERC20TokenAllowanceForm = ({
       startTime,
       expiry,
       justification,
+      redeemerAddresses,
+      payeeAddresses,
       isAdjustmentAllowed,
       tokenAddress,
     });
@@ -106,6 +112,8 @@ export const ERC20TokenAllowanceForm = ({
     startTime,
     expiry,
     justification,
+    redeemerAddresses,
+    payeeAddresses,
     isAdjustmentAllowed,
     tokenAddress,
   ]);
@@ -163,6 +171,8 @@ export const ERC20TokenAllowanceForm = ({
           onChange={handleExpiryChange}
         />
       </div>
+      <RedeemerAddressesField onChange={setRedeemerAddresses} />
+      <PayeeAddressesField onChange={setPayeeAddresses} />
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <label htmlFor="isAdjustmentAllowed">Allow adjustments:</label>
         <input

--- a/packages/site/src/components/permissions/NativeTokenAllowanceForm.tsx
+++ b/packages/site/src/components/permissions/NativeTokenAllowanceForm.tsx
@@ -1,0 +1,152 @@
+import { bigIntToHex } from '@metamask/utils';
+import { useCallback, useEffect, useState } from 'react';
+import { parseUnits } from 'viem';
+
+import type { NativeTokenAllowancePermissionRequest } from './types';
+
+type NativeTokenAllowanceFormProps = {
+  onChange: (request: NativeTokenAllowancePermissionRequest) => void;
+};
+
+export const NativeTokenAllowanceForm = ({
+  onChange,
+}: NativeTokenAllowanceFormProps) => {
+  const [allowanceAmount, setAllowanceAmount] = useState(
+    BigInt(bigIntToHex(parseUnits('1', 18))),
+  );
+  const [startTime, setStartTime] = useState<number | null>(
+    Math.floor(Date.now() / 1000),
+  );
+  const [expiry, setExpiry] = useState<number | null>(
+    Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30, // 30 days from now
+  );
+  const [justification, setJustification] = useState(
+    'This is a request for a single native token allowance',
+  );
+  const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
+
+  const handleAllowanceAmountChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      setAllowanceAmount(BigInt(inputValue));
+    },
+    [],
+  );
+
+  const handleStartTimeChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputValue.trim() === '') {
+        setStartTime(null);
+      } else {
+        setStartTime(Number(inputValue));
+      }
+    },
+    [],
+  );
+
+  const handleJustificationChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setJustification(inputValue);
+    },
+    [],
+  );
+
+  const handleExpiryChange = useCallback(
+    ({
+      target: { value: inputValue },
+    }: React.ChangeEvent<HTMLInputElement>) => {
+      if (inputValue.trim() === '') {
+        setExpiry(null);
+      } else {
+        setExpiry(Number(inputValue));
+      }
+    },
+    [],
+  );
+
+  const handleIsAdjustmentAllowedChange = useCallback(
+    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+      setIsAdjustmentAllowed(checked);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    onChange({
+      type: 'native-token-allowance',
+      allowanceAmount: bigIntToHex(allowanceAmount),
+      startTime,
+      expiry,
+      justification,
+      isAdjustmentAllowed,
+    });
+  }, [
+    onChange,
+    allowanceAmount,
+    startTime,
+    expiry,
+    justification,
+    isAdjustmentAllowed,
+  ]);
+
+  return (
+    <>
+      <div>
+        <label htmlFor="allowanceAmount">Allowance amount:</label>
+        <input
+          type="text"
+          id="allowanceAmount"
+          name="allowanceAmount"
+          value={allowanceAmount.toString()}
+          onChange={handleAllowanceAmountChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="startTime">Start time:</label>
+        <input
+          type="number"
+          id="startTime"
+          name="startTime"
+          value={startTime ?? ''}
+          onChange={handleStartTimeChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="justification">Justification:</label>
+        <textarea
+          id="justification"
+          name="justification"
+          rows={3}
+          value={justification}
+          onChange={handleJustificationChange}
+        ></textarea>
+      </div>
+      <div>
+        <label htmlFor="expiry">Expiry:</label>
+        <input
+          type="number"
+          id="expiry"
+          name="expiry"
+          value={expiry ?? ''}
+          onChange={handleExpiryChange}
+        />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <label htmlFor="isAdjustmentAllowed">Allow adjustments:</label>
+        <input
+          type="checkbox"
+          id="isAdjustmentAllowed"
+          name="isAdjustmentAllowed"
+          checked={isAdjustmentAllowed}
+          onChange={handleIsAdjustmentAllowedChange}
+          style={{ width: 'auto', marginLeft: '1rem' }}
+        />
+      </div>
+    </>
+  );
+};

--- a/packages/site/src/components/permissions/NativeTokenAllowanceForm.tsx
+++ b/packages/site/src/components/permissions/NativeTokenAllowanceForm.tsx
@@ -1,7 +1,10 @@
 import { bigIntToHex } from '@metamask/utils';
 import { useCallback, useEffect, useState } from 'react';
 import { parseUnits } from 'viem';
+import type { Hex } from 'viem';
 
+import { PayeeAddressesField } from './PayeeAddressesField';
+import { RedeemerAddressesField } from './RedeemerAddressesField';
 import type { NativeTokenAllowancePermissionRequest } from './types';
 
 type NativeTokenAllowanceFormProps = {
@@ -24,6 +27,8 @@ export const NativeTokenAllowanceForm = ({
     'This is a request for a single native token allowance',
   );
   const [isAdjustmentAllowed, setIsAdjustmentAllowed] = useState(true);
+  const [redeemerAddresses, setRedeemerAddresses] = useState<Hex[]>([]);
+  const [payeeAddresses, setPayeeAddresses] = useState<Hex[]>([]);
 
   const handleAllowanceAmountChange = useCallback(
     ({
@@ -83,6 +88,8 @@ export const NativeTokenAllowanceForm = ({
       startTime,
       expiry,
       justification,
+      redeemerAddresses,
+      payeeAddresses,
       isAdjustmentAllowed,
     });
   }, [
@@ -91,6 +98,8 @@ export const NativeTokenAllowanceForm = ({
     startTime,
     expiry,
     justification,
+    redeemerAddresses,
+    payeeAddresses,
     isAdjustmentAllowed,
   ]);
 
@@ -136,6 +145,8 @@ export const NativeTokenAllowanceForm = ({
           onChange={handleExpiryChange}
         />
       </div>
+      <RedeemerAddressesField onChange={setRedeemerAddresses} />
+      <PayeeAddressesField onChange={setPayeeAddresses} />
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <label htmlFor="isAdjustmentAllowed">Allow adjustments:</label>
         <input

--- a/packages/site/src/components/permissions/index.ts
+++ b/packages/site/src/components/permissions/index.ts
@@ -2,6 +2,8 @@ export { NativeTokenStreamForm } from './NativeTokenStreamForm';
 export { ERC20TokenStreamForm } from './ERC20TokenStreamForm';
 export { NativeTokenPeriodicForm } from './NativeTokenPeriodicForm';
 export { ERC20TokenPeriodicForm } from './ERC20TokenPeriodicForm';
+export { NativeTokenAllowanceForm } from './NativeTokenAllowanceForm';
+export { ERC20TokenAllowanceForm } from './ERC20TokenAllowanceForm';
 export { ERC20TokenRevocationForm } from './ERC20TokenRevocationForm';
 export { RedemptionForm } from './RedemptionForm';
 export type { RedemptionCall } from './RedemptionForm';

--- a/packages/site/src/components/permissions/types.ts
+++ b/packages/site/src/components/permissions/types.ts
@@ -39,6 +39,17 @@ export type ERC20TokenPeriodicPermissionRequest = BasePermissionRequest & {
   tokenAddress: Hex;
 };
 
+export type NativeTokenAllowancePermissionRequest = BasePermissionRequest & {
+  type: 'native-token-allowance';
+  allowanceAmount: Hex;
+};
+
+export type ERC20TokenAllowancePermissionRequest = BasePermissionRequest & {
+  type: 'erc20-token-allowance';
+  allowanceAmount: Hex;
+  tokenAddress: Hex;
+};
+
 export type ERC20TokenRevocationPermissionRequest = BasePermissionRequest & {
   type: 'erc20-token-revocation';
 };
@@ -46,6 +57,8 @@ export type ERC20TokenRevocationPermissionRequest = BasePermissionRequest & {
 export type PermissionRequest =
   | NativeTokenStreamPermissionRequest
   | NativeTokenPeriodicPermissionRequest
+  | NativeTokenAllowancePermissionRequest
   | ERC20TokenPeriodicPermissionRequest
+  | ERC20TokenAllowancePermissionRequest
   | ERC20TokenRevocationPermissionRequest
   | ERC20TokenStreamPermissionRequest;

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -24,18 +24,13 @@ import {
   ERC20TokenStreamForm,
   NativeTokenPeriodicForm,
   ERC20TokenPeriodicForm,
+  NativeTokenAllowanceForm,
+  ERC20TokenAllowanceForm,
   ERC20TokenRevocationForm,
   RedemptionForm,
 } from '../components/permissions';
 import type { RedemptionCall } from '../components/permissions';
-import type {
-  PermissionRequest,
-  NativeTokenStreamPermissionRequest,
-  ERC20TokenStreamPermissionRequest,
-  NativeTokenPeriodicPermissionRequest,
-  ERC20TokenPeriodicPermissionRequest,
-  ERC20TokenRevocationPermissionRequest,
-} from '../components/permissions/types';
+import type { PermissionRequest } from '../components/permissions/types';
 import { kernelSnapOrigin, gatorSnapOrigin } from '../config';
 import {
   useMetaMask,
@@ -355,19 +350,9 @@ const Index = () => {
     }
   };
 
-  const onFormChange = useCallback(
-    (
-      request:
-        | ERC20TokenPeriodicPermissionRequest
-        | ERC20TokenStreamPermissionRequest
-        | NativeTokenPeriodicPermissionRequest
-        | NativeTokenStreamPermissionRequest
-        | ERC20TokenRevocationPermissionRequest,
-    ) => {
-      setPermissionRequest(request);
-    },
-    [],
-  );
+  const onFormChange = useCallback((request: PermissionRequest) => {
+    setPermissionRequest(request);
+  }, []);
 
   return (
     <Container>
@@ -479,8 +464,14 @@ const Index = () => {
                   <option value="native-token-periodic">
                     Native Token Periodic
                   </option>
+                  <option value="native-token-allowance">
+                    Native Token Allowance
+                  </option>
                   <option value="erc20-token-periodic">
                     ERC20 Token Periodic
+                  </option>
+                  <option value="erc20-token-allowance">
+                    ERC20 Token Allowance
                   </option>
                   <option value="erc20-token-revocation">
                     ERC20 Token Revocation
@@ -502,6 +493,14 @@ const Index = () => {
 
               {permissionType === 'erc20-token-periodic' && (
                 <ERC20TokenPeriodicForm onChange={onFormChange} />
+              )}
+
+              {permissionType === 'native-token-allowance' && (
+                <NativeTokenAllowanceForm onChange={onFormChange} />
+              )}
+
+              {permissionType === 'erc20-token-allowance' && (
+                <ERC20TokenAllowanceForm onChange={onFormChange} />
               )}
 
               {permissionType === 'erc20-token-revocation' && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,18 +2907,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@metamask/base-controller@npm:9.0.0"
-  dependencies:
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.8.1"
-    immer: "npm:^9.0.6"
-  checksum: 10/27554d34ec85c4b585b87850c90dfeaaf9c7e6430f2ab2fa80a1ec06ccc17641e118afab7ad765a0b7255ffef37bc9f6ca5065d459228a2dc660bc463293310d
-  languageName: node
-  linkType: hard
-
-"@metamask/base-controller@npm:^9.0.1":
+"@metamask/base-controller@npm:^9.0.0, @metamask/base-controller@npm:^9.0.1":
   version: 9.1.0
   resolution: "@metamask/base-controller@npm:9.1.0"
   dependencies:
@@ -2929,7 +2918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.19.0":
+"@metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.19.0":
   version: 11.20.0
   resolution: "@metamask/controller-utils@npm:11.20.0"
   dependencies:
@@ -3131,21 +3120,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.1.0, @metamask/json-rpc-engine@npm:^10.1.1, @metamask/json-rpc-engine@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "@metamask/json-rpc-engine@npm:10.2.0"
-  dependencies:
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/safe-event-emitter": "npm:^3.0.0"
-    "@metamask/utils": "npm:^11.8.1"
-    "@types/deep-freeze-strict": "npm:^1.1.0"
-    deep-freeze-strict: "npm:^1.1.1"
-    klona: "npm:^2.0.6"
-  checksum: 10/c4d588ee2a27c5cd3b4634dbafebebb193092364e1eec2bf1fef2bd2f2352ab7fa59758067ab53440d8d93b812270bdf2c0e508640614b51e5d06d68a76a37c1
-  languageName: node
-  linkType: hard
-
-"@metamask/json-rpc-engine@npm:^10.2.1, @metamask/json-rpc-engine@npm:^10.2.4":
+"@metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.1.0, @metamask/json-rpc-engine@npm:^10.1.1, @metamask/json-rpc-engine@npm:^10.2.1, @metamask/json-rpc-engine@npm:^10.2.4":
   version: 10.3.0
   resolution: "@metamask/json-rpc-engine@npm:10.3.0"
   dependencies:
@@ -3226,26 +3201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^12.1.0, @metamask/permission-controller@npm:^12.2.0":
-  version: 12.2.0
-  resolution: "@metamask/permission-controller@npm:12.2.0"
-  dependencies:
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.17.0"
-    "@metamask/json-rpc-engine": "npm:^10.2.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.9.0"
-    "@types/deep-freeze-strict": "npm:^1.1.0"
-    deep-freeze-strict: "npm:^1.1.1"
-    immer: "npm:^9.0.6"
-    nanoid: "npm:^3.3.8"
-  checksum: 10/d15ce9b69b3f8dbed2409d2e789e800d06798e42e55ac05095f19db0feda7492a64e221865ec6ee3d41b6c809ba5467f2bdab443c2d99133df88ac624ae264b8
-  languageName: node
-  linkType: hard
-
-"@metamask/permission-controller@npm:^12.3.0":
+"@metamask/permission-controller@npm:^12.2.0, @metamask/permission-controller@npm:^12.3.0":
   version: 12.3.0
   resolution: "@metamask/permission-controller@npm:12.3.0"
   dependencies:
@@ -3418,14 +3374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/slip44@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@metamask/slip44@npm:4.3.0"
-  checksum: 10/508983a48911f2be8d9de117d390ecfb5b949a6032f5d6c5cc63f7f23302b87468be6ff08dee4881d39e8f5f66b5545eab15e6fc0511acea10fd4c99852a8212
-  languageName: node
-  linkType: hard
-
-"@metamask/slip44@npm:^4.4.0":
+"@metamask/slip44@npm:^4.3.0, @metamask/slip44@npm:^4.4.0":
   version: 4.4.0
   resolution: "@metamask/slip44@npm:4.4.0"
   checksum: 10/296ac7c578bd35792c7e3942a9a0b7d9d7af76cf98358b97403c1ed483faa3c2fe6c71b1c3f8c7719fbfcf9fc73e5fa8707c89ac277ee9ce6c8bc4c694b2059d
@@ -3643,24 +3592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^14.1.1":
-  version: 14.1.1
-  resolution: "@metamask/snaps-rpc-methods@npm:14.1.1"
-  dependencies:
-    "@metamask/key-tree": "npm:^10.1.1"
-    "@metamask/permission-controller": "npm:^12.1.0"
-    "@metamask/rpc-errors": "npm:^7.0.3"
-    "@metamask/snaps-sdk": "npm:^10.1.0"
-    "@metamask/snaps-utils": "npm:^11.6.1"
-    "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.8.1"
-    "@noble/hashes": "npm:^1.7.1"
-    async-mutex: "npm:^0.5.0"
-  checksum: 10/871c50f20e6427bcb14d30648bca2867725cc8ef6df579ef8951481f9919ebed2a7713dd821c94666829e240df6ceeb6181a0203fe18413e20a7ff45b1b29895
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-rpc-methods@npm:^14.2.0, @metamask/snaps-rpc-methods@npm:^14.3.0":
+"@metamask/snaps-rpc-methods@npm:^14.1.1, @metamask/snaps-rpc-methods@npm:^14.2.0, @metamask/snaps-rpc-methods@npm:^14.3.0":
   version: 14.3.0
   resolution: "@metamask/snaps-rpc-methods@npm:14.3.0"
   dependencies:
@@ -3698,21 +3630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^10.1.0, @metamask/snaps-sdk@npm:^10.3.0":
-  version: 10.3.0
-  resolution: "@metamask/snaps-sdk@npm:10.3.0"
-  dependencies:
-    "@metamask/key-tree": "npm:^10.1.1"
-    "@metamask/providers": "npm:^22.1.1"
-    "@metamask/rpc-errors": "npm:^7.0.3"
-    "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.8.1"
-    luxon: "npm:^3.5.0"
-  checksum: 10/24efa7af91557d2365cd2199e0572566675efadbcc51a350938cb57e4b5c0861188c30d26a9ec3a42cb9059b37bba0f44a5486ec3ed32ac2e956cf48213d6485
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-sdk@npm:^10.4.0":
+"@metamask/snaps-sdk@npm:^10.3.0, @metamask/snaps-sdk@npm:^10.4.0":
   version: 10.4.0
   resolution: "@metamask/snaps-sdk@npm:10.4.0"
   dependencies:
@@ -3768,7 +3686,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^11.0.0, @metamask/snaps-utils@npm:^11.6.1, @metamask/snaps-utils@npm:^11.7.1":
+"@metamask/snaps-utils@npm:^11.0.0, @metamask/snaps-utils@npm:^11.7.1":
   version: 11.7.1
   resolution: "@metamask/snaps-utils@npm:11.7.1"
   dependencies:
@@ -3852,7 +3770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:11.11.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.11.0":
+"@metamask/utils@npm:11.11.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.11.0, @metamask/utils@npm:^11.2.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
   version: 11.11.0
   resolution: "@metamask/utils@npm:11.11.0"
   dependencies:
@@ -3868,25 +3786,6 @@ __metadata:
     semver: "npm:^7.5.4"
     uuid: "npm:^9.0.1"
   checksum: 10/c4381b9e451a9616bde84ac659bc0d1848ef06b6e605f877bfa065b78c8ed5015706683ea88a3387de5eaeb3a50d1af9af0994f04f9e06258d992598fe2be3bf
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.2.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
-  version: 11.10.0
-  resolution: "@metamask/utils@npm:11.10.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^4.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@noble/hashes": "npm:^1.3.1"
-    "@scure/base": "npm:^1.1.3"
-    "@types/debug": "npm:^4.1.7"
-    "@types/lodash": "npm:^4.17.20"
-    debug: "npm:^4.3.4"
-    lodash: "npm:^4.17.21"
-    pony-cause: "npm:^2.1.10"
-    semver: "npm:^7.5.4"
-    uuid: "npm:^9.0.1"
-  checksum: 10/691a268af66593b60e9807a069127993cea3cdc941f99d5d7ca4664868754f08945821f1787b2f3e99e4497df63ceb0af37a2419ad494da29a1fddffe94f5797
   languageName: node
   linkType: hard
 
@@ -5957,16 +5856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.4, acorn@npm:^8.11.0, acorn@npm:^8.15.0":
-  version: 8.15.0
-  resolution: "acorn@npm:8.15.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 10/77f2de5051a631cf1729c090e5759148459cdb76b5f5c70f890503d629cf5052357b0ce783c0f976dd8a93c5150f59f6d18df1def3f502396a20f81282482fa4
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.16.0":
+"acorn@npm:^8.0.4, acorn@npm:^8.11.0, acorn@npm:^8.15.0, acorn@npm:^8.16.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -6635,21 +6525,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.24.0, browserslist@npm:^4.25.1":
-  version: 4.25.1
-  resolution: "browserslist@npm:4.25.1"
-  dependencies:
-    caniuse-lite: "npm:^1.0.30001726"
-    electron-to-chromium: "npm:^1.5.173"
-    node-releases: "npm:^2.0.19"
-    update-browserslist-db: "npm:^1.1.3"
-  bin:
-    browserslist: cli.js
-  checksum: 10/bfb5511b425886279bbe2ea44d10e340c8aea85866c9d45083c13491d049b6362e254018c0afbf56d41ceeb64f994957ea8ae98dbba74ef1e54ef901c8732987
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.28.1":
+"browserslist@npm:^4.24.0, browserslist@npm:^4.25.1, browserslist@npm:^4.28.1":
   version: 4.28.2
   resolution: "browserslist@npm:4.28.2"
   dependencies:
@@ -6842,13 +6718,6 @@ __metadata:
   version: 1.0.1
   resolution: "camelize@npm:1.0.1"
   checksum: 10/0e147b4299ac6363c50050716aadfae42831257ec56ce54773ffd2a94a88abb2e2540c5ccc38345e8a39963105b76d86cb24477165a36b78c9958fb304513db3
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001726":
-  version: 1.0.30001727
-  resolution: "caniuse-lite@npm:1.0.30001727"
-  checksum: 10/6155a4141332c337d6317325bea58a09036a65f45bd9bd834ec38978b40c27d214baa04d25b21a5661664f3fbd00cb830e2bdb7eee8df09970bdd98a71f4dabf
   languageName: node
   linkType: hard
 
@@ -7698,13 +7567,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.173":
-  version: 1.5.191
-  resolution: "electron-to-chromium@npm:1.5.191"
-  checksum: 10/d5a5ca41bb2fbe03bee2973d72d8eaa9d2112b153d6c45fd8ad418998423871047700c28c941d64a92ee1e3445b0552c5312621aba8ff550c3752951f2987dbb
-  languageName: node
-  linkType: hard
-
 "electron-to-chromium@npm:^1.5.328":
   version: 1.5.331
   resolution: "electron-to-chromium@npm:1.5.331"
@@ -7771,17 +7633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.17.1":
-  version: 5.18.4
-  resolution: "enhanced-resolve@npm:5.18.4"
-  dependencies:
-    graceful-fs: "npm:^4.2.4"
-    tapable: "npm:^2.2.0"
-  checksum: 10/dcd477cb694d9cc84109a03269c13d3da0851d50099fd3fa7c56b2867dd720d59c7f1431bd47c9cad2825ad52588bd71d3a68cf1e5ee0bc57551d8a3fab4e6f2
-  languageName: node
-  linkType: hard
-
-"enhanced-resolve@npm:^5.20.0":
+"enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.20.0":
   version: 5.20.1
   resolution: "enhanced-resolve@npm:5.20.1"
   dependencies:
@@ -11585,13 +11437,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.19":
-  version: 2.0.19
-  resolution: "node-releases@npm:2.0.19"
-  checksum: 10/c2b33b4f0c40445aee56141f13ca692fa6805db88510e5bbb3baadb2da13e1293b738e638e15e4a8eb668bb9e97debb08e7a35409b477b5cc18f171d35a83045
-  languageName: node
-  linkType: hard
-
 "node-releases@npm:^2.0.36":
   version: 2.0.37
   resolution: "node-releases@npm:2.0.37"
@@ -13056,19 +12901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^4.3.0":
-  version: 4.3.2
-  resolution: "schema-utils@npm:4.3.2"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.9"
-    ajv: "npm:^8.9.0"
-    ajv-formats: "npm:^2.1.1"
-    ajv-keywords: "npm:^5.1.0"
-  checksum: 10/02c32c34aae762d48468f98465a96a167fede637772871c7c7d8923671ddb9f20b2cc6f6e8448ae6bef5363e3597493c655212c8b06a4ee73aa099d9452fbd8b
-  languageName: node
-  linkType: hard
-
-"schema-utils@npm:^4.3.3":
+"schema-utils@npm:^4.3.0, schema-utils@npm:^4.3.3":
   version: 4.3.3
   resolution: "schema-utils@npm:4.3.3"
   dependencies:
@@ -13152,7 +12985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.1, serialize-javascript@npm:^6.0.2":
+"serialize-javascript@npm:^6.0.1":
   version: 6.0.2
   resolution: "serialize-javascript@npm:6.0.2"
   dependencies:
@@ -13185,18 +13018,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ses@npm:^1.14.0":
-  version: 1.14.0
-  resolution: "ses@npm:1.14.0"
-  dependencies:
-    "@endo/cache-map": "npm:^1.1.0"
-    "@endo/env-options": "npm:^1.1.11"
-    "@endo/immutable-arraybuffer": "npm:^1.1.2"
-  checksum: 10/bee10b958938fb3d153ea8f1b4514f8ddb390dc7533fe9cfc382dcc046bebd5fca02d80836bfb8f98e94609ffbe3580a0bb65428eb7e39d523315eacdc052300
-  languageName: node
-  linkType: hard
-
-"ses@npm:^1.15.0":
+"ses@npm:^1.14.0, ses@npm:^1.15.0":
   version: 1.15.0
   resolution: "ses@npm:1.15.0"
   dependencies:
@@ -14094,14 +13916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.2.0, tapable@npm:^2.2.1":
-  version: 2.2.2
-  resolution: "tapable@npm:2.2.2"
-  checksum: 10/065a0dc44aba1b32020faa1c27c719e8f76e5345347515d8494bf158524f36e9f22ad9eaa5b5494f9d5d67bf0640afdd5698505948c46d720b6b7e69d19349a6
-  languageName: node
-  linkType: hard
-
-"tapable@npm:^2.3.0":
+"tapable@npm:^2.2.1, tapable@npm:^2.3.0":
   version: 2.3.2
   resolution: "tapable@npm:2.3.2"
   checksum: 10/fd3affe2e34efb3970883f934b1828f10b48dffb1eb71a52b7f955bfdd88bf80e94ec388704d95334f72ddf77e34d813b19e1f4bf56897d20252fa025d44bede
@@ -14151,7 +13966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.3.17":
+"terser-webpack-plugin@npm:^5.3.17, terser-webpack-plugin@npm:^5.3.9":
   version: 5.4.0
   resolution: "terser-webpack-plugin@npm:5.4.0"
   dependencies:
@@ -14169,28 +13984,6 @@ __metadata:
     uglify-js:
       optional: true
   checksum: 10/f4618b18cec5dd41fca4a53f621ea06df04ff7bb2b09d3766559284e171a91df2884083e5c143aaacee2000870b046eb7157e39d1d2d8024577395165a070094
-  languageName: node
-  linkType: hard
-
-"terser-webpack-plugin@npm:^5.3.9":
-  version: 5.3.14
-  resolution: "terser-webpack-plugin@npm:5.3.14"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jest-worker: "npm:^27.4.5"
-    schema-utils: "npm:^4.3.0"
-    serialize-javascript: "npm:^6.0.2"
-    terser: "npm:^5.31.1"
-  peerDependencies:
-    webpack: ^5.1.0
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    esbuild:
-      optional: true
-    uglify-js:
-      optional: true
-  checksum: 10/5b7290f7edb179b83cefb8827c12371ddddc088cf251cf58a1c738d82628331ae6604273b61fe991d77411d4bb6b7178c3826aa47edf01b4ee21f973d6c8b8fb
   languageName: node
   linkType: hard
 
@@ -14760,20 +14553,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "update-browserslist-db@npm:1.1.3"
-  dependencies:
-    escalade: "npm:^3.2.0"
-    picocolors: "npm:^1.1.1"
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    update-browserslist-db: cli.js
-  checksum: 10/87af2776054ffb9194cf95e0201547d041f72ee44ce54b144da110e65ea7ca01379367407ba21de5c9edd52c74d95395366790de67f3eb4cc4afa0fe4424e76f
-  languageName: node
-  linkType: hard
-
 "update-browserslist-db@npm:^1.2.3":
   version: 1.2.3
   resolution: "update-browserslist-db@npm:1.2.3"
@@ -15077,14 +14856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.2.3":
-  version: 3.3.3
-  resolution: "webpack-sources@npm:3.3.3"
-  checksum: 10/ec5d72607e8068467370abccbfff855c596c098baedbe9d198a557ccf198e8546a322836a6f74241492576adba06100286592993a62b63196832cdb53c8bae91
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^3.3.4":
+"webpack-sources@npm:^3.2.3, webpack-sources@npm:^3.3.4":
   version: 3.3.4
   resolution: "webpack-sources@npm:3.3.4"
   checksum: 10/714427b235b04c2d7cf229f204b9e65145ea3643da3c7b139ebfa8a51056238d1e3a2a47c3cc3fc8eab71ed4300f66405cdc7cff29cd2f7f6b71086252f81cf1


### PR DESCRIPTION
## **Description**

New "simple" allowance permission types allow a user to grant a fixed allowance up to a specified amount of either ERC-20 tokens, or native tokens.

- `native-token-allowance` 
- `erc20-token-allowance`

This PR adds these new types to @metamask/gator-permissions-snap and to the snaps site. The snaps site requires the updated @metamask/smart-accounts-kit with the changes in https://github.com/MetaMask/smart-accounts-kit/pull/214 to function.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new permission types that affect request validation, delegation caveat construction, and UI display/flows for granting spend rights; mistakes could result in incorrect on-chain enforcement or confusing user prompts.
> 
> **Overview**
> Adds two new permission types—`native-token-allowance` and `erc20-token-allowance`—to support granting a **single total spend allowance** (with optional start time/expiry) instead of recurring stream/periodic schedules.
> 
> Implements full snap support for allowances: new permission definitions (context build/apply, validation, confirmation UI rules), new delegation caveats using period-transfer enforcers with an *"unbounded"* `periodDuration` constant, and updates payee handling, supported rule-type metadata, permission offers, and permission-intro copy.
> 
> Updates existing-permissions and formatting paths to recognize the new `-allowance` category, render allowance fields (including token-metadata formatting for `allowanceAmount`), and extends tests plus the demo site UI/forms to create and submit allowance requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dee5a2c6011380c112514fb51f793111c9ab5b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->