### PR TITLE
fix: Redeem logic in 7715 snaps site doesn't work

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -196,7 +196,7 @@ const Index = () => {
 
     const feePerGas = await getFeePerGas();
 
-    const { accountMeta, context, delegationManager } = permissionResponse[0];
+    const { context, delegationManager } = permissionResponse[0];
 
     const publicClient = createPublicClient({
       chain: selectedChain,
@@ -213,12 +213,11 @@ const Index = () => {
               to,
               data,
               value,
-              permissionsContext: context,
+              permissionContext: context,
               delegationManager,
             },
           ],
           ...feePerGas,
-          accountMetadata: accountMeta,
         });
 
       const operationReceipt = await bundlerClient.waitForUserOperationReceipt({


### PR DESCRIPTION
## **Description**

Fixed a typo in the site's redeem permission handler that caused `UserOperation reverted during simulation with reason: 0x`.

- `permissionsContext` → `permissionContext` (SDK expects no 's')
- Removed `accountMetadata: accountMeta` (not a valid parameter on `sendUserOperationWithDelegation`)
- Removed unused `accountMeta` destructuring

The wrong property name caused the SDK's `isDelegatedCall()` check to fail, so the call was treated as a plain `execute()` instead of `redeemDelegations()`, which reverted because the delegate account has no direct execution authority.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to the site (`packages/site`)
2. Grant a `native-token-stream` permission
3. Click "Redeem Permission" — should no longer revert with `0x`

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to a single UI flow that only adjusts request parameter names/removes an invalid field to prevent redemption from reverting.
> 
> **Overview**
> Fixes the "Redeem Permission" flow in `packages/site` by sending the delegated call with the correct `permissionContext` field name (previously `permissionsContext`).
> 
> Removes the unused `accountMeta` extraction and stops passing `accountMetadata` to `sendUserOperationWithDelegation`, since it isn’t a supported parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1b122d0fd52425728acad9029ccec28dff12eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->