### PR TITLE
feat: Remove LogicalOrWrapper payee support for ERC20

### DIFF
--- a/packages/gator-permissions-snap/src/core/chainMetadata.ts
+++ b/packages/gator-permissions-snap/src/core/chainMetadata.ts
@@ -20,7 +20,6 @@ export type DelegationContracts = {
   allowedCalldataEnforcer: Hex;
   redeemerEnforcer: Hex;
   allowedTargetsEnforcer: Hex;
-  logicalOrWrapperEnforcer: Hex;
 };
 
 const contracts: DelegationContracts = {
@@ -39,7 +38,6 @@ const contracts: DelegationContracts = {
   allowedCalldataEnforcer: '0xc2b0d624c1c4319760C96503BA27C347F3260f55',
   redeemerEnforcer: '0xE144b0b2618071B4E56f746313528a669c7E65c5',
   allowedTargetsEnforcer: '0x7F20f61b1f09b08D970938F6fa563634d65c4EeB',
-  logicalOrWrapperEnforcer: '0xE1302607a3251AF54c3a6e69318d6aa07F5eB46c',
 };
 
 // derived from https://chainid.network/chains.json

--- a/packages/gator-permissions-snap/src/core/payeeCaveat.ts
+++ b/packages/gator-permissions-snap/src/core/payeeCaveat.ts
@@ -4,10 +4,11 @@ import type { Caveat, Hex } from '@metamask/delegation-core';
 import {
   createAllowedCalldataTerms,
   createAllowedTargetsTerms,
-  createLogicalOrWrapperTerms,
 } from '@metamask/delegation-core';
+import { InvalidInputError } from '@metamask/snaps-sdk';
 
 import type { DelegationContracts } from './chainMetadata';
+import { MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR } from '../permissions/validation';
 
 const ERC20_PERMISSION_TYPES = new Set([
   'erc20-token-stream',
@@ -18,8 +19,6 @@ const NATIVE_PERMISSION_TYPES = new Set([
   'native-token-stream',
   'native-token-periodic',
 ]);
-
-const EMPTY_ARGS = new Uint8Array();
 
 /**
  * Pads an Ethereum address to 32 bytes (left-padded with zeros).
@@ -71,7 +70,7 @@ function buildNativePayeeCaveat(
  * Appends payee-restricting caveats when the permission request includes a payee rule.
  *
  * For native token permissions, allowedTargetsEnforcer supports multiple targets directly.
- * For ERC-20 permissions, multiple addresses are wrapped in a LogicalOrWrapperEnforcer.
+ * For ERC-20 permissions, allowedCalldataEnforcer supports one target.
  *
  * @param options - Arguments for appending the caveat.
  * @param options.rules - Resolved permission request rules from the grant flow.
@@ -106,17 +105,7 @@ export function appendPayeeCaveatIfPresent({
   }
 
   if (isErc20 && rawAddresses.length > 1) {
-    const caveatGroups = rawAddresses.map((address) => {
-      const caveat = buildErc20PayeeCaveat(address, contracts);
-      return [{ ...caveat, args: EMPTY_ARGS }];
-    });
-
-    caveats.push({
-      enforcer: contracts.logicalOrWrapperEnforcer,
-      terms: createLogicalOrWrapperTerms({ caveatGroups }),
-      args: '0x',
-    });
-    return;
+    throw new InvalidInputError(MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR);
   }
 
   const payeeCaveat = isErc20

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenPeriodic/validation.ts
@@ -36,7 +36,7 @@ function validatePermissionData(
 
   validateStartTime(startTime, rules);
   validateRedeemerRule(rules);
-  validatePayeeRule(rules);
+  validatePayeeRule(rules, { allowMultiplePayees: false });
 
   return true;
 }

--- a/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/erc20TokenStream/validation.ts
@@ -57,7 +57,7 @@ function validatePermissionData(
 
   validateStartTime(startTime, rules);
   validateRedeemerRule(rules);
-  validatePayeeRule(rules);
+  validatePayeeRule(rules, { allowMultiplePayees: false });
 
   return true;
 }

--- a/packages/gator-permissions-snap/src/permissions/validation.ts
+++ b/packages/gator-permissions-snap/src/permissions/validation.ts
@@ -3,6 +3,9 @@ import { extractDescriptorName } from '@metamask/7715-permissions-shared/utils';
 import type { Hex } from '@metamask/delegation-core';
 import { InvalidInputError } from '@metamask/snaps-sdk';
 
+export const MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR =
+  'Multiple payee addresses are not currently supported for ERC20 permissions.';
+
 /**
  * Validates a hex integer value with configurable constraints.
  * @param params - The validation parameters.
@@ -69,10 +72,17 @@ export function validateRedeemerRule(
 /**
  * Validates the payee rule, if present, has a non-empty addresses array.
  * @param rules - The rules of the permission request.
+ * @param options - Payee validation options.
+ * @param options.allowMultiplePayees - Whether more than one payee address is supported.
  * @throws {InvalidInputError} If a payee rule exists with missing or empty addresses.
  */
 export function validatePayeeRule(
   rules: PermissionRequest['rules'] | undefined,
+  {
+    allowMultiplePayees = true,
+  }: {
+    allowMultiplePayees?: boolean;
+  } = {},
 ): void {
   const payeeRule = rules?.find(
     (rule) => extractDescriptorName(rule.type) === 'payee',
@@ -86,6 +96,10 @@ export function validatePayeeRule(
     throw new InvalidInputError(
       'Invalid payee rule: must include a non-empty addresses array',
     );
+  }
+
+  if (!allowMultiplePayees && addresses.length > 1) {
+    throw new InvalidInputError(MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR);
   }
 }
 

--- a/packages/gator-permissions-snap/test/core/chainMetadata.test.ts
+++ b/packages/gator-permissions-snap/test/core/chainMetadata.test.ts
@@ -35,7 +35,6 @@ describe('chainMetadata', () => {
         allowedCalldataEnforcer: expect.any(String),
         redeemerEnforcer: expect.any(String),
         allowedTargetsEnforcer: expect.any(String),
-        logicalOrWrapperEnforcer: expect.any(String),
       },
       name: expect.any(String),
       explorerUrl: expect.any(String),
@@ -105,7 +104,6 @@ describe('chainMetadata', () => {
           'allowedCalldataEnforcer',
           'redeemerEnforcer',
           'allowedTargetsEnforcer',
-          'logicalOrWrapperEnforcer',
         ];
 
         const metadata = getChainMetadata({ chainId: 11155111 }); // Sepolia

--- a/packages/gator-permissions-snap/test/core/payeeCaveat.test.ts
+++ b/packages/gator-permissions-snap/test/core/payeeCaveat.test.ts
@@ -2,10 +2,10 @@ import type { Caveat, Hex } from '@metamask/delegation-core';
 import {
   createAllowedCalldataTerms,
   createAllowedTargetsTerms,
-  createLogicalOrWrapperTerms,
 } from '@metamask/delegation-core';
 
 import { appendPayeeCaveatIfPresent } from '../../src/core/payeeCaveat';
+import { MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR } from '../../src/permissions/validation';
 
 const MOCK_CONTRACTS = {
   delegationManager: '0x0000000000000000000000000000000000000001' as Hex,
@@ -26,12 +26,10 @@ const MOCK_CONTRACTS = {
   allowedCalldataEnforcer: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Hex,
   redeemerEnforcer: '0x000000000000000000000000000000000000000c' as Hex,
   allowedTargetsEnforcer: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Hex,
-  logicalOrWrapperEnforcer: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' as Hex,
 };
 
 const PAYEE_ADDRESS_1 = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as Hex;
 const PAYEE_ADDRESS_2 = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' as Hex;
-const EMPTY_ARGS = new Uint8Array();
 
 /**
  * Pads an Ethereum address to 32 bytes (left-padded with zeros).
@@ -117,49 +115,23 @@ describe('appendPayeeCaveatIfPresent', () => {
       },
     );
 
-    it('wraps multiple payees in logicalOrWrapperEnforcer for ERC-20', () => {
+    it('throws for multiple ERC-20 payees', () => {
       const caveats: Caveat[] = [];
-      appendPayeeCaveatIfPresent({
-        rules: [
-          {
-            type: 'payee',
-            data: { addresses: [PAYEE_ADDRESS_1, PAYEE_ADDRESS_2] },
-          },
-        ],
-        contracts: MOCK_CONTRACTS,
-        caveats,
-        permissionType: 'erc20-token-stream',
-      });
-
-      expect(caveats).toHaveLength(1);
-      expect(caveats[0].enforcer).toBe(MOCK_CONTRACTS.logicalOrWrapperEnforcer);
-      expect(caveats[0].terms).toStrictEqual(
-        createLogicalOrWrapperTerms({
-          caveatGroups: [
-            [
-              {
-                enforcer: MOCK_CONTRACTS.allowedCalldataEnforcer,
-                terms: createAllowedCalldataTerms({
-                  startIndex: 4,
-                  value: padTo32Bytes(PAYEE_ADDRESS_1),
-                }),
-                args: EMPTY_ARGS,
-              },
-            ],
-            [
-              {
-                enforcer: MOCK_CONTRACTS.allowedCalldataEnforcer,
-                terms: createAllowedCalldataTerms({
-                  startIndex: 4,
-                  value: padTo32Bytes(PAYEE_ADDRESS_2),
-                }),
-                args: EMPTY_ARGS,
-              },
-            ],
+      expect(() =>
+        appendPayeeCaveatIfPresent({
+          rules: [
+            {
+              type: 'payee',
+              data: { addresses: [PAYEE_ADDRESS_1, PAYEE_ADDRESS_2] },
+            },
           ],
+          contracts: MOCK_CONTRACTS,
+          caveats,
+          permissionType: 'erc20-token-stream',
         }),
-      );
-      expect(caveats[0].args).toBe('0x');
+      ).toThrow(MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR);
+
+      expect(caveats).toHaveLength(0);
     });
   });
 

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenPeriodic/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenPeriodic/validation.test.ts
@@ -4,6 +4,7 @@ import { bigIntToHex } from '@metamask/utils';
 import { TimePeriod } from '../../../src/core/types';
 import type { Erc20TokenPeriodicPermissionRequest } from '../../../src/permissions/erc20TokenPeriodic/types';
 import { parseAndValidatePermission } from '../../../src/permissions/erc20TokenPeriodic/validation';
+import { MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR } from '../../../src/permissions/validation';
 import { TIME_PERIOD_TO_SECONDS } from '../../../src/utils/time';
 import { parseUnits } from '../../../src/utils/value';
 
@@ -55,6 +56,49 @@ describe('erc20TokenPeriodic:validation', () => {
       expect(() =>
         parseAndValidatePermission(missingExpiryRequest as any),
       ).not.toThrow();
+    });
+
+    describe('payee rule validation', () => {
+      it('allows one payee', () => {
+        const singlePayeeRequest = {
+          ...validPermissionRequest,
+          rules: [
+            ...validPermissionRequest.rules,
+            {
+              type: 'payee',
+              data: {
+                addresses: ['0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'],
+              },
+            },
+          ],
+        };
+
+        expect(() =>
+          parseAndValidatePermission(singlePayeeRequest),
+        ).not.toThrow();
+      });
+
+      it('throws for multiple payees', () => {
+        const multiPayeeRequest = {
+          ...validPermissionRequest,
+          rules: [
+            ...validPermissionRequest.rules,
+            {
+              type: 'payee',
+              data: {
+                addresses: [
+                  '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+                  '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+                ],
+              },
+            },
+          ],
+        };
+
+        expect(() => parseAndValidatePermission(multiPayeeRequest)).toThrow(
+          MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR,
+        );
+      });
     });
 
     it('should throw for invalid permission type', () => {

--- a/packages/gator-permissions-snap/test/permissions/erc20TokenStream/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/erc20TokenStream/validation.test.ts
@@ -3,6 +3,7 @@ import { bigIntToHex } from '@metamask/utils';
 
 import type { Erc20TokenStreamPermissionRequest } from '../../../src/permissions/erc20TokenStream/types';
 import { parseAndValidatePermission } from '../../../src/permissions/erc20TokenStream/validation';
+import { MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR } from '../../../src/permissions/validation';
 import { parseUnits } from '../../../src/utils/value';
 
 const tokenDecimals = 10;
@@ -58,6 +59,49 @@ describe('erc20TokenStream:validation', () => {
       expect(() =>
         parseAndValidatePermission(missingExpiryRequest as any),
       ).not.toThrow();
+    });
+
+    describe('payee rule validation', () => {
+      it('allows one payee', () => {
+        const singlePayeeRequest = {
+          ...validPermissionRequest,
+          rules: [
+            ...validPermissionRequest.rules,
+            {
+              type: 'payee',
+              data: {
+                addresses: ['0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'],
+              },
+            },
+          ],
+        };
+
+        expect(() =>
+          parseAndValidatePermission(singlePayeeRequest),
+        ).not.toThrow();
+      });
+
+      it('throws for multiple payees', () => {
+        const multiPayeeRequest = {
+          ...validPermissionRequest,
+          rules: [
+            ...validPermissionRequest.rules,
+            {
+              type: 'payee',
+              data: {
+                addresses: [
+                  '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+                  '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+                ],
+              },
+            },
+          ],
+        };
+
+        expect(() => parseAndValidatePermission(multiPayeeRequest)).toThrow(
+          MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR,
+        );
+      });
     });
 
     it('should throw for invalid permission type', () => {

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenPeriodic/validation.test.ts
@@ -52,6 +52,30 @@ describe('nativeTokenPeriodic:validation', () => {
       ).not.toThrow();
     });
 
+    describe('payee rule validation', () => {
+      it('allows multiple payees', () => {
+        const multiPayeeRequest = {
+          ...validPermissionRequest,
+          rules: [
+            ...validPermissionRequest.rules,
+            {
+              type: 'payee',
+              data: {
+                addresses: [
+                  '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+                  '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+                ],
+              },
+            },
+          ],
+        };
+
+        expect(() =>
+          parseAndValidatePermission(multiPayeeRequest),
+        ).not.toThrow();
+      });
+    });
+
     it('should throw for invalid permission type', () => {
       const invalidTypeRequest = {
         ...validPermissionRequest,

--- a/packages/gator-permissions-snap/test/permissions/nativeTokenStream/validation.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/nativeTokenStream/validation.test.ts
@@ -53,6 +53,30 @@ describe('nativeTokenStream:validation', () => {
       ).not.toThrow();
     });
 
+    describe('payee rule validation', () => {
+      it('allows multiple payees', () => {
+        const multiPayeeRequest = {
+          ...validPermissionRequest,
+          rules: [
+            ...validPermissionRequest.rules,
+            {
+              type: 'payee',
+              data: {
+                addresses: [
+                  '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+                  '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+                ],
+              },
+            },
+          ],
+        };
+
+        expect(() =>
+          parseAndValidatePermission(multiPayeeRequest),
+        ).not.toThrow();
+      });
+    });
+
     it('should throw for invalid permission type', () => {
       const invalidTypeRequest = {
         ...validPermissionRequest,

--- a/packages/site/src/components/permissions/RedemptionForm.tsx
+++ b/packages/site/src/components/permissions/RedemptionForm.tsx
@@ -1,0 +1,335 @@
+import { useEffect, useMemo, useState } from 'react';
+import { encodeFunctionData, isAddress } from 'viem';
+import type { Hex } from 'viem';
+
+import type { PermissionRequest } from './types';
+
+const ERC20_ABI = [
+  {
+    type: 'function',
+    name: 'transfer',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+  {
+    type: 'function',
+    name: 'approve',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'spender', type: 'address' },
+      { name: 'value', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+] as const;
+
+type Rule = {
+  type: string;
+  data?: {
+    addresses?: Hex[];
+  };
+};
+
+type PermissionResponse = {
+  permission: {
+    type: PermissionRequest['type'];
+    data?: {
+      tokenAddress?: Hex;
+      initialAmount?: string | null;
+      amountPerSecond?: string;
+      periodAmount?: string;
+    };
+  };
+  rules?: Rule[];
+};
+
+export type RedemptionCall = {
+  to: Hex;
+  data: Hex;
+  value: bigint;
+};
+
+type RedemptionFormProps = {
+  delegateAddress: Hex | undefined;
+  onChange: (call: RedemptionCall) => void;
+  permissionResponse: PermissionResponse;
+};
+
+const EMPTY_HEX = '0x' as const;
+
+/**
+ * Reads rule addresses from a permission response.
+ *
+ * @param rules - Permission response rules.
+ * @param type - Rule type to read.
+ * @returns Addresses from the matching rule, if present.
+ */
+function getRuleAddresses(rules: Rule[] | undefined, type: string): Hex[] {
+  const rule = rules?.find((entry) => entry.type === type);
+  const addresses = rule?.data?.addresses;
+  return Array.isArray(addresses) ? addresses : [];
+}
+
+/**
+ * Parses a raw integer input without throwing during form edits.
+ *
+ * @param value - Raw form input.
+ * @returns Parsed bigint, or zero for empty/invalid input.
+ */
+function parseBigIntInput(value: string): bigint {
+  try {
+    return value.trim() === '' ? 0n : BigInt(value);
+  } catch {
+    return 0n;
+  }
+}
+
+/**
+ * Gets a sensible redemption amount from the granted permission data.
+ *
+ * @param permission - Granted permission response.
+ * @returns Default raw unit amount for redemption.
+ */
+function getDefaultAmount(
+  permission: PermissionResponse['permission'],
+): string {
+  const { data, type } = permission;
+  if (type === 'native-token-periodic' || type === 'erc20-token-periodic') {
+    return data?.periodAmount ?? '0';
+  }
+
+  if (type === 'native-token-stream' || type === 'erc20-token-stream') {
+    const initialAmount = parseBigIntInput(data?.initialAmount ?? '0');
+    return initialAmount > 0n
+      ? (data?.initialAmount ?? '0')
+      : (data?.amountPerSecond ?? '0');
+  }
+
+  return '0';
+}
+
+/**
+ * Encodes ERC-20 transfer calldata when the recipient is valid.
+ *
+ * @param recipient - Transfer recipient.
+ * @param amount - Raw token amount.
+ * @returns Encoded calldata, or `0x` while the form is incomplete.
+ */
+function encodeTransferCalldata(recipient: Hex, amount: bigint): Hex {
+  if (!isAddress(recipient)) {
+    return EMPTY_HEX;
+  }
+
+  return encodeFunctionData({
+    abi: ERC20_ABI,
+    functionName: 'transfer',
+    args: [recipient, amount],
+  });
+}
+
+/**
+ * Encodes ERC-20 approval revocation calldata when the spender is valid.
+ *
+ * @param spender - Allowance spender to revoke.
+ * @returns Encoded calldata, or `0x` while the form is incomplete.
+ */
+function encodeApproveCalldata(spender: Hex): Hex {
+  if (!isAddress(spender)) {
+    return EMPTY_HEX;
+  }
+
+  return encodeFunctionData({
+    abi: ERC20_ABI,
+    functionName: 'approve',
+    args: [spender, 0n],
+  });
+}
+
+export const RedemptionForm = ({
+  delegateAddress,
+  onChange,
+  permissionResponse,
+}: RedemptionFormProps) => {
+  const { permission, rules } = permissionResponse;
+  const payeeAddresses = useMemo(
+    () => getRuleAddresses(rules, 'payee'),
+    [rules],
+  );
+  const [recipientAddress, setRecipientAddress] = useState<Hex>(
+    payeeAddresses[0] ?? EMPTY_HEX,
+  );
+  const [spenderAddress, setSpenderAddress] = useState<Hex>(
+    delegateAddress ?? EMPTY_HEX,
+  );
+  const [tokenAddress, setTokenAddress] = useState<Hex>(
+    permission.data?.tokenAddress ?? EMPTY_HEX,
+  );
+  const [amount, setAmount] = useState(getDefaultAmount(permission));
+
+  useEffect(() => {
+    setRecipientAddress(payeeAddresses[0] ?? EMPTY_HEX);
+    setSpenderAddress(delegateAddress ?? EMPTY_HEX);
+    setTokenAddress(permission.data?.tokenAddress ?? EMPTY_HEX);
+    setAmount(getDefaultAmount(permission));
+  }, [delegateAddress, payeeAddresses, permission]);
+
+  const value = parseBigIntInput(amount);
+  const isErc20Transfer =
+    permission.type === 'erc20-token-stream' ||
+    permission.type === 'erc20-token-periodic';
+  const isNativeTransfer =
+    permission.type === 'native-token-stream' ||
+    permission.type === 'native-token-periodic';
+  const isErc20Revocation = permission.type === 'erc20-token-revocation';
+
+  let generatedCalldata: Hex = EMPTY_HEX;
+  if (isErc20Transfer) {
+    generatedCalldata = encodeTransferCalldata(recipientAddress, value);
+  } else if (isErc20Revocation) {
+    generatedCalldata = encodeApproveCalldata(spenderAddress);
+  }
+
+  useEffect(() => {
+    if (isNativeTransfer) {
+      onChange({
+        to: recipientAddress,
+        data: EMPTY_HEX,
+        value,
+      });
+      return;
+    }
+
+    onChange({
+      to: tokenAddress,
+      data: generatedCalldata,
+      value: 0n,
+    });
+  }, [
+    generatedCalldata,
+    isNativeTransfer,
+    onChange,
+    recipientAddress,
+    tokenAddress,
+    value,
+  ]);
+
+  const handleRecipientChange = ({
+    target: { value: inputValue },
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setRecipientAddress(inputValue as Hex);
+  };
+
+  const handleSpenderChange = ({
+    target: { value: inputValue },
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setSpenderAddress(inputValue as Hex);
+  };
+
+  const handleTokenAddressChange = ({
+    target: { value: inputValue },
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setTokenAddress(inputValue as Hex);
+  };
+
+  const handleAmountChange = ({
+    target: { value: inputValue },
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setAmount(inputValue);
+  };
+
+  if (isErc20Revocation) {
+    return (
+      <>
+        <div>
+          <label htmlFor="redeemTokenAddress">Token:</label>
+          <input
+            type="text"
+            id="redeemTokenAddress"
+            name="redeemTokenAddress"
+            value={tokenAddress}
+            onChange={handleTokenAddressChange}
+            placeholder="0x..."
+          />
+        </div>
+        <div>
+          <label htmlFor="redeemSpenderAddress">Spender:</label>
+          <input
+            type="text"
+            id="redeemSpenderAddress"
+            name="redeemSpenderAddress"
+            value={spenderAddress}
+            onChange={handleSpenderChange}
+            placeholder="0x..."
+          />
+        </div>
+        <div>
+          <label htmlFor="redeemData">Calldata:</label>
+          <textarea
+            id="redeemData"
+            name="redeemData"
+            rows={3}
+            value={generatedCalldata}
+            readOnly
+          />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {isErc20Transfer && (
+        <div>
+          <label htmlFor="redeemTokenAddress">Token:</label>
+          <input
+            type="text"
+            id="redeemTokenAddress"
+            name="redeemTokenAddress"
+            value={tokenAddress}
+            onChange={handleTokenAddressChange}
+            placeholder="0x..."
+          />
+        </div>
+      )}
+      <div>
+        <label htmlFor="redeemRecipientAddress">
+          {isErc20Transfer ? 'Payee:' : 'Recipient:'}
+        </label>
+        <input
+          type="text"
+          id="redeemRecipientAddress"
+          name="redeemRecipientAddress"
+          value={recipientAddress}
+          onChange={handleRecipientChange}
+          placeholder="0x..."
+        />
+      </div>
+      <div>
+        <label htmlFor="redeemAmount">
+          {isNativeTransfer ? 'Value:' : 'Amount:'}
+        </label>
+        <input
+          type="text"
+          id="redeemAmount"
+          name="redeemAmount"
+          value={amount}
+          onChange={handleAmountChange}
+        />
+      </div>
+      <div>
+        <label htmlFor="redeemData">Calldata:</label>
+        <textarea
+          id="redeemData"
+          name="redeemData"
+          rows={3}
+          value={generatedCalldata}
+          readOnly
+        />
+      </div>
+    </>
+  );
+};

--- a/packages/site/src/components/permissions/index.ts
+++ b/packages/site/src/components/permissions/index.ts
@@ -3,3 +3,5 @@ export { ERC20TokenStreamForm } from './ERC20TokenStreamForm';
 export { NativeTokenPeriodicForm } from './NativeTokenPeriodicForm';
 export { ERC20TokenPeriodicForm } from './ERC20TokenPeriodicForm';
 export { ERC20TokenRevocationForm } from './ERC20TokenRevocationForm';
+export { RedemptionForm } from './RedemptionForm';
+export type { RedemptionCall } from './RedemptionForm';

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -25,7 +25,9 @@ import {
   NativeTokenPeriodicForm,
   ERC20TokenPeriodicForm,
   ERC20TokenRevocationForm,
+  RedemptionForm,
 } from '../components/permissions';
+import type { RedemptionCall } from '../components/permissions';
 import type {
   PermissionRequest,
   NativeTokenStreamPermissionRequest,
@@ -162,23 +164,14 @@ const Index = () => {
     setPermissionType(inputValue);
   };
 
-  const handleToChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setTo(inputValue as Hex);
-  };
-
-  const handleDataChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setData(inputValue as Hex);
-  };
-
-  const handleValueChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(BigInt(inputValue));
-  };
+  const handleRedemptionCallChange = useCallback(
+    ({ data: nextData, to: nextTo, value: nextValue }: RedemptionCall) => {
+      setTo(nextTo);
+      setData(nextData);
+      setValue(nextValue);
+    },
+    [],
+  );
 
   const handleRedeemPermission = async () => {
     if (!delegateAccount) {
@@ -403,42 +396,22 @@ const Index = () => {
             )}
             <StyledForm>
               <Title>Redeem Permission</Title>
-              <div>
-                <label htmlFor="to">To:</label>
-                <input
-                  type="text"
-                  id="to"
-                  name="to"
-                  value={to}
-                  onChange={handleToChange}
-                  placeholder="Recipient address"
-                />
-              </div>
-              <div>
-                <label htmlFor="data">Data:</label>
-                <input
-                  type="text"
-                  id="data"
-                  name="data"
-                  value={data}
-                  onChange={handleDataChange}
-                  placeholder="Transaction calldata (hex)"
-                />
-              </div>
-              <div>
-                <label htmlFor="value">Value:</label>
-                <input
-                  type="text"
-                  id="value"
-                  name="value"
-                  value={value.toString()}
-                  onChange={handleValueChange}
-                  placeholder="ETH value to send"
-                />
-              </div>
+              <RedemptionForm
+                delegateAddress={delegateAccount?.address}
+                permissionResponse={permissionResponse[0]}
+                onChange={handleRedemptionCallChange}
+              />
               <div>
                 <label>From:</label>
                 <div>{delegateAccount?.address}</div>
+              </div>
+              <div>
+                <label>To:</label>
+                <div>{to}</div>
+              </div>
+              <div>
+                <label>Value:</label>
+                <div>{value.toString()}</div>
               </div>
             </StyledForm>
             <CustomMessageButton

--- a/packages/site/src/styles.tsx
+++ b/packages/site/src/styles.tsx
@@ -92,9 +92,10 @@ export const StyledForm = styled.form`
 
   label {
     display: inline-block;
-    width: 9rem;
+    width: 12rem;
     margin-right: 1rem;
     font-weight: 500;
+    flex-shrink: 0;
   }
 
   textarea,
@@ -103,6 +104,7 @@ export const StyledForm = styled.form`
     border: 1px solid ${({ theme }) => theme.colors.border?.default};
     border-radius: 0.3rem;
     flex-grow: 1;
+    min-width: 0;
   }
 
   div {


### PR DESCRIPTION
## **Description**

Removes `LogicalOrWrapperEnforcer` support for ERC20 payee rules. ERC20 permissions now only support a single payee via `AllowedCalldataEnforcer`; requests with multiple ERC20 payees are rejected early with a clear unsupported-rule error.

Native token permissions continue to support single or multiple payees via `AllowedTargetsEnforcer`.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run focused validation and caveat tests:
   ~~~bash
   yarn workspace @metamask/gator-permissions-snap test --runTestsByPath test/core/payeeCaveat.test.ts test/core/chainMetadata.test.ts test/permissions/erc20TokenStream/validation.test.ts test/permissions/erc20TokenPeriodic/validation.test.ts test/permissions/nativeTokenStream/validation.test.ts test/permissions/nativeTokenPeriodic/validation.test.ts
   ~~~
2. Confirm ERC20 multi-payee requests throw the unsupported-rule error.
3. Confirm native token multi-payee requests still pass validation.

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A
<img width="689" height="1023" alt="PixPin_2026-05-06_10-04-44" src="https://github.com/user-attachments/assets/c1787bcb-62f4-4afc-9d6d-7580d4482c0d" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission validation/caveat generation to hard-reject multi-payee ERC20 requests, which can affect existing clients and enforcement behavior. Adds a new redemption form that auto-generates calldata/value, introducing moderate UI/encoding risk.
> 
> **Overview**
> **ERC-20 payee handling is simplified:** multi-payee `payee` rules are no longer wrapped via `LogicalOrWrapperEnforcer`; ERC-20 permissions now only accept a single payee and throw `MULTIPLE_ERC20_PAYEES_UNSUPPORTED_ERROR` during both caveat construction (`appendPayeeCaveatIfPresent`) and ERC-20 permission validation.
> 
> **Contract metadata is updated** to drop the `logicalOrWrapperEnforcer` address/typing, and tests are rewritten/expanded to assert the new single-payee constraint for ERC-20 while keeping multi-payee support for native-token permissions.
> 
> **Site redemption UX is improved:** adds a `RedemptionForm` that derives default recipients/amounts from the granted permission and auto-encodes ERC-20 `transfer`/`approve(0)` calldata, replacing manual `to`/`data`/`value` inputs and tweaking form styling for better layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72dff1f092f879c2e25a0a34f1ed5575530a9879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->