### PR TITLE
feat: Adds the ability to decode permission context in development site

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -1,5 +1,10 @@
+import { getSmartAccountsEnvironment } from '@metamask/smart-accounts-kit';
 import { erc7715ProviderActions } from '@metamask/smart-accounts-kit/actions';
 import type { RequestExecutionPermissionsParameters } from '@metamask/smart-accounts-kit/actions';
+import {
+  decodeCaveat,
+  decodeDelegations,
+} from '@metamask/smart-accounts-kit/utils';
 import { useCallback, useMemo, useState } from 'react';
 import {
   createClient,
@@ -134,6 +139,7 @@ const Index = () => {
     useState<PermissionRequest | null>(null);
   const [permissionResponse, setPermissionResponse] = useState<any>(null);
   const [isCopied, setIsCopied] = useState(false);
+  const [decodedIsCopied, setDecodedIsCopied] = useState(false);
   const [supportedPermissionsResponse, setSupportedPermissionsResponse] =
     useState<any>(null);
   const [grantedPermissionsResponse, setGrantedPermissionsResponse] =
@@ -147,6 +153,48 @@ const Index = () => {
   const [pendingPermissionRequests, setPendingPermissionRequests] = useState<
     Set<string>
   >(new Set());
+
+  const decodedPermissionContext = useMemo(() => {
+    if (!Array.isArray(permissionResponse)) {
+      return null;
+    }
+
+    return permissionResponse.map((responseEntry) => {
+      const permissionContext = responseEntry?.context;
+
+      if (!permissionContext) {
+        return [];
+      }
+
+      try {
+        const delegations = decodeDelegations(permissionContext as Hex);
+        const responseChainId =
+          typeof responseEntry?.chainId === 'number'
+            ? responseEntry.chainId
+            : Number(responseEntry?.chainId);
+        const environment = getSmartAccountsEnvironment(
+          Number.isNaN(responseChainId) ? selectedChain.id : responseChainId,
+        );
+        const decodedDelegations = delegations.map((delegation) => ({
+          ...delegation,
+          caveats: (delegation.caveats ?? []).map((caveat) => {
+            try {
+              return decodeCaveat({
+                caveat,
+                environment,
+              });
+            } catch {
+              return caveat;
+            }
+          }),
+        }));
+
+        return decodedDelegations;
+      } catch {
+        return [];
+      }
+    });
+  }, [permissionResponse, selectedChain.id]);
 
   const handleChainChange = ({
     target: { value: inputValue },
@@ -307,6 +355,20 @@ const Index = () => {
     }
   };
 
+  const handleCopyDecodedToClipboard = () => {
+    if (decodedPermissionContext) {
+      navigator.clipboard
+        .writeText(stringifyWithBigInt(decodedPermissionContext))
+        .then(() => {
+          setDecodedIsCopied(true);
+          setTimeout(() => setDecodedIsCopied(false), 2000);
+        })
+        .catch((clipboardError) => {
+          console.error('Failed to copy: ', clipboardError);
+        });
+    }
+  };
+
   const handleGetSupportedPermissions = async () => {
     setPermissionResponseError(null);
     try {
@@ -421,20 +483,35 @@ const Index = () => {
             />
           </Box>
         )}
-        {metaMaskClient && (
+        {metaMaskClient && permissionResponse && (
           <Box style={{ position: 'relative' }}>
-            {permissionResponse && (
-              <ResponseContainer>
-                <Title>Permission Response</Title>
-                <CopyButton
-                  onClick={handleCopyToClipboard}
-                  title={'Copy to clipboard'}
-                >
-                  {isCopied ? '✅' : '📝'}
-                </CopyButton>
-                <pre>{stringifyWithBigInt(permissionResponse)}</pre>
-              </ResponseContainer>
-            )}
+            <ResponseContainer>
+              <Title>Permission Response</Title>
+              <CopyButton
+                onClick={handleCopyToClipboard}
+                title={'Copy to clipboard'}
+              >
+                {isCopied ? '✅' : '📝'}
+              </CopyButton>
+              <pre>{stringifyWithBigInt(permissionResponse)}</pre>
+              {decodedPermissionContext && (
+                <details style={{ marginTop: '1rem' }}>
+                  <summary>Decoded Permission Context</summary>
+                  <CopyButton
+                    onClick={handleCopyDecodedToClipboard}
+                    title={'Copy to clipboard'}
+                    style={{ position: 'relative', float: 'right' }}
+                  >
+                    {decodedIsCopied ? '✅' : '📝'}
+                  </CopyButton>
+                  <pre>{stringifyWithBigInt(decodedPermissionContext)}</pre>
+                </details>
+              )}
+            </ResponseContainer>
+          </Box>
+        )}
+        {metaMaskClient && (
+          <Box>
             <StyledForm>
               <div>
                 <label htmlFor="chainSelector">Chain:</label>


### PR DESCRIPTION
## **Description**

Adds a developer QOL feature, displaying the decoded permission context. Where a caveat successfully decodes, we show the caveat config object, otherwise the full caveat struct.

## **Screenshots/Recordings**

<img width="697" height="607" alt="image" src="https://github.com/user-attachments/assets/50e041e6-95af-431e-9cfa-7e1f2022c7ac" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: development-site-only UI/QOL changes that decode and render existing permission response data without affecting snap or transaction execution logic.
> 
> **Overview**
> Adds a **Decoded Permission Context** view to the dev site permission response panel by decoding each response entry’s `context` via `decodeDelegations` and best-effort `decodeCaveat` using the chain-derived smart accounts environment.
> 
> Updates the UI to show this decoded output under a collapsible `details` section with its own copy-to-clipboard button/state, while still rendering the original raw `permissionResponse`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4403be798fb079ab75d2a29231ffd109597169e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->