### PR TITLE
chore: bump yarn from 4.10.1 to 4.14.1

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+approvedGitRepositories: []
+
 compressionLevel: mixed
 
 enableGlobalCache: false

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.39.0"
   },
-  "packageManager": "yarn@4.10.1",
+  "packageManager": "yarn@4.14.1",
   "engines": {
     "node": "^20 || >=22"
   },

--- a/packages/gator-permissions-snap/package.json
+++ b/packages/gator-permissions-snap/package.json
@@ -83,7 +83,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.39.0"
   },
-  "packageManager": "yarn@4.10.1",
+  "packageManager": "yarn@4.14.1",
   "engines": {
     "node": "^20 || >=22"
   },

--- a/packages/permissions-kernel-snap/package.json
+++ b/packages/permissions-kernel-snap/package.json
@@ -78,7 +78,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.39.0"
   },
-  "packageManager": "yarn@4.10.1",
+  "packageManager": "yarn@4.14.1",
   "engines": {
     "node": "^20 || >=22"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -59,7 +59,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.39.0"
   },
-  "packageManager": "yarn@4.10.1",
+  "packageManager": "yarn@4.14.1",
   "engines": {
     "node": "^20 || >=22"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@adraffy/ens-normalize@npm:1.10.1":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Upgrades yarn from 4.10.1 to 4.14.1 to take advantage of `approvedGitRepositories`.

## 🔄 What Changed?

- Upgrades yarn from 4.10.1 to 4.14.1 in root `package.json`
- Updates `packageManager` field in all workspace packages:
  - `@metamask/permissions-kernel-snap`
  - `@metamask/gator-permissions-snap`
  - `@metamask/7715-permissions-shared`
- Adds `approvedGitRepositories` to `.yarnrc.yml` with empty array
- Updates `yarn.lock` with new yarn version metadata

## 🚀 Why?

By enforcing no-git-dependencies, we close a security vulnerability where transient dependencies can be added to a package, resulting in unverified code being downloaded.

Any dependencies that are required via git may be added by including the glob in `approvedGitRepositories` in `.yarnrc.yml`.

## 🧪 How to Test?

```bash
❯ yarn add typanion@git@github.com/arcanis/typanion.git
➤ YN0000: · Yarn 4.14.1
➤ YN0000: ┌ Resolution step
➤ YN0080: │ typanion@git@github.com/arcanis/typanion.git: Request to 'ssh://git@github.com/arcanis/typanion.git' has been blocked because it doesn't match any of the patterns in 'approvedGitRepositories'
➤ YN0000: └ Completed
➤ YN0000: · Failed with errors in 0s 109ms
```

The command should fail with the error above, confirming that git dependencies are now blocked.

## ⚠️ Breaking Changes

- [X] No breaking changes

## 🔗 Related

Same change as https://github.com/MetaMask/smart-accounts-kit/pull/230
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C089Z7KQPS9/p1778623548318919?thread_ts=1778623548.318919&cid=C089Z7KQPS9)

<div><a href="https://cursor.com/agents/bc-d1a63957-3bc1-581d-b73b-f7c151761edd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1a63957-3bc1-581d-b73b-f7c151761edd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

