### PR TITLE
fix: Ensure once the dialog is closed, it stays closed

### DIFF
--- a/packages/gator-permissions-snap/src/core/dialogInterface.ts
+++ b/packages/gator-permissions-snap/src/core/dialogInterface.ts
@@ -13,6 +13,8 @@ export class DialogInterface {
 
   #isDialogShown = false;
 
+  #isClosed = false;
+
   #onDialogClose: (() => void) | undefined;
 
   constructor(snap: SnapsProvider) {
@@ -23,12 +25,17 @@ export class DialogInterface {
    * Shows content in the dialog interface.
    * Creates interface on first call, updates on subsequent calls.
    * Shows dialog on first call, no-ops on subsequent calls.
+   * After the dialog is closed, subsequent calls become no-ops and never recreate the interface.
    * Registers close handler if provided (latest handler wins).
    * @param ui - The UI content to display.
    * @param onClose - Optional callback when dialog is closed by user (X button).
    * @returns The interface ID.
    */
   async show(ui: JSX.Element, onClose?: () => void): Promise<string> {
+    if (this.#isClosed) {
+      return this.#interfaceId as string;
+    }
+
     if (this.#interfaceId) {
       await this.#snap.request({
         method: 'snap_updateInterface',
@@ -58,6 +65,10 @@ export class DialogInterface {
         .catch(() => {
           // Dialog closed with error, treat as user cancel
           this.#onDialogClose?.();
+        })
+        .finally(() => {
+          this.#isDialogShown = false;
+          this.#isClosed = true;
         });
     }
 
@@ -105,16 +116,16 @@ export class DialogInterface {
    * Callers in confirmation.tsx do not catch errors, so this method does not throw.
    */
   async close(): Promise<void> {
+    if (this.#isClosed || !this.#interfaceId) {
+      return;
+    }
+
     const MAX_ATTEMPTS = 3;
 
     const cleanup = (): void => {
-      this.#interfaceId = undefined;
       this.#isDialogShown = false;
+      this.#isClosed = true;
     };
-
-    if (!this.#interfaceId) {
-      return;
-    }
 
     const id = this.#interfaceId;
 

--- a/packages/gator-permissions-snap/src/core/dialogInterface.ts
+++ b/packages/gator-permissions-snap/src/core/dialogInterface.ts
@@ -11,8 +11,6 @@ export class DialogInterface {
 
   #interfaceId: string | undefined;
 
-  #isDialogShown = false;
-
   #isClosed = false;
 
   #onDialogClose: (() => void) | undefined;
@@ -24,7 +22,7 @@ export class DialogInterface {
   /**
    * Shows content in the dialog interface.
    * Creates interface on first call, updates on subsequent calls.
-   * Shows dialog on first call, no-ops on subsequent calls.
+   * Shows dialog only when creating the interface.
    * After the dialog is closed, subsequent calls become no-ops and never recreate the interface.
    * Registers close handler if provided (latest handler wins).
    * @param ui - The UI content to display.
@@ -46,14 +44,7 @@ export class DialogInterface {
         method: 'snap_createInterface',
         params: { ui, context: {} },
       });
-    }
 
-    if (onClose) {
-      this.#onDialogClose = onClose;
-    }
-
-    if (!this.#isDialogShown) {
-      this.#isDialogShown = true;
       this.#snap
         .request({ method: 'snap_dialog', params: { id: this.#interfaceId } })
         .then((result) => {
@@ -67,9 +58,12 @@ export class DialogInterface {
           this.#onDialogClose?.();
         })
         .finally(() => {
-          this.#isDialogShown = false;
           this.#isClosed = true;
         });
+    }
+
+    if (onClose) {
+      this.#onDialogClose = onClose;
     }
 
     return this.#interfaceId;
@@ -123,7 +117,6 @@ export class DialogInterface {
     const MAX_ATTEMPTS = 3;
 
     const cleanup = (): void => {
-      this.#isDialogShown = false;
       this.#isClosed = true;
     };
 

--- a/packages/gator-permissions-snap/test/core/dialogInterface.test.tsx
+++ b/packages/gator-permissions-snap/test/core/dialogInterface.test.tsx
@@ -210,7 +210,7 @@ describe('DialogInterface', () => {
   describe('close', () => {
     const mockInterfaceId = 'test-interface-123';
 
-    it('should resolve the interface and clear state on first attempt', async () => {
+    it('should resolve the interface on first attempt', async () => {
       mockSnapsProvider.request.mockImplementation(async (params: any) => {
         if (params.method === 'snap_createInterface') {
           return mockInterfaceId;
@@ -234,7 +234,7 @@ describe('DialogInterface', () => {
           value: {},
         },
       });
-      expect(dialogInterface.interfaceId).toBeUndefined();
+      expect(dialogInterface.interfaceId).toBe(mockInterfaceId);
     });
 
     it('should be safe to call when no interface exists', async () => {
@@ -260,10 +260,10 @@ describe('DialogInterface', () => {
 
       await dialogInterface.show(<Text>Test</Text>);
       await expect(dialogInterface.close()).resolves.toBeUndefined();
-      expect(dialogInterface.interfaceId).toBeUndefined();
+      expect(dialogInterface.interfaceId).toBe(mockInterfaceId);
     });
 
-    it('should retry and clear state when first close fails but second succeeds', async () => {
+    it('should retry close when first attempt fails but second succeeds', async () => {
       let resolveCallCount = 0;
       mockSnapsProvider.request.mockImplementation(async (params: any) => {
         if (params.method === 'snap_createInterface') {
@@ -289,7 +289,7 @@ describe('DialogInterface', () => {
       await dialogInterface.close();
 
       expect(resolveCallCount).toBe(2);
-      expect(dialogInterface.interfaceId).toBeUndefined();
+      expect(dialogInterface.interfaceId).toBe(mockInterfaceId);
     });
 
     it('should not throw when all close attempts fail', async () => {
@@ -313,7 +313,7 @@ describe('DialogInterface', () => {
       await expect(dialogInterface.close()).resolves.toBeUndefined();
     });
 
-    it('should clear state after exhausting retries when all close attempts fail', async () => {
+    it('should keep interface ID after exhausting retries when all close attempts fail', async () => {
       mockSnapsProvider.request.mockImplementation(async (params: any) => {
         if (params.method === 'snap_createInterface') {
           return mockInterfaceId;
@@ -335,7 +335,33 @@ describe('DialogInterface', () => {
 
       await dialogInterface.close();
 
-      expect(dialogInterface.interfaceId).toBeUndefined();
+      expect(dialogInterface.interfaceId).toBe(mockInterfaceId);
+    });
+
+    it('should no-op show after close without calling snap methods', async () => {
+      const testUi = <Text>Test content</Text>;
+      mockSnapsProvider.request.mockImplementation(async (params: any) => {
+        if (params.method === 'snap_createInterface') {
+          return mockInterfaceId;
+        }
+        if (params.method === 'snap_dialog') {
+          return new Promise(() => {});
+        }
+        if (params.method === 'snap_resolveInterface') {
+          return null;
+        }
+        return null;
+      });
+
+      await dialogInterface.show(testUi);
+      await dialogInterface.close();
+
+      mockSnapsProvider.request.mockClear();
+
+      const result = await dialogInterface.show(<Text>Late update</Text>);
+
+      expect(result).toBe(mockInterfaceId);
+      expect(mockSnapsProvider.request).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## **Description**

In some cases, after clicking "Grant", the Permission Picker remains open, while the Sign Permission confirmation opens behind the picker.

The root cause of the problem is asyncronous processes (such as resolving token prices) call `show()` on the `DialogInterface` after it has been closed, causing the dialog to be recreated through `snap_createInterface`.

`DialogInterface` is intended to be single purpose, we now enforce that.

## **Manual testing steps**

This is difficult to reproduce, as it's a race condition. I modified the development site to add 10 identical permissions to the request, and clicked "grant" as quickly as it would allow. This would mostly reproduce the issue at least once.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dialog lifecycle semantics so `show()` becomes a no-op after the dialog is closed, which could affect any callers expecting updates/reopens. Risk is moderated by updated unit tests covering close and post-close behavior.
> 
> **Overview**
> `DialogInterface` now treats the dialog as **single-use**: once the dialog is closed (user dismiss or `close()`), it marks itself closed and future `show()` calls **no-op** and never call `snap_createInterface`/`snap_updateInterface`/`snap_dialog` again.
> 
> `close()` is updated to return immediately if already closed and to **retain** the stored `interfaceId` while only flipping the closed flag; tests are updated accordingly and add coverage that `show()` does nothing after close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c434dc358629300172e84823ead115fc6f525764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->