### PR TITLE
feat: updates the token approval revocation summary copy

### DIFF
--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -323,7 +323,7 @@
       "message": "Revocation primitives"
     },
     "allApprovalRevocationPrimitivesLabel": {
-      "message": "All primitives"
+      "message": "All revocation primitives for ERC-20, ERC-1155, ERC-721."
     },
     "erc20ApproveRevocationLabel": {
       "message": "ERC-20 approve(spender, 0)"

--- a/packages/gator-permissions-snap/src/permissions/tokenApprovalRevocation/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/tokenApprovalRevocation/content.tsx
@@ -42,10 +42,7 @@ export async function createConfirmationContent({
         >
           <Box>
             {isAllPrimitivesEnabled ? (
-              <Box direction="horizontal">
-                <Icon name="full-circle" color="default" size="inherit" />
-                <Text>{t('allApprovalRevocationPrimitivesLabel')}</Text>
-              </Box>
+              <Text>{t('allApprovalRevocationPrimitivesLabel')}</Text>
             ) : (
               enabledPrimitives.map(({ key, labelKey }) => (
                 <Box direction="horizontal" key={key}>

--- a/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
@@ -107,7 +107,7 @@ describe('groupPermissionsByFromAddress', () => {
     const grouped = groupPermissionsByFromAddress([permission]);
 
     expect(grouped[fromA]?.[0]?.tokenApprovals?.value).toBe(
-      'All revocation primitives for ERC-20, ERC-1155, ERC-721',
+      'All revocation primitives for ERC-20, ERC-1155, ERC-721.',
     );
   });
 

--- a/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
+++ b/packages/gator-permissions-snap/test/core/existingPermissions/permissionFormatter.test.ts
@@ -106,7 +106,9 @@ describe('groupPermissionsByFromAddress', () => {
 
     const grouped = groupPermissionsByFromAddress([permission]);
 
-    expect(grouped[fromA]?.[0]?.tokenApprovals?.value).toBe('All primitives');
+    expect(grouped[fromA]?.[0]?.tokenApprovals?.value).toBe(
+      'All revocation primitives for ERC-20, ERC-1155, ERC-721',
+    );
   });
 
   it('lists only selected token approval revocation primitives', () => {

--- a/packages/gator-permissions-snap/test/permissions/tokenApprovalRevocation/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/tokenApprovalRevocation/content.test.ts
@@ -45,8 +45,10 @@ describe('tokenApprovalRevocation:content', () => {
       const rendered = JSON.stringify(content);
 
       expect(rendered).toContain('Revocation primitives');
-      expect(rendered).toContain('All primitives');
-      expect(rendered).toContain('full-circle');
+      expect(rendered).toContain(
+        'All revocation primitives for ERC-20, ERC-1155, ERC-721',
+      );
+      expect(rendered).not.toContain('full-circle');
       expect(rendered).toContain('token-approval-revocation-expiry');
     });
 
@@ -67,7 +69,9 @@ describe('tokenApprovalRevocation:content', () => {
       expect(rendered).toContain('Revocation primitives');
       expect(rendered).toContain('full-circle');
       expect(rendered).toContain('ERC-20 approve(spender, 0)');
-      expect(rendered).not.toContain('All primitives');
+      expect(rendered).not.toContain(
+        'All revocation primitives for ERC-20, ERC-1155, ERC-721',
+      );
     });
   });
 });

--- a/packages/gator-permissions-snap/test/permissions/tokenApprovalRevocation/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/tokenApprovalRevocation/content.test.ts
@@ -46,7 +46,7 @@ describe('tokenApprovalRevocation:content', () => {
 
       expect(rendered).toContain('Revocation primitives');
       expect(rendered).toContain(
-        'All revocation primitives for ERC-20, ERC-1155, ERC-721',
+        'All revocation primitives for ERC-20, ERC-1155, ERC-721.',
       );
       expect(rendered).not.toContain('full-circle');
       expect(rendered).toContain('token-approval-revocation-expiry');
@@ -70,7 +70,7 @@ describe('tokenApprovalRevocation:content', () => {
       expect(rendered).toContain('full-circle');
       expect(rendered).toContain('ERC-20 approve(spender, 0)');
       expect(rendered).not.toContain(
-        'All revocation primitives for ERC-20, ERC-1155, ERC-721',
+        'All revocation primitives for ERC-20, ERC-1155, ERC-721.',
       );
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3064,7 +3064,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-core@npm:^2.1.0, @metamask/delegation-core@npm:^2.2.1":
+"@metamask/delegation-core@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/delegation-core@npm:2.1.0"
+  dependencies:
+    "@metamask/abi-utils": "npm:^3.0.0"
+    "@metamask/utils": "npm:^11.4.0"
+    "@noble/hashes": "npm:^1.8.0"
+  checksum: 10/4b699987e178ce25a4ef726e61290636afd40e4d43cf856163d46f747ee9deb70641501b11e2d13dca9b7fa8bcae287058022929f3507868019e3802d3a52751
+  languageName: node
+  linkType: hard
+
+"@metamask/delegation-core@npm:^2.2.1":
   version: 2.2.1
   resolution: "@metamask/delegation-core@npm:2.2.1"
   dependencies:


### PR DESCRIPTION
## **Description**

Updates the token approval revocation summary copy to clarify that enabling all primitives covers ERC-20, ERC-1155, and ERC-721 revocation methods.

Also removes the bullet icon from the all-primitives summary while keeping bullet rows for individually selected revocation primitives.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn start`.
2. Open the site and request a `token-approval-revocation` permission with all revocation primitives enabled.
3. Confirm the review screen shows `All revocation primitives for ERC-20, ERC-1155, ERC-721.` without a bullet icon.
4. Request the permission again with only some primitives enabled.
5. Confirm the selected primitives still render as a bulleted list.

## **Screenshots/Recordings**


### **Before**

N/A

### **After**
<img width="424" height="1101" alt="image" src="https://github.com/user-attachments/assets/692ecc79-e378-4a54-945e-eb18f7a76e8c" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: copy/UI-only change to the token-approval-revocation confirmation summary, plus corresponding test and lockfile updates; no permission logic or security-sensitive behavior is modified.
> 
> **Overview**
> Updates the token approval revocation confirmation summary to use clearer copy (**"All revocation primitives for ERC-20, ERC-1155, ERC-721."**) and removes the bullet icon when *all* primitives are enabled (while keeping bulleted rows for individually selected primitives).
> 
> Adjusts existing-permissions formatting and content rendering tests to match the new string/icon behavior, and normalizes `yarn.lock` by splitting the combined `@metamask/delegation-core` entry into separate `^2.1.0` and `^2.2.1` resolutions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed1e7c5815bec06b27ca1476679155ba786ab306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->