### PR TITLE
fix: update icon for enabled approval revocation primitives

### DIFF
--- a/packages/gator-permissions-snap/src/permissions/tokenApprovalRevocation/content.tsx
+++ b/packages/gator-permissions-snap/src/permissions/tokenApprovalRevocation/content.tsx
@@ -46,7 +46,7 @@ export async function createConfirmationContent({
             ) : (
               enabledPrimitives.map(({ key, labelKey }) => (
                 <Box direction="horizontal" key={key}>
-                  <Icon name="full-circle" color="default" size="inherit" />
+                  <Icon name="minus" color="default" size="inherit" />
                   <Text>{t(labelKey)}</Text>
                 </Box>
               ))

--- a/packages/gator-permissions-snap/test/permissions/tokenApprovalRevocation/content.test.ts
+++ b/packages/gator-permissions-snap/test/permissions/tokenApprovalRevocation/content.test.ts
@@ -48,7 +48,7 @@ describe('tokenApprovalRevocation:content', () => {
       expect(rendered).toContain(
         'All revocation primitives for ERC-20, ERC-1155, ERC-721.',
       );
-      expect(rendered).not.toContain('full-circle');
+      expect(rendered).not.toContain('minus');
       expect(rendered).toContain('token-approval-revocation-expiry');
     });
 
@@ -67,7 +67,7 @@ describe('tokenApprovalRevocation:content', () => {
       const rendered = JSON.stringify(content);
 
       expect(rendered).toContain('Revocation primitives');
-      expect(rendered).toContain('full-circle');
+      expect(rendered).toContain('minus');
       expect(rendered).toContain('ERC-20 approve(spender, 0)');
       expect(rendered).not.toContain(
         'All revocation primitives for ERC-20, ERC-1155, ERC-721.',


### PR DESCRIPTION
## **Description**

Updates the token approval revocation primitive list styling so selected primitives use a minus icon instead of the filled circle icon.

The all-primitives summary remains plain text without a list icon.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn start`.
2. Open the site and request a `token-approval-revocation` permission with only some revocation primitives enabled.
3. Confirm the selected primitives render as a list with minus icons.
4. Request the permission again with all revocation primitives enabled.
5. Confirm the all-primitives summary remains plain text without a list icon.

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

<img width="402" height="326" alt="image" src="https://github.com/user-attachments/assets/31749a52-5752-4ea6-b160-5766bc9d5535" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps an icon in the confirmation content and updates snapshot-style assertions accordingly.
> 
> **Overview**
> Updates the token approval revocation confirmation UI so *individually enabled* revocation primitives render with a `minus` icon instead of `full-circle`, while the *all-primitives* case remains plain text.
> 
> Adjusts the associated `createConfirmationContent` tests to assert the new icon behavior (present for partial selection, absent when all primitives are enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c1715085e968e54865cdcf6e1772fa5b6a4aacf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->