### PR TITLE
Refactor snap site architecture and delegated execution error handling

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@metamask/7715-permission-types": "0.7.1",
     "@metamask/providers": "22.1.1",
-    "@metamask/smart-accounts-kit": "^1.5.0",
+    "@metamask/smart-accounts-kit": "^1.6.0",
     "@metamask/utils": "11.11.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/packages/site/src/components/ErrorAlert.tsx
+++ b/packages/site/src/components/ErrorAlert.tsx
@@ -1,0 +1,70 @@
+import { useMemo, useState } from 'react';
+import styled from 'styled-components';
+
+import { ErrorMessage } from '../styles';
+import { getErrorDisplay } from '../utils';
+
+type ErrorAlertProps = {
+  error: unknown;
+};
+
+const ErrorSummary = styled.p`
+  margin: 0;
+`;
+
+const DetailsButton = styled.button`
+  background-color: transparent;
+  border-color: ${({ theme }) => theme.colors.error?.default};
+  color: ${({ theme }) => theme.colors.error?.alternative};
+  margin-top: 1.2rem;
+  min-height: 3.6rem;
+  padding: 0.7rem 1rem;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.error?.muted};
+    border-color: ${({ theme }) => theme.colors.error?.default};
+    color: ${({ theme }) => theme.colors.error?.alternative};
+  }
+`;
+
+const ErrorDetails = styled.pre`
+  background-color: ${({ theme }) => theme.colors.background?.alternative};
+  border: 1px solid ${({ theme }) => theme.colors.border?.default};
+  border-radius: ${({ theme }) => theme.radii.button};
+  color: ${({ theme }) => theme.colors.text?.default};
+  font-family: ${({ theme }) => theme.fonts.code};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  line-height: 1.5;
+  margin: 1.2rem 0 0;
+  max-height: 28rem;
+  overflow: auto;
+  padding: 1.2rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+export const ErrorAlert = ({ error }: ErrorAlertProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { summary, details } = useMemo(() => getErrorDisplay(error), [error]);
+  const hasDetails = details !== summary;
+
+  return (
+    <ErrorMessage role="alert">
+      <ErrorSummary>
+        <b>An error happened:</b> {summary}
+      </ErrorSummary>
+      {hasDetails && (
+        <>
+          <DetailsButton
+            aria-expanded={isExpanded}
+            onClick={() => setIsExpanded((currentValue) => !currentValue)}
+            type="button"
+          >
+            {isExpanded ? 'Hide details' : 'Show details'}
+          </DetailsButton>
+          {isExpanded && <ErrorDetails>{details}</ErrorDetails>}
+        </>
+      )}
+    </ErrorMessage>
+  );
+};

--- a/packages/site/src/components/SnapConnectionCards.tsx
+++ b/packages/site/src/components/SnapConnectionCards.tsx
@@ -1,0 +1,64 @@
+import { ConnectButton, InstallMetaMaskButton } from './Buttons';
+import { Card } from './Card';
+
+type SnapConnectionCardsProps = {
+  isGatorSnapReady: boolean;
+  isKernelSnapReady: boolean;
+  isMetaMaskReady: boolean;
+  onRequestKernelSnap: () => Promise<void> | void;
+  onRequestPermissionSnap: () => Promise<void> | void;
+};
+
+export const SnapConnectionCards = ({
+  isGatorSnapReady,
+  isKernelSnapReady,
+  isMetaMaskReady,
+  onRequestKernelSnap,
+  onRequestPermissionSnap,
+}: SnapConnectionCardsProps) => (
+  <>
+    {!isMetaMaskReady && (
+      <Card
+        content={{
+          title: 'Install',
+          description:
+            'Snaps requires MetaMask to be installed. Install MetaMask to get started.',
+          button: <InstallMetaMaskButton />,
+        }}
+        fullWidth
+      />
+    )}
+
+    <Card
+      content={{
+        title: `${isKernelSnapReady ? 'Reconnect' : 'Connect'}(kernel)`,
+        description:
+          'Get started by connecting to and installing the kernel snap.',
+        button: (
+          <ConnectButton
+            onClick={onRequestKernelSnap}
+            disabled={!isMetaMaskReady}
+            $isReconnect={isKernelSnapReady}
+          />
+        ),
+      }}
+      disabled={!isMetaMaskReady}
+    />
+
+    <Card
+      content={{
+        title: `${isGatorSnapReady ? 'Reconnect' : 'Connect'}(provider)`,
+        description:
+          'Get started by connecting to and installing the permission provider snap.',
+        button: (
+          <ConnectButton
+            onClick={onRequestPermissionSnap}
+            disabled={!isMetaMaskReady}
+            $isReconnect={isGatorSnapReady}
+          />
+        ),
+      }}
+      disabled={!isMetaMaskReady}
+    />
+  </>
+);

--- a/packages/site/src/components/index.ts
+++ b/packages/site/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Buttons';
 export * from './Card';
+export * from './ErrorAlert';
 export * from './Footer';
 export * from './Header';
 export * from './MetaMask';

--- a/packages/site/src/components/index.ts
+++ b/packages/site/src/components/index.ts
@@ -5,4 +5,5 @@ export * from './Header';
 export * from './MetaMask';
 export * from './PoweredBy';
 export * from './SnapLogo';
+export * from './SnapConnectionCards';
 export * from './Toggle';

--- a/packages/site/src/components/permissions/PermissionQueriesPanel.tsx
+++ b/packages/site/src/components/permissions/PermissionQueriesPanel.tsx
@@ -1,0 +1,76 @@
+import { Box, CopyButton, ResponseContainer } from '../../styles';
+import { stringifyWithBigInt } from '../../utils';
+import { CustomMessageButton } from '../Buttons';
+import { Title } from '../Card';
+
+type PermissionQueriesPanelProps = {
+  grantedIsCopied: boolean;
+  grantedPermissionsResponse: unknown;
+  onCopyGrantedPermissions: () => void;
+  onCopySupportedPermissions: () => void;
+  onGetGrantedPermissions: () => void;
+  onGetSupportedPermissions: () => void;
+  supportedIsCopied: boolean;
+  supportedPermissionsResponse: unknown;
+};
+
+const permissionQueryActionsStyle = {
+  display: 'flex',
+  gap: '1rem',
+  marginTop: '1rem',
+  marginBottom: '1rem',
+};
+
+export const PermissionQueriesPanel = ({
+  grantedIsCopied,
+  grantedPermissionsResponse,
+  onCopyGrantedPermissions,
+  onCopySupportedPermissions,
+  onGetGrantedPermissions,
+  onGetSupportedPermissions,
+  supportedIsCopied,
+  supportedPermissionsResponse,
+}: PermissionQueriesPanelProps) => {
+  const hasSupportedPermissionsResponse = Boolean(supportedPermissionsResponse);
+  const hasGrantedPermissionsResponse = Boolean(grantedPermissionsResponse);
+
+  return (
+    <Box>
+      <Title>Permission Queries</Title>
+      <div style={permissionQueryActionsStyle}>
+        <CustomMessageButton
+          $text="Get Supported Permissions"
+          onClick={onGetSupportedPermissions}
+        />
+        <CustomMessageButton
+          $text="Get Granted Permissions"
+          onClick={onGetGrantedPermissions}
+        />
+      </div>
+      {hasSupportedPermissionsResponse && (
+        <ResponseContainer>
+          <Title>Supported Permissions</Title>
+          <CopyButton
+            onClick={onCopySupportedPermissions}
+            title={'Copy to clipboard'}
+          >
+            {supportedIsCopied ? '✅' : '📝'}
+          </CopyButton>
+          <pre>{stringifyWithBigInt(supportedPermissionsResponse)}</pre>
+        </ResponseContainer>
+      )}
+      {hasGrantedPermissionsResponse && (
+        <ResponseContainer style={{ marginTop: '1rem' }}>
+          <Title>Granted Permissions</Title>
+          <CopyButton
+            onClick={onCopyGrantedPermissions}
+            title={'Copy to clipboard'}
+          >
+            {grantedIsCopied ? '✅' : '📝'}
+          </CopyButton>
+          <pre>{stringifyWithBigInt(grantedPermissionsResponse)}</pre>
+        </ResponseContainer>
+      )}
+    </Box>
+  );
+};

--- a/packages/site/src/components/permissions/PermissionRequestPanel.tsx
+++ b/packages/site/src/components/permissions/PermissionRequestPanel.tsx
@@ -1,0 +1,112 @@
+import type { ChangeEvent } from 'react';
+import type { Chain } from 'viem';
+
+import { ERC20TokenAllowanceForm } from './ERC20TokenAllowanceForm';
+import { ERC20TokenPeriodicForm } from './ERC20TokenPeriodicForm';
+import { ERC20TokenStreamForm } from './ERC20TokenStreamForm';
+import { NativeTokenAllowanceForm } from './NativeTokenAllowanceForm';
+import { NativeTokenPeriodicForm } from './NativeTokenPeriodicForm';
+import { NativeTokenStreamForm } from './NativeTokenStreamForm';
+import { TokenApprovalRevocationForm } from './TokenApprovalRevocationForm';
+import type { PermissionRequest } from './types';
+import { Box, StyledForm } from '../../styles';
+import { CustomMessageButton } from '../Buttons';
+
+type PermissionRequestPanelProps = {
+  onChainChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  onFormChange: (request: PermissionRequest) => void;
+  onGrantPermissions: () => void;
+  onPermissionTypeChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  permissionType: PermissionRequest['type'];
+  selectedChain: Chain;
+  supportedChains: Chain[];
+};
+
+const selectStyle = {
+  padding: '0.8rem',
+  border: '1px solid',
+  borderRadius: '0.3rem',
+  flexGrow: 1,
+};
+
+const renderPermissionForm = (
+  permissionType: PermissionRequest['type'],
+  onFormChange: (request: PermissionRequest) => void,
+) => {
+  switch (permissionType) {
+    case 'native-token-stream':
+      return <NativeTokenStreamForm onChange={onFormChange} />;
+    case 'erc20-token-stream':
+      return <ERC20TokenStreamForm onChange={onFormChange} />;
+    case 'native-token-periodic':
+      return <NativeTokenPeriodicForm onChange={onFormChange} />;
+    case 'erc20-token-periodic':
+      return <ERC20TokenPeriodicForm onChange={onFormChange} />;
+    case 'native-token-allowance':
+      return <NativeTokenAllowanceForm onChange={onFormChange} />;
+    case 'erc20-token-allowance':
+      return <ERC20TokenAllowanceForm onChange={onFormChange} />;
+    case 'token-approval-revocation':
+      return <TokenApprovalRevocationForm onChange={onFormChange} />;
+    default:
+      return null;
+  }
+};
+
+export const PermissionRequestPanel = ({
+  onChainChange,
+  onFormChange,
+  onGrantPermissions,
+  onPermissionTypeChange,
+  permissionType,
+  selectedChain,
+  supportedChains,
+}: PermissionRequestPanelProps) => (
+  <Box>
+    <StyledForm>
+      <div>
+        <label htmlFor="chainSelector">Chain:</label>
+        <select
+          id="chainSelector"
+          name="chainSelector"
+          value={selectedChain.id}
+          onChange={onChainChange}
+          style={selectStyle}
+        >
+          {supportedChains.map((chain) => (
+            <option key={chain.id} value={chain.id}>
+              {chain.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="permissionType">Permission Type:</label>
+        <select
+          id="permissionType"
+          name="permissionType"
+          value={permissionType}
+          onChange={onPermissionTypeChange}
+          style={selectStyle}
+        >
+          <option value="native-token-stream">Native Token Stream</option>
+          <option value="erc20-token-stream">ERC20 Token Stream</option>
+          <option value="native-token-periodic">Native Token Periodic</option>
+          <option value="native-token-allowance">Native Token Allowance</option>
+          <option value="erc20-token-periodic">ERC20 Token Periodic</option>
+          <option value="erc20-token-allowance">ERC20 Token Allowance</option>
+          <option value="token-approval-revocation">
+            Token Approval Revocation
+          </option>
+        </select>
+      </div>
+
+      {renderPermissionForm(permissionType, onFormChange)}
+    </StyledForm>
+    <CustomMessageButton
+      $text="Grant Permission"
+      onClick={onGrantPermissions}
+    />
+  </Box>
+);

--- a/packages/site/src/components/permissions/PermissionResponsePanel.tsx
+++ b/packages/site/src/components/permissions/PermissionResponsePanel.tsx
@@ -1,0 +1,51 @@
+import { Box, CopyButton, ResponseContainer } from '../../styles';
+import { stringifyWithBigInt } from '../../utils';
+import { Title } from '../Card';
+
+type PermissionResponsePanelProps = {
+  decodedIsCopied: boolean;
+  decodedPermissionContext: unknown;
+  isCopied: boolean;
+  onCopyDecodedPermissionContext: () => void;
+  onCopyPermissionResponse: () => void;
+  permissionResponse: unknown;
+};
+
+export const PermissionResponsePanel = ({
+  decodedIsCopied,
+  decodedPermissionContext,
+  isCopied,
+  onCopyDecodedPermissionContext,
+  onCopyPermissionResponse,
+  permissionResponse,
+}: PermissionResponsePanelProps) => {
+  const hasDecodedPermissionContext = Boolean(decodedPermissionContext);
+
+  return (
+    <Box style={{ position: 'relative' }}>
+      <ResponseContainer>
+        <Title>Permission Response</Title>
+        <CopyButton
+          onClick={onCopyPermissionResponse}
+          title={'Copy to clipboard'}
+        >
+          {isCopied ? '✅' : '📝'}
+        </CopyButton>
+        <pre>{stringifyWithBigInt(permissionResponse)}</pre>
+        {hasDecodedPermissionContext && (
+          <details style={{ marginTop: '1rem' }}>
+            <summary>Decoded Permission Context</summary>
+            <CopyButton
+              onClick={onCopyDecodedPermissionContext}
+              title={'Copy to clipboard'}
+              style={{ position: 'relative', float: 'right' }}
+            >
+              {decodedIsCopied ? '✅' : '📝'}
+            </CopyButton>
+            <pre>{stringifyWithBigInt(decodedPermissionContext)}</pre>
+          </details>
+        )}
+      </ResponseContainer>
+    </Box>
+  );
+};

--- a/packages/site/src/components/permissions/RedeemPermissionPanel.tsx
+++ b/packages/site/src/components/permissions/RedeemPermissionPanel.tsx
@@ -1,0 +1,69 @@
+import type { ComponentProps } from 'react';
+import type { Hex } from 'viem';
+import type { UserOperationReceipt } from 'viem/account-abstraction';
+
+import { Box, ResponseContainer, StyledForm } from '../../styles';
+import { stringifyWithBigInt } from '../../utils';
+import { CustomMessageButton } from '../Buttons';
+import { Title } from '../Card';
+import { RedemptionForm } from './RedemptionForm';
+
+type RedemptionFormProps = ComponentProps<typeof RedemptionForm>;
+
+type RedeemPermissionPanelProps = {
+  delegateAddress: Hex | undefined;
+  isPending: boolean;
+  onRedeemPermission: () => void;
+  onRedemptionCallChange: RedemptionFormProps['onChange'];
+  permissionResponse: RedemptionFormProps['permissionResponse'];
+  receipt: UserOperationReceipt | null;
+  to: Hex;
+  value: bigint;
+};
+
+export const RedeemPermissionPanel = ({
+  delegateAddress,
+  isPending,
+  onRedeemPermission,
+  onRedemptionCallChange,
+  permissionResponse,
+  receipt,
+  to,
+  value,
+}: RedeemPermissionPanelProps) => (
+  <Box>
+    {receipt && (
+      <div style={{ marginTop: '1rem' }}>
+        <ResponseContainer>
+          <Title>User operation receipt</Title>
+          <pre>{stringifyWithBigInt(receipt)}</pre>
+        </ResponseContainer>
+      </div>
+    )}
+    <StyledForm>
+      <Title>Redeem Permission</Title>
+      <RedemptionForm
+        delegateAddress={delegateAddress}
+        permissionResponse={permissionResponse}
+        onChange={onRedemptionCallChange}
+      />
+      <div>
+        <label>From:</label>
+        <div>{delegateAddress}</div>
+      </div>
+      <div>
+        <label>To:</label>
+        <div>{to}</div>
+      </div>
+      <div>
+        <label>Value:</label>
+        <div>{value.toString()}</div>
+      </div>
+    </StyledForm>
+    <CustomMessageButton
+      $text="Redeem Permission"
+      onClick={onRedeemPermission}
+      disabled={isPending}
+    />
+  </Box>
+);

--- a/packages/site/src/components/permissions/RedemptionForm.tsx
+++ b/packages/site/src/components/permissions/RedemptionForm.tsx
@@ -317,7 +317,7 @@ function encodePermit2InvalidateNoncesCalldata(
   return encodeFunctionData({
     abi: PERMIT2_ABI,
     functionName: 'invalidateNonces',
-    args: [token, spender, parseBigIntInput(newNonce)],
+    args: [token, spender, Number(parseBigIntInput(newNonce))],
   });
 }
 

--- a/packages/site/src/components/permissions/index.ts
+++ b/packages/site/src/components/permissions/index.ts
@@ -7,3 +7,7 @@ export { ERC20TokenAllowanceForm } from './ERC20TokenAllowanceForm';
 export { TokenApprovalRevocationForm } from './TokenApprovalRevocationForm';
 export { RedemptionForm } from './RedemptionForm';
 export type { RedemptionCall } from './RedemptionForm';
+export { PermissionQueriesPanel } from './PermissionQueriesPanel';
+export { PermissionRequestPanel } from './PermissionRequestPanel';
+export { PermissionResponsePanel } from './PermissionResponsePanel';
+export { RedeemPermissionPanel } from './RedeemPermissionPanel';

--- a/packages/site/src/config/chains.ts
+++ b/packages/site/src/config/chains.ts
@@ -1,0 +1,33 @@
+import { extractChain } from 'viem';
+import type { Chain } from 'viem';
+import * as chains from 'viem/chains';
+
+const ALL_CHAINS = [...Object.values(chains)];
+
+const DEFAULT_CHAINS = [chains.sepolia];
+
+const supportedChainsString = import.meta.env.VITE_SUPPORTED_CHAINS;
+
+export const supportedChains: Chain[] = supportedChainsString
+  ? supportedChainsString.split(',').map((chainIdString) => {
+      const chainId = parseInt(chainIdString);
+      const chain = extractChain({
+        chains: ALL_CHAINS,
+        id: chainId as any,
+      });
+
+      if (!chain) {
+        throw new Error(`Chain ${chainId} not found`);
+      }
+
+      return chain;
+    })
+  : DEFAULT_CHAINS;
+
+const firstSupportedChain = supportedChains[0];
+
+if (!firstSupportedChain) {
+  throw new Error('No supported chains found.');
+}
+
+export const defaultSupportedChain: Chain = firstSupportedChain;

--- a/packages/site/src/config/index.ts
+++ b/packages/site/src/config/index.ts
@@ -1,1 +1,2 @@
 export * from './snap';
+export * from './chains';

--- a/packages/site/src/hooks/index.ts
+++ b/packages/site/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './useRequest';
 export * from './useRequestSnap';
 export * from './useDelegateAccount';
 export * from './useBundlerClient';
+export * from './useCopyToClipboard';

--- a/packages/site/src/hooks/useBundlerClient.ts
+++ b/packages/site/src/hooks/useBundlerClient.ts
@@ -1,7 +1,7 @@
 import { erc7710BundlerActions } from '@metamask/smart-accounts-kit/actions';
 import { useMemo } from 'react';
 import { createClient, http } from 'viem';
-import type { Chain } from 'viem';
+import type { Chain, Hex } from 'viem';
 import {
   createBundlerClient,
   createPaymasterClient,
@@ -31,6 +31,10 @@ type PimlicoRpcSchema = [
   },
 ];
 
+type DelegatedBundlerClient<TBundlerClient> = TBundlerClient & {
+  sendUserOperationWithDelegation: (args: unknown) => Promise<Hex>;
+};
+
 /**
  * Creates and manages bundler client for smart account interactions.
  *
@@ -53,11 +57,15 @@ export const useBundlerClient = ({
       transport,
     });
 
-    const bundlerClient = createBundlerClient({
+    const baseBundlerClient = createBundlerClient({
       transport,
       chain,
       paymaster: paymasterClient,
-    }).extend(erc7710BundlerActions());
+    });
+
+    const bundlerClient = baseBundlerClient.extend(
+      erc7710BundlerActions() as Parameters<typeof baseBundlerClient.extend>[0],
+    ) as unknown as DelegatedBundlerClient<typeof baseBundlerClient>;
 
     const pimlicoClient = createClient<
       typeof transport,

--- a/packages/site/src/hooks/useBundlerClient.ts
+++ b/packages/site/src/hooks/useBundlerClient.ts
@@ -1,7 +1,7 @@
 import { erc7710BundlerActions } from '@metamask/smart-accounts-kit/actions';
 import { useMemo } from 'react';
 import { createClient, http } from 'viem';
-import type { Chain, Hex } from 'viem';
+import type { Chain } from 'viem';
 import {
   createBundlerClient,
   createPaymasterClient,
@@ -31,10 +31,6 @@ type PimlicoRpcSchema = [
   },
 ];
 
-type DelegatedBundlerClient<TBundlerClient> = TBundlerClient & {
-  sendUserOperationWithDelegation: (args: unknown) => Promise<Hex>;
-};
-
 /**
  * Creates and manages bundler client for smart account interactions.
  *
@@ -63,9 +59,7 @@ export const useBundlerClient = ({
       paymaster: paymasterClient,
     });
 
-    const bundlerClient = baseBundlerClient.extend(
-      erc7710BundlerActions() as Parameters<typeof baseBundlerClient.extend>[0],
-    ) as unknown as DelegatedBundlerClient<typeof baseBundlerClient>;
+    const bundlerClient = baseBundlerClient.extend(erc7710BundlerActions());
 
     const pimlicoClient = createClient<
       typeof transport,

--- a/packages/site/src/hooks/useCopyToClipboard.ts
+++ b/packages/site/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState } from 'react';
+
+export const useCopyToClipboard = (resetDelayMs = 2000) => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copyToClipboard = useCallback(
+    (value: string) => {
+      navigator.clipboard
+        .writeText(value)
+        .then(() => {
+          setIsCopied(true);
+          setTimeout(() => setIsCopied(false), resetDelayMs);
+        })
+        .catch((clipboardError) => {
+          console.error('Failed to copy: ', clipboardError);
+        });
+    },
+    [resetDelayMs],
+  );
+
+  return { copyToClipboard, isCopied };
+};

--- a/packages/site/src/hooks/useDelegateAccount.ts
+++ b/packages/site/src/hooks/useDelegateAccount.ts
@@ -2,18 +2,11 @@ import {
   Implementation,
   toMetaMaskSmartAccount,
 } from '@metamask/smart-accounts-kit';
-import type {
-  AccountSignerConfig,
-  MetaMaskSmartAccount,
-} from '@metamask/smart-accounts-kit';
+import type { MetaMaskSmartAccount } from '@metamask/smart-accounts-kit';
 import { useEffect, useState } from 'react';
 import { createPublicClient, http } from 'viem';
 import type { Chain } from 'viem';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
-
-type ToMetaMaskSmartAccountOptions = Parameters<
-  typeof toMetaMaskSmartAccount
->[0];
 
 /**
  * Creates and manages a delegate account for smart account interactions.
@@ -40,15 +33,10 @@ export const useDelegateAccount = ({ chain }: { chain: Chain }) => {
 
         const smartAccount = await toMetaMaskSmartAccount({
           implementation: Implementation.MultiSig,
-          signer: [
-            {
-              account: account as AccountSignerConfig['account'],
-            },
-          ],
+          signer: [{ account }],
           deployParams: [[account.address], 1n],
           deploySalt: '0x',
-          client:
-            publicClient as unknown as ToMetaMaskSmartAccountOptions['client'],
+          client: publicClient,
         });
 
         setDelegateAccount(smartAccount);

--- a/packages/site/src/hooks/useDelegateAccount.ts
+++ b/packages/site/src/hooks/useDelegateAccount.ts
@@ -2,11 +2,18 @@ import {
   Implementation,
   toMetaMaskSmartAccount,
 } from '@metamask/smart-accounts-kit';
-import type { MetaMaskSmartAccount } from '@metamask/smart-accounts-kit';
+import type {
+  AccountSignerConfig,
+  MetaMaskSmartAccount,
+} from '@metamask/smart-accounts-kit';
 import { useEffect, useState } from 'react';
 import { createPublicClient, http } from 'viem';
 import type { Chain } from 'viem';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+
+type ToMetaMaskSmartAccountOptions = Parameters<
+  typeof toMetaMaskSmartAccount
+>[0];
 
 /**
  * Creates and manages a delegate account for smart account interactions.
@@ -33,10 +40,15 @@ export const useDelegateAccount = ({ chain }: { chain: Chain }) => {
 
         const smartAccount = await toMetaMaskSmartAccount({
           implementation: Implementation.MultiSig,
-          signer: [{ account }],
+          signer: [
+            {
+              account: account as AccountSignerConfig['account'],
+            },
+          ],
           deployParams: [[account.address], 1n],
           deploySalt: '0x',
-          client: publicClient,
+          client:
+            publicClient as unknown as ToMetaMaskSmartAccountOptions['client'],
         });
 
         setDelegateAccount(smartAccount);

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -6,7 +6,7 @@ import { createClient, http, custom, createPublicClient } from 'viem';
 import type { Chain, Hex } from 'viem';
 import type { UserOperationReceipt } from 'viem/account-abstraction';
 
-import { SnapConnectionCards } from '../components';
+import { ErrorAlert, SnapConnectionCards } from '../components';
 import {
   PermissionQueriesPanel,
   PermissionRequestPanel,
@@ -36,7 +36,6 @@ import {
   Subtitle,
   CardContainer,
   Box,
-  ErrorMessage,
 } from '../styles';
 import {
   decodePermissionContext,
@@ -341,9 +340,7 @@ const Index = () => {
       </Subtitle>
       <CardContainer>
         {errors.map((error, idx) => (
-          <ErrorMessage key={idx}>
-            <b>An error happened:</b> {error?.message}
-          </ErrorMessage>
+          <ErrorAlert key={idx} error={error} />
         ))}
 
         {selectedPermissionResponse && (

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -1,48 +1,33 @@
-import { getSmartAccountsEnvironment } from '@metamask/smart-accounts-kit';
 import { erc7715ProviderActions } from '@metamask/smart-accounts-kit/actions';
 import type { RequestExecutionPermissionsParameters } from '@metamask/smart-accounts-kit/actions';
-import {
-  decodeCaveat,
-  decodeDelegations,
-} from '@metamask/smart-accounts-kit/utils';
 import { useCallback, useMemo, useState } from 'react';
-import {
-  createClient,
-  http,
-  custom,
-  createPublicClient,
-  extractChain,
-} from 'viem';
+import type { ChangeEvent } from 'react';
+import { createClient, http, custom, createPublicClient } from 'viem';
 import type { Chain, Hex } from 'viem';
 import type { UserOperationReceipt } from 'viem/account-abstraction';
-import * as chains from 'viem/chains';
 
+import { SnapConnectionCards } from '../components';
 import {
-  ConnectButton,
-  InstallMetaMaskButton,
-  CustomMessageButton,
-  Card,
-  Title,
-} from '../components';
-import {
-  NativeTokenStreamForm,
-  ERC20TokenStreamForm,
-  NativeTokenPeriodicForm,
-  ERC20TokenPeriodicForm,
-  NativeTokenAllowanceForm,
-  ERC20TokenAllowanceForm,
-  TokenApprovalRevocationForm,
-  RedemptionForm,
+  PermissionQueriesPanel,
+  PermissionRequestPanel,
+  PermissionResponsePanel,
+  RedeemPermissionPanel,
 } from '../components/permissions';
 import type { RedemptionCall } from '../components/permissions';
 import type { PermissionRequest } from '../components/permissions/types';
-import { kernelSnapOrigin, gatorSnapOrigin } from '../config';
+import {
+  defaultSupportedChain,
+  gatorSnapOrigin,
+  kernelSnapOrigin,
+  supportedChains,
+} from '../config';
 import {
   useMetaMask,
   useMetaMaskContext,
   useRequestSnap,
   useDelegateAccount,
   useBundlerClient,
+  useCopyToClipboard,
 } from '../hooks';
 import {
   Container,
@@ -52,41 +37,22 @@ import {
   CardContainer,
   Box,
   ErrorMessage,
-  StyledForm,
-  ResponseContainer,
-  CopyButton,
 } from '../styles';
-
-const stringifyWithBigInt = (value: unknown): string =>
-  JSON.stringify(
-    value,
-    (_, v) => (typeof v === 'bigint' ? v.toString() : v),
-    2,
-  );
+import {
+  decodePermissionContext,
+  formatDelegatedExecutionError,
+  stringifyWithBigInt,
+} from '../utils';
 
 const BUNDLER_RPC_URL = import.meta.env.VITE_BUNDLER_RPC_URL;
 
-const ALL_CHAINS = [...Object.values(chains)];
-
-const supportedChainsString = import.meta.env.VITE_SUPPORTED_CHAINS;
-
-const DEFAULT_CHAINS = [chains.sepolia];
-
-const supportedChains: Chain[] = supportedChainsString
-  ? supportedChainsString.split(',').map((chainIdString) => {
-      const chainId = parseInt(chainIdString);
-      const chain = extractChain({
-        chains: ALL_CHAINS,
-        id: chainId as any,
-      });
-
-      if (!chain) {
-        throw new Error(`Chain ${chainId} not found`);
-      }
-
-      return chain;
-    })
-  : DEFAULT_CHAINS;
+type MetaMaskClient = {
+  getGrantedExecutionPermissions: () => Promise<unknown>;
+  getSupportedExecutionPermissions: () => Promise<unknown>;
+  requestExecutionPermissions: (
+    parameters: RequestExecutionPermissionsParameters,
+  ) => Promise<unknown>;
+};
 
 const Index = () => {
   const { error: metaMaskContextError } = useMetaMaskContext();
@@ -97,11 +63,9 @@ const Index = () => {
     Boolean(e),
   );
 
-  if (!supportedChains[0]) {
-    throw new Error('No supported chains found.');
-  }
-
-  const [selectedChain, setSelectedChain] = useState<Chain>(supportedChains[0]);
+  const [selectedChain, setSelectedChain] = useState<Chain>(
+    defaultSupportedChain,
+  );
 
   const { snapsDetected, installedSnaps, provider } = useMetaMask();
   const requestKernelSnap = useRequestSnap(kernelSnapOrigin);
@@ -115,32 +79,40 @@ const Index = () => {
 
   const isMetaMaskReady = snapsDetected;
 
-  const metaMaskClient = useMemo(() => {
+  const metaMaskClient = useMemo<MetaMaskClient | undefined>(() => {
     if (!provider || !isMetaMaskReady) {
       return undefined;
     }
 
-    return createClient({
+    const baseMetaMaskClient = createClient({
       transport: custom(provider),
-    }).extend(erc7715ProviderActions());
+    });
+
+    return baseMetaMaskClient.extend(
+      erc7715ProviderActions() as Parameters<
+        typeof baseMetaMaskClient.extend
+      >[0],
+    ) as unknown as MetaMaskClient;
   }, [provider, kernelSnapOrigin, gatorSnapOrigin, isMetaMaskReady]);
 
   const isKernelSnapReady = Boolean(installedSnaps[kernelSnapOrigin]);
   const isGatorSnapReady = Boolean(installedSnaps[gatorSnapOrigin]);
 
   const chainId = selectedChain.id;
-  const [permissionType, setPermissionType] = useState('native-token-stream');
+  const [permissionType, setPermissionType] = useState<
+    PermissionRequest['type']
+  >('native-token-stream');
   const [permissionRequest, setPermissionRequest] =
     useState<PermissionRequest | null>(null);
   const [permissionResponse, setPermissionResponse] = useState<any>(null);
-  const [isCopied, setIsCopied] = useState(false);
-  const [decodedIsCopied, setDecodedIsCopied] = useState(false);
+  const permissionResponseClipboard = useCopyToClipboard();
+  const decodedPermissionContextClipboard = useCopyToClipboard();
   const [supportedPermissionsResponse, setSupportedPermissionsResponse] =
     useState<any>(null);
   const [grantedPermissionsResponse, setGrantedPermissionsResponse] =
     useState<any>(null);
-  const [supportedIsCopied, setSupportedIsCopied] = useState(false);
-  const [grantedIsCopied, setGrantedIsCopied] = useState(false);
+  const supportedPermissionsClipboard = useCopyToClipboard();
+  const grantedPermissionsClipboard = useCopyToClipboard();
   const [to, setTo] = useState<Hex>('0x');
   const [data, setData] = useState<Hex>('0x');
   const [value, setValue] = useState<bigint>(0n);
@@ -149,51 +121,18 @@ const Index = () => {
     Set<string>
   >(new Set());
 
-  const decodedPermissionContext = useMemo(() => {
-    if (!Array.isArray(permissionResponse)) {
-      return null;
-    }
+  const selectedPermissionResponse = Array.isArray(permissionResponse)
+    ? permissionResponse[0]
+    : undefined;
 
-    return permissionResponse.map((responseEntry) => {
-      const permissionContext = responseEntry?.context;
-
-      if (!permissionContext) {
-        return [];
-      }
-
-      try {
-        const delegations = decodeDelegations(permissionContext as Hex);
-        const responseChainId =
-          typeof responseEntry?.chainId === 'number'
-            ? responseEntry.chainId
-            : Number(responseEntry?.chainId);
-        const environment = getSmartAccountsEnvironment(
-          Number.isNaN(responseChainId) ? selectedChain.id : responseChainId,
-        );
-        const decodedDelegations = delegations.map((delegation) => ({
-          ...delegation,
-          caveats: (delegation.caveats ?? []).map((caveat) => {
-            try {
-              return decodeCaveat({
-                caveat,
-                environment,
-              });
-            } catch {
-              return caveat;
-            }
-          }),
-        }));
-
-        return decodedDelegations;
-      } catch {
-        return [];
-      }
-    });
-  }, [permissionResponse, selectedChain.id]);
+  const decodedPermissionContext = useMemo(
+    () => decodePermissionContext(permissionResponse, selectedChain.id),
+    [permissionResponse, selectedChain.id],
+  );
 
   const handleChainChange = ({
     target: { value: inputValue },
-  }: React.ChangeEvent<HTMLSelectElement>) => {
+  }: ChangeEvent<HTMLSelectElement>) => {
     const chainId = parseInt(inputValue);
     const chain = supportedChains.find((ch) => ch.id === chainId);
     if (chain) {
@@ -203,8 +142,8 @@ const Index = () => {
 
   const handlePermissionTypeChange = ({
     target: { value: inputValue },
-  }: React.ChangeEvent<HTMLSelectElement>) => {
-    setPermissionType(inputValue);
+  }: ChangeEvent<HTMLSelectElement>) => {
+    setPermissionType(inputValue as PermissionRequest['type']);
   };
 
   const handleRedemptionCallChange = useCallback(
@@ -262,7 +201,7 @@ const Index = () => {
 
       setReceipt(operationReceipt);
     } catch (error) {
-      setPermissionResponseError(error as Error);
+      setPermissionResponseError(formatDelegatedExecutionError(error));
     } finally {
       // Remove this request from pending requests
       setPendingPermissionRequests((prev) => {
@@ -338,29 +277,17 @@ const Index = () => {
 
   const handleCopyToClipboard = () => {
     if (permissionResponse) {
-      navigator.clipboard
-        .writeText(stringifyWithBigInt(permissionResponse))
-        .then(() => {
-          setIsCopied(true);
-          setTimeout(() => setIsCopied(false), 2000);
-        })
-        .catch((clipboardError) => {
-          console.error('Failed to copy: ', clipboardError);
-        });
+      permissionResponseClipboard.copyToClipboard(
+        stringifyWithBigInt(permissionResponse),
+      );
     }
   };
 
   const handleCopyDecodedToClipboard = () => {
     if (decodedPermissionContext) {
-      navigator.clipboard
-        .writeText(stringifyWithBigInt(decodedPermissionContext))
-        .then(() => {
-          setDecodedIsCopied(true);
-          setTimeout(() => setDecodedIsCopied(false), 2000);
-        })
-        .catch((clipboardError) => {
-          console.error('Failed to copy: ', clipboardError);
-        });
+      decodedPermissionContextClipboard.copyToClipboard(
+        stringifyWithBigInt(decodedPermissionContext),
+      );
     }
   };
 
@@ -386,29 +313,17 @@ const Index = () => {
 
   const handleCopySupportedToClipboard = () => {
     if (supportedPermissionsResponse) {
-      navigator.clipboard
-        .writeText(stringifyWithBigInt(supportedPermissionsResponse))
-        .then(() => {
-          setSupportedIsCopied(true);
-          setTimeout(() => setSupportedIsCopied(false), 2000);
-        })
-        .catch((clipboardError) => {
-          console.error('Failed to copy: ', clipboardError);
-        });
+      supportedPermissionsClipboard.copyToClipboard(
+        stringifyWithBigInt(supportedPermissionsResponse),
+      );
     }
   };
 
   const handleCopyGrantedToClipboard = () => {
     if (grantedPermissionsResponse) {
-      navigator.clipboard
-        .writeText(stringifyWithBigInt(grantedPermissionsResponse))
-        .then(() => {
-          setGrantedIsCopied(true);
-          setTimeout(() => setGrantedIsCopied(false), 2000);
-        })
-        .catch((clipboardError) => {
-          console.error('Failed to copy: ', clipboardError);
-        });
+      grantedPermissionsClipboard.copyToClipboard(
+        stringifyWithBigInt(grantedPermissionsResponse),
+      );
     }
   };
 
@@ -431,255 +346,59 @@ const Index = () => {
           </ErrorMessage>
         ))}
 
-        {permissionResponse && (
-          <Box>
-            {receipt && (
-              <div style={{ marginTop: '1rem' }}>
-                <ResponseContainer>
-                  <Title>User operation receipt</Title>
-                  <pre>{stringifyWithBigInt(receipt)}</pre>
-                </ResponseContainer>
-              </div>
-            )}
-            <StyledForm>
-              <Title>Redeem Permission</Title>
-              <RedemptionForm
-                delegateAddress={delegateAccount?.address}
-                permissionResponse={permissionResponse[0]}
-                onChange={handleRedemptionCallChange}
-              />
-              <div>
-                <label>From:</label>
-                <div>{delegateAccount?.address}</div>
-              </div>
-              <div>
-                <label>To:</label>
-                <div>{to}</div>
-              </div>
-              <div>
-                <label>Value:</label>
-                <div>{value.toString()}</div>
-              </div>
-            </StyledForm>
-            <CustomMessageButton
-              $text="Redeem Permission"
-              onClick={handleRedeemPermission}
-              disabled={pendingPermissionRequests.size > 0}
-            />
-          </Box>
+        {selectedPermissionResponse && (
+          <RedeemPermissionPanel
+            delegateAddress={delegateAccount?.address}
+            isPending={pendingPermissionRequests.size > 0}
+            onRedeemPermission={handleRedeemPermission}
+            onRedemptionCallChange={handleRedemptionCallChange}
+            permissionResponse={selectedPermissionResponse}
+            receipt={receipt}
+            to={to}
+            value={value}
+          />
         )}
         {metaMaskClient && permissionResponse && (
-          <Box style={{ position: 'relative' }}>
-            <ResponseContainer>
-              <Title>Permission Response</Title>
-              <CopyButton
-                onClick={handleCopyToClipboard}
-                title={'Copy to clipboard'}
-              >
-                {isCopied ? '✅' : '📝'}
-              </CopyButton>
-              <pre>{stringifyWithBigInt(permissionResponse)}</pre>
-              {decodedPermissionContext && (
-                <details style={{ marginTop: '1rem' }}>
-                  <summary>Decoded Permission Context</summary>
-                  <CopyButton
-                    onClick={handleCopyDecodedToClipboard}
-                    title={'Copy to clipboard'}
-                    style={{ position: 'relative', float: 'right' }}
-                  >
-                    {decodedIsCopied ? '✅' : '📝'}
-                  </CopyButton>
-                  <pre>{stringifyWithBigInt(decodedPermissionContext)}</pre>
-                </details>
-              )}
-            </ResponseContainer>
-          </Box>
+          <PermissionResponsePanel
+            decodedIsCopied={decodedPermissionContextClipboard.isCopied}
+            decodedPermissionContext={decodedPermissionContext}
+            isCopied={permissionResponseClipboard.isCopied}
+            onCopyDecodedPermissionContext={handleCopyDecodedToClipboard}
+            onCopyPermissionResponse={handleCopyToClipboard}
+            permissionResponse={permissionResponse}
+          />
         )}
         {metaMaskClient && (
-          <Box>
-            <StyledForm>
-              <div>
-                <label htmlFor="chainSelector">Chain:</label>
-                <select
-                  id="chainSelector"
-                  name="chainSelector"
-                  value={selectedChain.id}
-                  onChange={handleChainChange}
-                  style={{
-                    padding: '0.8rem',
-                    border: '1px solid',
-                    borderRadius: '0.3rem',
-                    flexGrow: 1,
-                  }}
-                >
-                  {supportedChains.map((chain) => (
-                    <option key={chain.id} value={chain.id}>
-                      {chain.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label htmlFor="permissionType">Permission Type:</label>
-                <select
-                  id="permissionType"
-                  name="permissionType"
-                  value={permissionType}
-                  onChange={handlePermissionTypeChange}
-                  style={{
-                    padding: '0.8rem',
-                    border: '1px solid',
-                    borderRadius: '0.3rem',
-                    flexGrow: 1,
-                  }}
-                >
-                  <option value="native-token-stream">
-                    Native Token Stream
-                  </option>
-                  <option value="erc20-token-stream">ERC20 Token Stream</option>
-                  <option value="native-token-periodic">
-                    Native Token Periodic
-                  </option>
-                  <option value="native-token-allowance">
-                    Native Token Allowance
-                  </option>
-                  <option value="erc20-token-periodic">
-                    ERC20 Token Periodic
-                  </option>
-                  <option value="erc20-token-allowance">
-                    ERC20 Token Allowance
-                  </option>
-                  <option value="token-approval-revocation">
-                    Token Approval Revocation
-                  </option>
-                </select>
-              </div>
-
-              {permissionType === 'native-token-stream' && (
-                <NativeTokenStreamForm onChange={onFormChange} />
-              )}
-
-              {permissionType === 'erc20-token-stream' && (
-                <ERC20TokenStreamForm onChange={onFormChange} />
-              )}
-
-              {permissionType === 'native-token-periodic' && (
-                <NativeTokenPeriodicForm onChange={onFormChange} />
-              )}
-
-              {permissionType === 'erc20-token-periodic' && (
-                <ERC20TokenPeriodicForm onChange={onFormChange} />
-              )}
-
-              {permissionType === 'native-token-allowance' && (
-                <NativeTokenAllowanceForm onChange={onFormChange} />
-              )}
-
-              {permissionType === 'erc20-token-allowance' && (
-                <ERC20TokenAllowanceForm onChange={onFormChange} />
-              )}
-
-              {permissionType === 'token-approval-revocation' && (
-                <TokenApprovalRevocationForm onChange={onFormChange} />
-              )}
-            </StyledForm>
-            <CustomMessageButton
-              $text="Grant Permission"
-              onClick={handleGrantPermissions}
-            />
-          </Box>
-        )}
-
-        {metaMaskClient && (
-          <Box>
-            <Title>Permission Queries</Title>
-            <div
-              style={{
-                display: 'flex',
-                gap: '1rem',
-                marginTop: '1rem',
-                marginBottom: '1rem',
-              }}
-            >
-              <CustomMessageButton
-                $text="Get Supported Permissions"
-                onClick={handleGetSupportedPermissions}
-              />
-              <CustomMessageButton
-                $text="Get Granted Permissions"
-                onClick={handleGetGrantedPermissions}
-              />
-            </div>
-            {supportedPermissionsResponse && (
-              <ResponseContainer>
-                <Title>Supported Permissions</Title>
-                <CopyButton
-                  onClick={handleCopySupportedToClipboard}
-                  title={'Copy to clipboard'}
-                >
-                  {supportedIsCopied ? '✅' : '📝'}
-                </CopyButton>
-                <pre>{stringifyWithBigInt(supportedPermissionsResponse)}</pre>
-              </ResponseContainer>
-            )}
-            {grantedPermissionsResponse && (
-              <ResponseContainer style={{ marginTop: '1rem' }}>
-                <Title>Granted Permissions</Title>
-                <CopyButton
-                  onClick={handleCopyGrantedToClipboard}
-                  title={'Copy to clipboard'}
-                >
-                  {grantedIsCopied ? '✅' : '📝'}
-                </CopyButton>
-                <pre>{stringifyWithBigInt(grantedPermissionsResponse)}</pre>
-              </ResponseContainer>
-            )}
-          </Box>
-        )}
-
-        {!isMetaMaskReady && (
-          <Card
-            content={{
-              title: 'Install',
-              description:
-                'Snaps requires MetaMask to be installed. Install MetaMask to get started.',
-              button: <InstallMetaMaskButton />,
-            }}
-            fullWidth
+          <PermissionRequestPanel
+            onChainChange={handleChainChange}
+            onFormChange={onFormChange}
+            onGrantPermissions={handleGrantPermissions}
+            onPermissionTypeChange={handlePermissionTypeChange}
+            permissionType={permissionType}
+            selectedChain={selectedChain}
+            supportedChains={supportedChains}
           />
         )}
 
-        <Card
-          content={{
-            title: `${isKernelSnapReady ? 'Reconnect' : 'Connect'}(kernel)`,
-            description:
-              'Get started by connecting to and installing the kernel snap.',
-            button: (
-              <ConnectButton
-                onClick={requestKernelSnap}
-                disabled={!isMetaMaskReady}
-                $isReconnect={isKernelSnapReady}
-              />
-            ),
-          }}
-          disabled={!isMetaMaskReady}
-        />
+        {metaMaskClient && (
+          <PermissionQueriesPanel
+            grantedIsCopied={grantedPermissionsClipboard.isCopied}
+            grantedPermissionsResponse={grantedPermissionsResponse}
+            onCopyGrantedPermissions={handleCopyGrantedToClipboard}
+            onCopySupportedPermissions={handleCopySupportedToClipboard}
+            onGetGrantedPermissions={handleGetGrantedPermissions}
+            onGetSupportedPermissions={handleGetSupportedPermissions}
+            supportedIsCopied={supportedPermissionsClipboard.isCopied}
+            supportedPermissionsResponse={supportedPermissionsResponse}
+          />
+        )}
 
-        <Card
-          content={{
-            title: `${isGatorSnapReady ? 'Reconnect' : 'Connect'}(provider)`,
-            description:
-              'Get started by connecting to and installing the permission provider snap.',
-            button: (
-              <ConnectButton
-                onClick={requestPermissionSnap}
-                disabled={!isMetaMaskReady}
-                $isReconnect={isGatorSnapReady}
-              />
-            ),
-          }}
-          disabled={!isMetaMaskReady}
+        <SnapConnectionCards
+          isGatorSnapReady={isGatorSnapReady}
+          isKernelSnapReady={isKernelSnapReady}
+          isMetaMaskReady={isMetaMaskReady}
+          onRequestKernelSnap={requestKernelSnap}
+          onRequestPermissionSnap={requestPermissionSnap}
         />
 
         <Box>

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -1,5 +1,8 @@
 import { erc7715ProviderActions } from '@metamask/smart-accounts-kit/actions';
-import type { RequestExecutionPermissionsParameters } from '@metamask/smart-accounts-kit/actions';
+import type {
+  Erc7715Client,
+  RequestExecutionPermissionsParameters,
+} from '@metamask/smart-accounts-kit/actions';
 import { useCallback, useMemo, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import { createClient, http, custom, createPublicClient } from 'viem';
@@ -45,14 +48,6 @@ import {
 
 const BUNDLER_RPC_URL = import.meta.env.VITE_BUNDLER_RPC_URL;
 
-type MetaMaskClient = {
-  getGrantedExecutionPermissions: () => Promise<unknown>;
-  getSupportedExecutionPermissions: () => Promise<unknown>;
-  requestExecutionPermissions: (
-    parameters: RequestExecutionPermissionsParameters,
-  ) => Promise<unknown>;
-};
-
 const Index = () => {
   const { error: metaMaskContextError } = useMetaMaskContext();
   const [permissionResponseError, setPermissionResponseError] =
@@ -78,7 +73,7 @@ const Index = () => {
 
   const isMetaMaskReady = snapsDetected;
 
-  const metaMaskClient = useMemo<MetaMaskClient | undefined>(() => {
+  const metaMaskClient = useMemo<Erc7715Client | undefined>(() => {
     if (!provider || !isMetaMaskReady) {
       return undefined;
     }
@@ -87,11 +82,7 @@ const Index = () => {
       transport: custom(provider),
     });
 
-    return baseMetaMaskClient.extend(
-      erc7715ProviderActions() as Parameters<
-        typeof baseMetaMaskClient.extend
-      >[0],
-    ) as unknown as MetaMaskClient;
+    return baseMetaMaskClient.extend(erc7715ProviderActions());
   }, [provider, kernelSnapOrigin, gatorSnapOrigin, isMetaMaskReady]);
 
   const isKernelSnapReady = Boolean(installedSnaps[kernelSnapOrigin]);

--- a/packages/site/src/styles.tsx
+++ b/packages/site/src/styles.tsx
@@ -76,6 +76,8 @@ export const ErrorMessage = styled.div`
   margin-top: 2.4rem;
   max-width: 60rem;
   width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
   ${({ theme }) => theme.mediaQueries.small} {
     padding: 1.6rem;
     margin-bottom: 1.2rem;

--- a/packages/site/src/utils/delegatedExecutionError.ts
+++ b/packages/site/src/utils/delegatedExecutionError.ts
@@ -1,0 +1,40 @@
+import { decodeRevertReason } from '@metamask/smart-accounts-kit/utils';
+
+import { stringifyWithBigInt } from './stringify';
+
+const getOriginalErrorOutput = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message || String(error);
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  try {
+    const stringifiedError = stringifyWithBigInt(error);
+    return stringifiedError || String(error);
+  } catch {
+    return String(error);
+  }
+};
+
+export const formatDelegatedExecutionError = (error: unknown): Error => {
+  const decodedRevertReason = decodeRevertReason(error);
+  const originalErrorOutput = getOriginalErrorOutput(error);
+
+  if (!decodedRevertReason) {
+    return error instanceof Error ? error : new Error(originalErrorOutput);
+  }
+
+  return new Error(
+    [
+      `Decoded revert reason: ${decodedRevertReason.message}`,
+      `Decoded error name: ${decodedRevertReason.errorName}`,
+      `Raw revert data: ${decodedRevertReason.rawData}`,
+      '',
+      'Original error output:',
+      originalErrorOutput,
+    ].join('\n'),
+  );
+};

--- a/packages/site/src/utils/delegatedExecutionError.ts
+++ b/packages/site/src/utils/delegatedExecutionError.ts
@@ -20,8 +20,14 @@ const getOriginalErrorOutput = (error: unknown): string => {
 };
 
 export const formatDelegatedExecutionError = (error: unknown): Error => {
-  const decodedRevertReason = decodeRevertReason(error);
   const originalErrorOutput = getOriginalErrorOutput(error);
+  let decodedRevertReason: ReturnType<typeof decodeRevertReason> | undefined;
+
+  try {
+    decodedRevertReason = decodeRevertReason(error);
+  } catch {
+    decodedRevertReason = undefined;
+  }
 
   if (!decodedRevertReason) {
     return error instanceof Error ? error : new Error(originalErrorOutput);

--- a/packages/site/src/utils/errorDisplay.ts
+++ b/packages/site/src/utils/errorDisplay.ts
@@ -1,0 +1,120 @@
+import { stringifyWithBigInt } from './stringify';
+
+const FALLBACK_ERROR_MESSAGE = 'Unknown error';
+const SUMMARY_KEYS = ['shortMessage', 'reason', 'message'] as const;
+const NESTED_ERROR_KEYS = ['cause', 'error', 'data', 'originalError'] as const;
+
+type ErrorRecord = Record<string, unknown>;
+
+export type ErrorDisplay = {
+  summary: string;
+  details: string;
+};
+
+const isRecord = (value: unknown): value is ErrorRecord =>
+  typeof value === 'object' && value !== null;
+
+const getTrimmedString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : undefined;
+};
+
+const getStringField = (value: unknown, key: string): string | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return getTrimmedString(value[key]);
+};
+
+const getNestedStringField = (
+  value: unknown,
+  key: string,
+  depth = 0,
+): string | undefined => {
+  if (!isRecord(value) || depth > 2) {
+    return undefined;
+  }
+
+  const directValue = getStringField(value, key);
+  if (directValue) {
+    return directValue;
+  }
+
+  for (const nestedKey of NESTED_ERROR_KEYS) {
+    const nestedValue = getNestedStringField(value[nestedKey], key, depth + 1);
+    if (nestedValue) {
+      return nestedValue;
+    }
+  }
+
+  return undefined;
+};
+
+const stringifyErrorValue = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    return getTrimmedString(value);
+  }
+
+  if (value instanceof Error) {
+    return getTrimmedString(value.message) ?? String(value);
+  }
+
+  try {
+    return getTrimmedString(stringifyWithBigInt(value));
+  } catch {
+    return getTrimmedString(String(value));
+  }
+};
+
+const getFirstMeaningfulLine = (message: string): string =>
+  message
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean) ?? message;
+
+const getSummaryMessage = (error: unknown): string => {
+  for (const key of SUMMARY_KEYS) {
+    const message = getNestedStringField(error, key);
+    if (message) {
+      return getFirstMeaningfulLine(message);
+    }
+  }
+
+  return getFirstMeaningfulLine(
+    stringifyErrorValue(error) ?? FALLBACK_ERROR_MESSAGE,
+  );
+};
+
+const getSerializedProperties = (error: unknown): string | undefined => {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  try {
+    const serializedError = stringifyWithBigInt(error);
+    return serializedError === '{}' ? undefined : serializedError;
+  } catch {
+    return undefined;
+  }
+};
+
+const getDetailMessage = (error: unknown): string => {
+  const detailParts = [
+    stringifyErrorValue(error),
+    getSerializedProperties(error),
+  ].filter((part): part is string => Boolean(part));
+
+  return detailParts.length > 0
+    ? Array.from(new Set(detailParts)).join('\n\n')
+    : FALLBACK_ERROR_MESSAGE;
+};
+
+export const getErrorDisplay = (error: unknown): ErrorDisplay => ({
+  summary: getSummaryMessage(error),
+  details: getDetailMessage(error),
+});

--- a/packages/site/src/utils/index.ts
+++ b/packages/site/src/utils/index.ts
@@ -3,3 +3,6 @@ export * from './snap';
 export * from './theme';
 export * from './localStorage';
 export * from './button';
+export * from './delegatedExecutionError';
+export * from './permissionContext';
+export * from './stringify';

--- a/packages/site/src/utils/index.ts
+++ b/packages/site/src/utils/index.ts
@@ -4,5 +4,6 @@ export * from './theme';
 export * from './localStorage';
 export * from './button';
 export * from './delegatedExecutionError';
+export * from './errorDisplay';
 export * from './permissionContext';
 export * from './stringify';

--- a/packages/site/src/utils/permissionContext.ts
+++ b/packages/site/src/utils/permissionContext.ts
@@ -1,0 +1,74 @@
+import { getSmartAccountsEnvironment } from '@metamask/smart-accounts-kit';
+import {
+  decodeCaveat,
+  decodeDelegations,
+} from '@metamask/smart-accounts-kit/utils';
+import type { Hex } from 'viem';
+
+export type DecodedPermissionContext = unknown[][];
+
+type PermissionResponseEntry = {
+  chainId?: unknown;
+  context?: unknown;
+};
+
+const isPermissionResponseEntry = (
+  value: unknown,
+): value is PermissionResponseEntry =>
+  typeof value === 'object' && value !== null;
+
+const getResponseChainId = (
+  responseEntry: PermissionResponseEntry,
+  fallbackChainId: number,
+): number => {
+  const responseChainId =
+    typeof responseEntry.chainId === 'number'
+      ? responseEntry.chainId
+      : Number(responseEntry.chainId);
+
+  return Number.isNaN(responseChainId) ? fallbackChainId : responseChainId;
+};
+
+export const decodePermissionContext = (
+  permissionResponse: unknown,
+  fallbackChainId: number,
+): DecodedPermissionContext | null => {
+  if (!Array.isArray(permissionResponse)) {
+    return null;
+  }
+
+  return permissionResponse.map((responseEntry) => {
+    if (!isPermissionResponseEntry(responseEntry)) {
+      return [];
+    }
+
+    const permissionContext = responseEntry.context;
+
+    if (typeof permissionContext !== 'string') {
+      return [];
+    }
+
+    try {
+      const delegations = decodeDelegations(permissionContext as Hex);
+      const environment = getSmartAccountsEnvironment(
+        getResponseChainId(responseEntry, fallbackChainId),
+      );
+
+      return delegations.map((delegation) => ({
+        ...delegation,
+        caveats: (delegation.caveats ?? []).map((caveat) => {
+          try {
+            return decodeCaveat({
+              caveat,
+              environment,
+            });
+          } catch {
+            return caveat;
+          }
+        }),
+      }));
+    } catch {
+      return [];
+    }
+  });
+};

--- a/packages/site/src/utils/stringify.ts
+++ b/packages/site/src/utils/stringify.ts
@@ -1,0 +1,6 @@
+export const stringifyWithBigInt = (value: unknown): string =>
+  JSON.stringify(
+    value,
+    (_, v) => (typeof v === 'bigint' ? v.toString() : v),
+    2,
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,13 +2830,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/7715-permission-types@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@metamask/7715-permission-types@npm:0.6.0"
-  checksum: 10/bac0741ed0d880d9f418a58ef5d1f165cff0171636cb4431bc42a05b471b92afd6593810ac805a427a76dc02abcba651cc3c1c05b67d5a4b6ad3923b057de039
-  languageName: node
-  linkType: hard
-
 "@metamask/7715-permissions-shared@workspace:*, @metamask/7715-permissions-shared@workspace:packages/shared":
   version: 0.0.0-use.local
   resolution: "@metamask/7715-permissions-shared@workspace:packages/shared"
@@ -3057,24 +3050,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-abis@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/delegation-abis@npm:1.0.0"
-  checksum: 10/31b58d3080710cd48fbf471a1cb94fc4cae705f2472d392a3daaa7c73603ad6d0b1c9068e3b71b10f9c39bfe19c1fad90ecf3115e20a00b2d39f5c7789c5b932
-  languageName: node
-  linkType: hard
-
-"@metamask/delegation-core@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@metamask/delegation-core@npm:2.1.0"
-  dependencies:
-    "@metamask/abi-utils": "npm:^3.0.0"
-    "@metamask/utils": "npm:^11.4.0"
-    "@noble/hashes": "npm:^1.8.0"
-  checksum: 10/4b699987e178ce25a4ef726e61290636afd40e4d43cf856163d46f747ee9deb70641501b11e2d13dca9b7fa8bcae287058022929f3507868019e3802d3a52751
-  languageName: node
-  linkType: hard
-
 "@metamask/delegation-core@npm:^2.2.1":
   version: 2.2.1
   resolution: "@metamask/delegation-core@npm:2.2.1"
@@ -3083,13 +3058,6 @@ __metadata:
     "@metamask/utils": "npm:^11.4.0"
     "@noble/hashes": "npm:^1.8.0"
   checksum: 10/8cc532e4a5fdc83eddb36fada6283d51629272fcce8b7c7c2d3b4addde5aff7c741365a3bcd701364460fbbcbbe94fccc0460ee3ef9af284a82f84ca708f0e06
-  languageName: node
-  linkType: hard
-
-"@metamask/delegation-deployments@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@metamask/delegation-deployments@npm:1.3.0"
-  checksum: 10/58f4aafb5f0e3cbc543811cbc0100efab4ed67b9c9794b83192962153e4edbe12fd6ab6fa7be689503309862a65eb7fde771f632893d38ab54f8171aa682b34f
   languageName: node
   linkType: hard
 
@@ -3587,21 +3555,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-accounts-kit@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@metamask/smart-accounts-kit@npm:1.5.0"
-  dependencies:
-    "@metamask/7715-permission-types": "npm:^0.6.0"
-    "@metamask/delegation-abis": "npm:^1.0.0"
-    "@metamask/delegation-core": "npm:^2.1.0"
-    "@metamask/delegation-deployments": "npm:^1.3.0"
-    openapi-fetch: "npm:^0.13.5"
-    ox: "npm:0.8.1"
-  peerDependencies:
-    viem: ^2.31.4
-  checksum: 10/b7552ef232d984a5e1f7ea32d605de6eb192d15f9e29a0d5c08fa4a674d5d1a989df9277bc60a3bd5de2bec8b8e772b77a02e57471bf969b65f6dcafaca7415a
+"@metamask/smart-accounts-kit@link:../smart-accounts-kit/packages/smart-accounts-kit::locator=%40metamask%2Fsnap-7715-permissions-monorepo%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@metamask/smart-accounts-kit@link:../smart-accounts-kit/packages/smart-accounts-kit::locator=%40metamask%2Fsnap-7715-permissions-monorepo%40workspace%3A."
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@metamask/snap-7715-permissions-monorepo@workspace:.":
   version: 0.0.0-use.local
@@ -11991,22 +11949,6 @@ __metadata:
     is-inside-container: "npm:^1.0.0"
     wsl-utils: "npm:^0.1.0"
   checksum: 10/e6ad9474734eac3549dcc7d85e952394856ccaee48107c453bd6a725b82e3b8ed5f427658935df27efa76b411aeef62888edea8a9e347e8e7c82632ec966b30e
-  languageName: node
-  linkType: hard
-
-"openapi-fetch@npm:^0.13.5":
-  version: 0.13.8
-  resolution: "openapi-fetch@npm:0.13.8"
-  dependencies:
-    openapi-typescript-helpers: "npm:^0.0.15"
-  checksum: 10/fed630452ac2d6abc680402651d848b7377b651164ca2be61a8c5e1fc89e41b09c928ba9dc92cf7c7ad2d400b3fbe5af380165303f293501dc08cefa4c0f92fd
-  languageName: node
-  linkType: hard
-
-"openapi-typescript-helpers@npm:^0.0.15":
-  version: 0.0.15
-  resolution: "openapi-typescript-helpers@npm:0.0.15"
-  checksum: 10/63f8f0b8464aed3e5c6910428bd14839bd5c1dd6ddf841bcea9d5f536a6e03e942a028202920da1a8b1ed9e4304c6fca14943d01a8adff2942d1254a229b8c70
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,6 +2830,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/7715-permission-types@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@metamask/7715-permission-types@npm:0.6.0"
+  checksum: 10/bac0741ed0d880d9f418a58ef5d1f165cff0171636cb4431bc42a05b471b92afd6593810ac805a427a76dc02abcba651cc3c1c05b67d5a4b6ad3923b057de039
+  languageName: node
+  linkType: hard
+
 "@metamask/7715-permissions-shared@workspace:*, @metamask/7715-permissions-shared@workspace:packages/shared":
   version: 0.0.0-use.local
   resolution: "@metamask/7715-permissions-shared@workspace:packages/shared"
@@ -3050,7 +3057,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-core@npm:^2.2.1":
+"@metamask/delegation-abis@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@metamask/delegation-abis@npm:1.1.0"
+  checksum: 10/fd5cd9cbfbbf725405d2f53de682ab0042959d53486a9b6da32689a8f4f7f0ec1e61bfdc73bbb708055968dd7f71f18ff94cfdcd1c6a8a723bc0a112f6b35f83
+  languageName: node
+  linkType: hard
+
+"@metamask/delegation-core@npm:^2.1.0, @metamask/delegation-core@npm:^2.2.1":
   version: 2.2.1
   resolution: "@metamask/delegation-core@npm:2.2.1"
   dependencies:
@@ -3061,7 +3075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-deployments@npm:^1.4.0":
+"@metamask/delegation-deployments@npm:^1.3.0, @metamask/delegation-deployments@npm:^1.4.0":
   version: 1.4.0
   resolution: "@metamask/delegation-deployments@npm:1.4.0"
   checksum: 10/e5e7b83e27daec5b1b61482647d43d4b685954818ff02687e2dbe8169a4dfe199cc8d2ed444242b60425ac2e7d2cf2a5ca29f3e69936abe6a8391f578ec693bb
@@ -3555,11 +3569,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-accounts-kit@link:../smart-accounts-kit/packages/smart-accounts-kit::locator=%40metamask%2Fsnap-7715-permissions-monorepo%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@metamask/smart-accounts-kit@link:../smart-accounts-kit/packages/smart-accounts-kit::locator=%40metamask%2Fsnap-7715-permissions-monorepo%40workspace%3A."
+"@metamask/smart-accounts-kit@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@metamask/smart-accounts-kit@npm:1.5.0"
+  dependencies:
+    "@metamask/7715-permission-types": "npm:^0.6.0"
+    "@metamask/delegation-abis": "npm:^1.0.0"
+    "@metamask/delegation-core": "npm:^2.1.0"
+    "@metamask/delegation-deployments": "npm:^1.3.0"
+    openapi-fetch: "npm:^0.13.5"
+    ox: "npm:0.8.1"
+  peerDependencies:
+    viem: ^2.31.4
+  checksum: 10/b7552ef232d984a5e1f7ea32d605de6eb192d15f9e29a0d5c08fa4a674d5d1a989df9277bc60a3bd5de2bec8b8e772b77a02e57471bf969b65f6dcafaca7415a
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@metamask/snap-7715-permissions-monorepo@workspace:.":
   version: 0.0.0-use.local
@@ -11949,6 +11973,22 @@ __metadata:
     is-inside-container: "npm:^1.0.0"
     wsl-utils: "npm:^0.1.0"
   checksum: 10/e6ad9474734eac3549dcc7d85e952394856ccaee48107c453bd6a725b82e3b8ed5f427658935df27efa76b411aeef62888edea8a9e347e8e7c82632ec966b30e
+  languageName: node
+  linkType: hard
+
+"openapi-fetch@npm:^0.13.5":
+  version: 0.13.8
+  resolution: "openapi-fetch@npm:0.13.8"
+  dependencies:
+    openapi-typescript-helpers: "npm:^0.0.15"
+  checksum: 10/fed630452ac2d6abc680402651d848b7377b651164ca2be61a8c5e1fc89e41b09c928ba9dc92cf7c7ad2d400b3fbe5af380165303f293501dc08cefa4c0f92fd
+  languageName: node
+  linkType: hard
+
+"openapi-typescript-helpers@npm:^0.0.15":
+  version: 0.0.15
+  resolution: "openapi-typescript-helpers@npm:0.0.15"
+  checksum: 10/63f8f0b8464aed3e5c6910428bd14839bd5c1dd6ddf841bcea9d5f536a6e03e942a028202920da1a8b1ed9e4304c6fca14943d01a8adff2942d1254a229b8c70
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,17 +2823,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/7715-permission-types@npm:0.7.1":
+"@metamask/7715-permission-types@npm:0.7.1, @metamask/7715-permission-types@npm:^0.7.1":
   version: 0.7.1
   resolution: "@metamask/7715-permission-types@npm:0.7.1"
   checksum: 10/2cbe7b8d09ae9b11171d2f9c36bf94f1acea17f9541b399bf99caa14e500c0e91d79e69a4846db2c80b18aa0df0215b36be1ea661cc99f4d6b5bc8d9eea5a4dd
-  languageName: node
-  linkType: hard
-
-"@metamask/7715-permission-types@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@metamask/7715-permission-types@npm:0.6.0"
-  checksum: 10/bac0741ed0d880d9f418a58ef5d1f165cff0171636cb4431bc42a05b471b92afd6593810ac805a427a76dc02abcba651cc3c1c05b67d5a4b6ad3923b057de039
   languageName: node
   linkType: hard
 
@@ -3057,14 +3050,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-abis@npm:^1.0.0":
+"@metamask/delegation-abis@npm:^1.1.0":
   version: 1.1.0
   resolution: "@metamask/delegation-abis@npm:1.1.0"
   checksum: 10/fd5cd9cbfbbf725405d2f53de682ab0042959d53486a9b6da32689a8f4f7f0ec1e61bfdc73bbb708055968dd7f71f18ff94cfdcd1c6a8a723bc0a112f6b35f83
   languageName: node
   linkType: hard
 
-"@metamask/delegation-core@npm:^2.1.0, @metamask/delegation-core@npm:^2.2.1":
+"@metamask/delegation-core@npm:^2.2.1":
   version: 2.2.1
   resolution: "@metamask/delegation-core@npm:2.2.1"
   dependencies:
@@ -3075,7 +3068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-deployments@npm:^1.3.0, @metamask/delegation-deployments@npm:^1.4.0":
+"@metamask/delegation-deployments@npm:^1.4.0":
   version: 1.4.0
   resolution: "@metamask/delegation-deployments@npm:1.4.0"
   checksum: 10/e5e7b83e27daec5b1b61482647d43d4b685954818ff02687e2dbe8169a4dfe199cc8d2ed444242b60425ac2e7d2cf2a5ca29f3e69936abe6a8391f578ec693bb
@@ -3569,19 +3562,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-accounts-kit@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@metamask/smart-accounts-kit@npm:1.5.0"
+"@metamask/smart-accounts-kit@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@metamask/smart-accounts-kit@npm:1.6.0"
   dependencies:
-    "@metamask/7715-permission-types": "npm:^0.6.0"
-    "@metamask/delegation-abis": "npm:^1.0.0"
-    "@metamask/delegation-core": "npm:^2.1.0"
-    "@metamask/delegation-deployments": "npm:^1.3.0"
+    "@metamask/7715-permission-types": "npm:^0.7.1"
+    "@metamask/delegation-abis": "npm:^1.1.0"
+    "@metamask/delegation-core": "npm:^2.2.1"
+    "@metamask/delegation-deployments": "npm:^1.4.0"
+    "@metamask/utils": "npm:^11.4.0"
     openapi-fetch: "npm:^0.13.5"
     ox: "npm:0.8.1"
   peerDependencies:
     viem: ^2.31.4
-  checksum: 10/b7552ef232d984a5e1f7ea32d605de6eb192d15f9e29a0d5c08fa4a674d5d1a989df9277bc60a3bd5de2bec8b8e772b77a02e57471bf969b65f6dcafaca7415a
+  checksum: 10/807713727f6c65a2a4b94c226b4db20128e0dcdf48bc8ec3f1022ac081a058e90a5c2a69c9e99729eb600f955ac52c91dea949fee1e9a9a82585788081924b9a
   languageName: node
   linkType: hard
 
@@ -13671,7 +13665,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:15.0.0"
     "@metamask/eslint-config-typescript": "npm:15.0.0"
     "@metamask/providers": "npm:22.1.1"
-    "@metamask/smart-accounts-kit": "npm:^1.5.0"
+    "@metamask/smart-accounts-kit": "npm:^1.6.0"
     "@metamask/utils": "npm:11.11.0"
     "@types/jest": "npm:27.5.2"
     "@types/react": "npm:19.2.3"


### PR DESCRIPTION
## **Description**

Refactors the snap site so page-level code focuses on state and RPC orchestration, while UI panels, chain config, clipboard handling, permission context decoding, BigInt JSON formatting, and delegated execution error formatting live in dedicated modules.

This also wires the smart-accounts-kit revert reason decoder into delegated execution errors while preserving the original error output for debugging.

This update utilizes the `decodeRevertReason` helper function from PR #245 of MetaMask/smart-accounts-kit

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run `yarn workspace site lint:eslint`
2. Run `yarn workspace site exec tsc --noEmit --pretty false`
3. Run `yarn workspace site build`
4. Start the site and verify permission request, response copy, decoded context display, and redeem flows still work.

## **Screenshots/Recordings**

N/A - structural refactor with no intended UI changes.

### **Before**

N/A

### **After**

N/A

## **CHANGELOG entry**

N/A - development site refactor only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Development-site refactor with no production snap logic changes; the Permit2 nonce encoding tweak is the main functional change in redemption calldata.
> 
> **Overview**
> Refactors the **7715 permissions demo site** so the main page keeps orchestration (MetaMask client, grant/redeem RPCs, pending state) while UI and helpers move into focused modules.
> 
> **Structure:** Inline JSX is replaced with **`ErrorAlert`**, **`SnapConnectionCards`**, and permission panels (`PermissionRequestPanel`, `PermissionResponsePanel`, `PermissionQueriesPanel`, `RedeemPermissionPanel`). Shared logic moves to **`config/chains`**, **`useCopyToClipboard`**, and utils for **`stringifyWithBigInt`**, **`decodePermissionContext`**, **`getErrorDisplay`**, and **`formatDelegatedExecutionError`**.
> 
> **Behavior / deps:** **`@metamask/smart-accounts-kit`** is bumped to **^1.6.0** (lockfile refresh). Redeem failures run through **`decodeRevertReason`** via **`formatDelegatedExecutionError`**, with **`ErrorAlert`** showing a short summary and expandable full details. **`invalidateNonces`** encoding now passes **`Number(...)`** for the Permit2 **`uint48`** nonce arg.
> 
> **Minor:** Bundler/MetaMask viem clients are built as a base client then **`.extend(...)`** for clearer typing; error banner styling supports long multiline messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d4f640845ce817a657d8a07518b31e8d5e5bc09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->