### PR TITLE
chore: upgrade MetaMask action npm publish to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
     if: needs.is-release.outputs.IS_RELEASE == 'true'
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       SLACK_WEBHOOK_URL:
         required: true
 env:
@@ -60,7 +60,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry run publish to NPM
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -70,6 +70,9 @@ jobs:
     environment: npm-publish
     runs-on: ubuntu-latest
     needs: publish-npm-dry-run
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -81,6 +84,6 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish to NPM
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.39.0"
   },
-  "packageManager": "yarn@4.14.1",
+  "packageManager": "yarn@4.16.0",
   "engines": {
     "node": "^20 || >=22"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10
 
 "@adraffy/ens-normalize@npm:1.10.1":


### PR DESCRIPTION
## **Description**

Moving forward, we are replacing NPM tokens with [trusted publishing using OIDC](https://docs.npmjs.com/trusted-publishers), and we are now supporting [NPM staged publishing](https://docs.npmjs.com/staged-publishing/). This is a critical step in locking down our software supply chain.

This PR upgrades to MetaMask/action-npm-publish@v6. Doing this will automatically implement the new OIDC and staged publishing changes.

The instructions for upgrading are:

- Update the publishing workflow to have id-token: write permission, and make the NPM token optional. 
- Bump the Yarn version to 4.16.0 or higher.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release NPM publish path and auth model (OIDC + optional token); a misconfiguration could block or alter how packages are published on release merges.
> 
> **Overview**
> Upgrades release publishing from **`MetaMask/action-npm-publish@v5` to `@v6`** on both the NPM dry-run and publish jobs.
> 
> To support the new action (typically **OIDC / trusted publishing**), the workflows grant **`id-token: write`** on the main `publish-release` caller and on the `publish-npm` job (with **`contents: read`** there). **`NPM_TOKEN`** is no longer required at the reusable workflow secret level (`required: false`), while the publish step can still pass the token when configured.
> 
> Also bumps the repo **`packageManager`** to **Yarn 4.16.0** with the matching **`yarn.lock`** metadata update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ae054ea35cc57dd98f4d30ab3c41b467188ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->