### PR TITLE
Add default publish workflow permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,10 @@ on:
         required: false
       SLACK_WEBHOOK_URL:
         required: true
+
+permissions:
+  contents: read
+
 env:
   SNAP_ENV: ${{ vars.SNAP_ENV }}
   PRICE_API_BASE_URL: ${{ vars.PRICE_API_BASE_URL }}


### PR DESCRIPTION
## **Description**

Adds a top-level default permissions block to the publish release workflow so workflow jobs start with read-only contents access unless they explicitly request broader permissions.

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only least-privilege default; release and NPM jobs already declare the permissions they need, so runtime behavior should be unchanged.
> 
> **Overview**
> Adds a workflow-level **`permissions: contents: read`** block to **`publish-release.yml`**, so reusable publish jobs inherit read-only repository access by default instead of broader implicit **`GITHUB_TOKEN`** scopes.
> 
> Jobs that still need more access keep their existing overrides: **`publish-release`** keeps **`contents: write`** for GitHub releases, and **`publish-npm`** keeps **`contents: read`** plus **`id-token: write`** for OIDC publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b1b8425c6341a8dbcb68f26f2c397cc30373ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->