### PR TITLE
Narrow the list of chains on which we enforce sentinel redemption

### DIFF
--- a/packages/gator-permissions-snap/src/core/sentinelRedeemer.ts
+++ b/packages/gator-permissions-snap/src/core/sentinelRedeemer.ts
@@ -16,21 +16,12 @@ export const SENTINEL_REDEEMER_ADDRESSES = [
 
 export const SENTINEL_SUPPORTED_CHAINS = [
   0x1, // Ethereum Mainnet
-  0xa, // OP Mainnet
-  0x38, // BNB Smart Chain Mainnet
-  0x89, // Polygon Mainnet
   0xa4b1, // Arbitrum One
-  0xa86a, // Avalanche C-Chain
-  0xe708, // Linea Mainnet
   0x2105, // Base
-  0x531, // Sei Network
-  0x8f, // Monad
-  0x10e6, // MegaETH Mainnet
-  0x1079, // Tempo Mainnet Presto
-  0x13b2, // Arc
+  0x38, // BNB Smart Chain Mainnet
   0xaa36a7, // Ethereum Sepolia
   0x14a34, // Base Sepolia
-] as const satisfies readonly number[];
+] satisfies readonly number[];
 
 const UNISWAP_HOSTNAME = 'uniswap.org';
 

--- a/packages/gator-permissions-snap/test/core/sentinelRedeemer.test.ts
+++ b/packages/gator-permissions-snap/test/core/sentinelRedeemer.test.ts
@@ -53,21 +53,12 @@ describe('normalizePermissionRequestWithSentinelRedeemerRule', () => {
     ]);
   });
 
-  it('supports all Sentinel-enabled mainnets and testnets', () => {
+  it('supports all designated Sentinel mainnets and testnets', () => {
     expect(SENTINEL_SUPPORTED_CHAINS).toStrictEqual([
       0x1, // Ethereum Mainnet
-      0xa, // OP Mainnet
-      0x38, // BNB Smart Chain Mainnet
-      0x89, // Polygon Mainnet
       0xa4b1, // Arbitrum One
-      0xa86a, // Avalanche C-Chain
-      0xe708, // Linea Mainnet
       0x2105, // Base
-      0x531, // Sei Network
-      0x8f, // Monad
-      0x10e6, // MegaETH Mainnet
-      0x1079, // Tempo Mainnet Presto
-      0x13b2, // Arc
+      0x38, // BNB Smart Chain Mainnet
       0xaa36a7, // Ethereum Sepolia
       0x14a34, // Base Sepolia
     ]);


### PR DESCRIPTION
## **Description**

Permissions granted via uniswap domain have a `redeemer` rule added with sentinel addresses, if sentinel is available on that chain.

This PR reduces the chains on which this is enforced to those with the largest swap traffic, and their testnets (where sentinel is available):
- Eth mainnet
- Arbitrum mainnet
- Base mainnet
- BSC mainnet
- Eth sepolia
- Base sepolia


## **Manual testing steps**

Request any permission, while spoofing uniswap.org domain. Ensure that the redeemer is only added on the chains listed above (and none of the chains removed in this PR):
-  0xa, // OP Mainnet
-  0x38, // BNB Smart Chain Mainnet
-  0x89, // Polygon Mainnet
-  0xa86a, // Avalanche C-Chain
-  0xe708, // Linea Mainnet
-  0x531, // Sei Network
-  0x8f, // Monad
-  0x10e6, // MegaETH Mainnet
-  0x1079, // Tempo

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which chains require Sentinel-only redemption for Uniswap permissions, which affects permission redemption policy on removed networks but does not alter redeemer addresses or origin checks.
> 
> **Overview**
> **Uniswap-origin permission requests** no longer auto-inject the Sentinel **`redeemer`** rule on every chain where Sentinel exists. Enforcement is limited to six chains: Ethereum, Arbitrum, Base, BSC mainnets plus Ethereum Sepolia and Base Sepolia.
> 
> **Removed** from `SENTINEL_SUPPORTED_CHAINS` (so Uniswap grants on these chains behave like other origins unless the app supplies its own redeemer rule): OP, Polygon, Avalanche, Linea, Sei, Monad, MegaETH, Tempo Presto, and Arc. BSC stays on the list; only ordering and the `as const satisfies` typing on the array were adjusted.
> 
> Tests were updated to match the shorter chain list and renamed to reflect “designated” chains rather than “all Sentinel-enabled” networks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5110560ab69646d3668f0f0f2f3edd858c64b03d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->