### PR TITLE
Implement shared `callOnceGuard`

### DIFF
--- a/packages/gator-permissions-snap/src/core/callOnceGuard.ts
+++ b/packages/gator-permissions-snap/src/core/callOnceGuard.ts
@@ -1,0 +1,16 @@
+import { InternalError } from '@metamask/snaps-sdk';
+
+/**
+ * Creates a guard that throws if invoked more than once.
+ * @param name - Label included in the error message (e.g. `Foo.bar()`).
+ * @returns A function that throws on a second call.
+ */
+export function createCallOnceGuard(name: string): () => void {
+  let called = false;
+  return () => {
+    if (called) {
+      throw new InternalError(`${name} called more than once`);
+    }
+    called = true;
+  };
+}

--- a/packages/gator-permissions-snap/src/core/confirmation.tsx
+++ b/packages/gator-permissions-snap/src/core/confirmation.tsx
@@ -1,14 +1,17 @@
 import { UserInputEventType } from '@metamask/snaps-sdk';
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 
-import type { DialogInterface } from './dialogInterface';
 import type { UserEventDispatcher } from '../userEventDispatcher';
+import { createCallOnceGuard } from './callOnceGuard';
+import type { DialogInterface } from './dialogInterface';
 import type { Timeout, TimeoutFactory } from './timeoutFactory';
 import type { ConfirmationProps } from './types';
 
 /**
  * Dialog for handling user confirmation of permission grants.
  * Manages the UI state, timeout behavior, and user interactions.
+ * One instance per permission request; {@link displayConfirmationDialogAndAwaitUserDecision}
+ * must only be called once.
  */
 export class ConfirmationDialog {
   static readonly cancelButton = 'cancel-button';
@@ -35,6 +38,10 @@ export class ConfirmationDialog {
   #decisionResolve: ((value: boolean) => void) | undefined;
 
   readonly #onBeforeGrant: () => Promise<boolean>;
+
+  readonly #callOnceGuard = createCallOnceGuard(
+    'ConfirmationDialog.displayConfirmationDialogAndAwaitUserDecision()',
+  );
 
   constructor({
     dialogInterface,
@@ -77,6 +84,8 @@ export class ConfirmationDialog {
   /**
    * Waits for the user to grant or cancel the confirmation.
    * @returns Object with isApproved boolean.
+   * @throws If called more than once on the same instance.
+   * @throws If {@link initialize} has not been called.
    */
   async displayConfirmationDialogAndAwaitUserDecision(): Promise<{
     isApproved: boolean;
@@ -85,6 +94,8 @@ export class ConfirmationDialog {
     if (!interfaceId) {
       throw new Error('Interface not yet created. Call initialize() first.');
     }
+
+    this.#callOnceGuard();
 
     const isApproved = new Promise<boolean>((resolve, reject) => {
       this.#decisionResolve = resolve;

--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationShell.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationShell.ts
@@ -37,6 +37,7 @@ import type {
   AccountController,
   AccountUpgradeStatus,
 } from '../accountController';
+import { createCallOnceGuard } from '../callOnceGuard';
 import { getChainMetadata } from '../chainMetadata';
 import { EXISTING_PERMISSIONS_CONFIRM_BUTTON } from '../existingpermissions';
 import type { ExistingPermissionsState } from '../existingpermissions/existingPermissionsState';
@@ -87,6 +88,7 @@ export type ConfirmationShellParams<
 
 /**
  * Permission-agnostic confirmation chrome and event wiring for permission requests.
+ * One instance per permission request; {@link bindSessionEvents} must only be called once.
  */
 export class ConfirmationShell<
   TContext extends BaseContext,
@@ -122,6 +124,10 @@ export class ConfirmationShell<
   #tokenBalanceFiat: string | null = null;
 
   #accountUpgradeStatus: AccountUpgradeStatus = { isUpgraded: true };
+
+  readonly #callOnceGuard = createCallOnceGuard(
+    'ConfirmationShell.bindSessionEvents()',
+  );
 
   constructor({
     userEventDispatcher,
@@ -223,10 +229,13 @@ export class ConfirmationShell<
    * Registers session events for the confirmation dialog.
    * @param args - Session identifiers, rules, and context update callback.
    * @returns Unbind function for the registered handlers.
+   * @throws If called more than once on the same instance.
    */
   bindSessionEvents(
     args: ConfirmationShellBindSessionArgs<TContext, TMetadata>,
   ): () => void {
+    this.#callOnceGuard();
+
     const { interfaceId, initialContext, rules, updateContext } = args;
 
     let currentContext = initialContext;

--- a/packages/gator-permissions-snap/src/core/coordinators/ExistingPermissionsCoordinator.ts
+++ b/packages/gator-permissions-snap/src/core/coordinators/ExistingPermissionsCoordinator.ts
@@ -3,6 +3,7 @@ import { logger } from '@metamask/7715-permissions-shared/utils';
 import { InternalError } from '@metamask/snaps-sdk';
 
 import type { StoredGrantedPermission } from '../../profileSync/profileSync';
+import { createCallOnceGuard } from '../callOnceGuard';
 import type { DialogInterface } from '../dialogInterface';
 import type { ExistingPermissionsService } from '../existingpermissions';
 import { ExistingPermissionsState } from '../existingpermissions/existingPermissionsState';
@@ -15,11 +16,13 @@ import type { BaseContext } from '../types';
 export class ExistingPermissionsCoordinator {
   readonly #existingPermissionsService: ExistingPermissionsService;
 
-  #prefetched = false;
-
   #snapshotPromise: Promise<StoredGrantedPermission[]> | undefined;
 
   #statusPromise: Promise<ExistingPermissionsState> | undefined;
+
+  readonly #callOnceGuard = createCallOnceGuard(
+    'ExistingPermissionsCoordinator.prefetch()',
+  );
 
   constructor({
     existingPermissionsService,
@@ -38,12 +41,7 @@ export class ExistingPermissionsCoordinator {
    * @throws If called more than once on the same instance.
    */
   prefetch(origin: string, permission: Permission): void {
-    if (this.#prefetched) {
-      throw new InternalError(
-        'ExistingPermissionsCoordinator.prefetch() called more than once',
-      );
-    }
-    this.#prefetched = true;
+    this.#callOnceGuard();
 
     this.#snapshotPromise =
       this.#existingPermissionsService.getExistingPermissions(origin);

--- a/packages/gator-permissions-snap/src/core/coordinators/TrustSignalsCoordinator.ts
+++ b/packages/gator-permissions-snap/src/core/coordinators/TrustSignalsCoordinator.ts
@@ -1,5 +1,4 @@
 import { logger } from '@metamask/7715-permissions-shared/utils';
-import { InternalError } from '@metamask/snaps-sdk';
 import type { Hex } from '@metamask/utils';
 
 import type {
@@ -7,6 +6,7 @@ import type {
   ScanDappUrlResult,
   TrustSignalsClient,
 } from '../../clients/trustSignalsClient';
+import { createCallOnceGuard } from '../callOnceGuard';
 
 /**
  * Runs trust-signal scans in the background and tracks the latest results.
@@ -21,7 +21,9 @@ export class TrustSignalsCoordinator {
 
   #scanAddressResult: FetchAddressScanResult | null = null;
 
-  #started = false;
+  readonly #callOnceGuard = createCallOnceGuard(
+    'TrustSignalsCoordinator.start()',
+  );
 
   constructor({
     trustSignalsClient,
@@ -66,12 +68,7 @@ export class TrustSignalsCoordinator {
       scanAddressResult: FetchAddressScanResult | null;
     }) => void;
   }): void {
-    if (this.#started) {
-      throw new InternalError(
-        'TrustSignalsCoordinator.start() called more than once',
-      );
-    }
-    this.#started = true;
+    this.#callOnceGuard();
 
     const { origin, chainId, delegateAddress, onResults } = args;
 

--- a/packages/gator-permissions-snap/src/userEventDispatcher.ts
+++ b/packages/gator-permissions-snap/src/userEventDispatcher.ts
@@ -223,7 +223,7 @@ export class UserEventDispatcher {
    * for other event types, while maintaining proper ordering and sequential execution.
    *
    * @returns A function that handles user input events.
-   * @throws If the handler has already been created.
+   * @throws If called more than once on the same instance.
    */
   public createUserInputEventHandler(): (args: {
     event: UserInputEvent;

--- a/packages/gator-permissions-snap/src/userEventDispatcher.ts
+++ b/packages/gator-permissions-snap/src/userEventDispatcher.ts
@@ -6,7 +6,9 @@ import type {
   InputChangeEvent,
   UserInputEvent,
 } from '@metamask/snaps-sdk';
-import { InternalError, UserInputEventType } from '@metamask/snaps-sdk';
+import { UserInputEventType } from '@metamask/snaps-sdk';
+
+import { createCallOnceGuard } from './core/callOnceGuard';
 
 export type DialogContentEventHandlers = {
   elementName: string;
@@ -63,10 +65,9 @@ export class UserEventDispatcher {
     [userInputEventKey: string]: UserEventHandler<UserInputEventType>[];
   };
 
-  /**
-   * Flag to ensure only one component can get the event handler
-   */
-  #hasEventHandler = false;
+  readonly #callOnceGuard = createCallOnceGuard(
+    'UserEventDispatcher.createUserInputEventHandler()',
+  );
 
   /**
    * Queue for processing events sequentially to prevent race conditions
@@ -228,12 +229,7 @@ export class UserEventDispatcher {
     event: UserInputEvent;
     id: string;
   }) => Promise<void> {
-    if (this.#hasEventHandler) {
-      throw new InternalError(
-        'User input event handler has already been created',
-      );
-    }
-    this.#hasEventHandler = true;
+    this.#callOnceGuard();
 
     return async (args: { event: UserInputEvent; id: string }) => {
       const { event, id } = args;

--- a/packages/gator-permissions-snap/test/core/callOnceGuard.test.ts
+++ b/packages/gator-permissions-snap/test/core/callOnceGuard.test.ts
@@ -1,0 +1,30 @@
+import { InternalError } from '@metamask/snaps-sdk';
+
+import { createCallOnceGuard } from '../../src/core/callOnceGuard';
+
+describe('createCallOnceGuard', () => {
+  it('allows the first call', () => {
+    const guard = createCallOnceGuard('Example.method()');
+
+    expect(() => guard()).not.toThrow();
+  });
+
+  it('throws InternalError on subsequent calls', () => {
+    const guard = createCallOnceGuard('Example.method()');
+
+    guard();
+
+    for (let i = 0; i < 5; i++) {
+      expect(() => guard()).toThrow(InternalError);
+    }
+  });
+
+  it('does not share state across guards', () => {
+    const first = createCallOnceGuard('First.method()');
+    const second = createCallOnceGuard('Second.method()');
+
+    first();
+
+    expect(() => second()).not.toThrow();
+  });
+});

--- a/packages/gator-permissions-snap/test/core/confirmation.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, beforeEach, it, jest } from '@jest/globals';
 import { createMockSnapsProvider } from '@metamask/7715-permissions-shared/testing';
-import { UserInputEventType } from '@metamask/snaps-sdk';
+import { InternalError, UserInputEventType } from '@metamask/snaps-sdk';
 import { Text } from '@metamask/snaps-sdk/jsx';
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 
@@ -161,6 +161,87 @@ describe('ConfirmationDialog', () => {
       await expect(
         newDialog.displayConfirmationDialogAndAwaitUserDecision(),
       ).rejects.toThrow('Interface not yet created. Call initialize() first.');
+    });
+
+    it('throws if displayConfirmationDialogAndAwaitUserDecision is called more than once', async () => {
+      const first =
+        confirmationDialog.displayConfirmationDialogAndAwaitUserDecision();
+
+      await expect(
+        confirmationDialog.displayConfirmationDialogAndAwaitUserDecision(),
+      ).rejects.toThrow(InternalError);
+      await expect(
+        confirmationDialog.displayConfirmationDialogAndAwaitUserDecision(),
+      ).rejects.toThrow(
+        'ConfirmationDialog.displayConfirmationDialogAndAwaitUserDecision() called more than once',
+      );
+
+      const grantButtonHandler = mockUserEventDispatcher.on.mock.calls.find(
+        (call) => call[0].elementName === 'grant-button',
+      )?.[0]?.handler;
+
+      if (grantButtonHandler === undefined) {
+        throw new Error('Grant button handler is undefined');
+      }
+
+      await grantButtonHandler({
+        event: { type: UserInputEventType.ButtonClickEvent },
+        interfaceId: mockInterfaceId,
+      });
+
+      await first;
+    });
+
+    it('does not consume the call-once guard when initialize has not run', async () => {
+      const newDialogInterface = new DialogInterface(mockSnapsProvider);
+      const newDialog = new ConfirmationDialog({
+        dialogInterface: newDialogInterface,
+        ui: mockUi,
+        userEventDispatcher: mockUserEventDispatcher,
+        onBeforeGrant: mockOnBeforeGrant,
+        timeoutFactory: mockTimeoutFactory,
+      });
+
+      await expect(
+        newDialog.displayConfirmationDialogAndAwaitUserDecision(),
+      ).rejects.toThrow('Interface not yet created. Call initialize() first.');
+
+      mockSnapsProvider.request.mockImplementation(async (params: any) => {
+        if (params.method === 'snap_createInterface') {
+          return mockInterfaceId;
+        }
+        if (params.method === 'snap_dialog') {
+          return new Promise(() => {
+            // Dialog stays open
+          });
+        }
+        if (params.method === 'snap_resolveInterface') {
+          return null;
+        }
+        return null;
+      });
+
+      await newDialog.initialize();
+
+      const awaitingUserDecision =
+        newDialog.displayConfirmationDialogAndAwaitUserDecision();
+
+      const grantButtonHandler = mockUserEventDispatcher.on.mock.calls.find(
+        (call) => call[0].elementName === 'grant-button',
+      )?.[0]?.handler;
+
+      if (grantButtonHandler === undefined) {
+        throw new Error('Grant button handler is undefined');
+      }
+
+      await grantButtonHandler({
+        event: { type: UserInputEventType.ButtonClickEvent },
+        interfaceId: mockInterfaceId,
+      });
+
+      await expect(awaitingUserDecision).resolves.toStrictEqual({
+        isApproved: true,
+      });
     });
 
     it('should resolve with true when grant button clicked', async () => {

--- a/packages/gator-permissions-snap/test/core/confirmation/ConfirmationShell.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation/ConfirmationShell.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import type { PermissionRequest } from '@metamask/7715-permissions-shared/types';
 import { NO_ASSET_ADDRESS } from '@metamask/7715-permissions-shared/types';
-import { UserInputEventType } from '@metamask/snaps-sdk';
+import { InternalError, UserInputEventType } from '@metamask/snaps-sdk';
 import { Text } from '@metamask/snaps-sdk/jsx';
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 
@@ -347,6 +347,34 @@ describe('ConfirmationShell', () => {
 
       expect(accountSelectorBoundEvent).toBeDefined();
       expect(showMoreButtonBoundEvent).toBeDefined();
+    });
+
+    it('throws if bindSessionEvents is called more than once', () => {
+      const { confirmationShell, rules, updateContext } = setupTest();
+
+      confirmationShell.bindSessionEvents({
+        interfaceId: mockInterfaceId,
+        initialContext: mockContext,
+        rules,
+        updateContext,
+      });
+
+      expect(() =>
+        confirmationShell.bindSessionEvents({
+          interfaceId: mockInterfaceId,
+          initialContext: mockContext,
+          rules,
+          updateContext,
+        }),
+      ).toThrow(InternalError);
+      expect(() =>
+        confirmationShell.bindSessionEvents({
+          interfaceId: mockInterfaceId,
+          initialContext: mockContext,
+          rules,
+          updateContext,
+        }),
+      ).toThrow('ConfirmationShell.bindSessionEvents() called more than once');
     });
 
     it('loads the balance for the selected account', async () => {

--- a/packages/gator-permissions-snap/test/userEventDispatcher.test.ts
+++ b/packages/gator-permissions-snap/test/userEventDispatcher.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { describe, it, beforeEach, expect, jest } from '@jest/globals';
 import type { InputChangeEvent, ButtonClickEvent } from '@metamask/snaps-sdk';
-import { UserInputEventType } from '@metamask/snaps-sdk';
+import { InternalError, UserInputEventType } from '@metamask/snaps-sdk';
 
 import { UserEventDispatcher } from '../src/userEventDispatcher';
 
@@ -316,12 +316,17 @@ describe('UserEventDispatcher', () => {
   });
 
   describe('createUserInputEventHandler', () => {
-    it('should throw error when creating multiple handlers', () => {
+    it('throws if createUserInputEventHandler is called more than once', () => {
       userEventDispatcher.createUserInputEventHandler();
 
       expect(() => {
         userEventDispatcher.createUserInputEventHandler();
-      }).toThrow('User input event handler has already been created');
+      }).toThrow(InternalError);
+      expect(() => {
+        userEventDispatcher.createUserInputEventHandler();
+      }).toThrow(
+        'UserEventDispatcher.createUserInputEventHandler() called more than once',
+      );
     });
 
     it('should do nothing when no handlers are registered', async () => {


### PR DESCRIPTION
## **Description**

The `TrustSignalsCoordinator` and `ExistingPermissionsCoordinator` implement call once guards. This PR refactors this guard into a shared `callOnceGuard` and adds this guard to `ConfirmationDialog.displayConfirmationDialogAndAwaitUserDecision()` and `ConfirmationShell.bindSessionEvents()`.

The new guards are protecting functionality that was already only called once, but with no explicit restrictions. There is no change in behaviour.

## **Manual testing steps**

This has functional change in behaviour.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive enforcement of already-once call paths in the permissions snap UI layer; duplicate calls now fail fast with consistent errors instead of undefined behavior.
> 
> **Overview**
> Introduces **`createCallOnceGuard`**, a small helper that throws `InternalError` with a labeled message on a second invocation, and uses it to enforce one-call-per-instance semantics across permission confirmation plumbing.
> 
> **ExistingPermissionsCoordinator** and **TrustSignalsCoordinator** drop their ad hoc `#prefetched` / `#started` flags in favor of the shared guard on `prefetch()` and `start()`. The same pattern is added to **`ConfirmationDialog.displayConfirmationDialogAndAwaitUserDecision()`**, **`ConfirmationShell.bindSessionEvents()`**, and **`UserEventDispatcher.createUserInputEventHandler()`** (replacing `#hasEventHandler`). JSDoc on the dialog and shell notes the one-instance-per-request contract.
> 
> On **`ConfirmationDialog`**, the guard runs only after the `initialize()` check, so a call without an interface still fails without consuming the once-only slot—covered by a new test. Unit tests cover the guard itself and duplicate-call behavior on the affected classes; dispatcher expectations now assert `InternalError` and the standardized message format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0f048d49582ba05b6749834adcf24cceebcebee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->