### PR TITLE
feat: Add Robinhood chain and Robinhood chain testnet

### DIFF
--- a/packages/gator-permissions-snap/src/core/chainMetadata.ts
+++ b/packages/gator-permissions-snap/src/core/chainMetadata.ts
@@ -146,6 +146,10 @@ export const nameAndExplorerUrlByChainId: Record<
   0x64: { name: 'Gnosis', explorerUrl: 'https://gnosisscan.io' },
   0x82: { name: 'Unichain', explorerUrl: 'https://uniscan.xyz' },
   0x89: { name: 'Polygon Mainnet', explorerUrl: 'https://polygonscan.com' },
+  0x1237: {
+    name: 'Robinhood Chain',
+    explorerUrl: 'https://robinhoodchain.blockscout.com',
+  },
   0x2105: { name: 'Base', explorerUrl: 'https://basescan.org' },
   0xa4b1: { name: 'Arbitrum One', explorerUrl: 'https://arbiscan.io' },
   0xa4ba: {
@@ -172,6 +176,10 @@ export const nameAndExplorerUrlByChainId: Record<
   0x27d8: {
     name: 'Gnosis Chiado Testnet',
     explorerUrl: 'https://gnosis-chiado.blockscout.com',
+  },
+  0xb626: {
+    name: 'Robinhood Chain Testnet',
+    explorerUrl: 'https://explorer.testnet.chain.robinhood.com',
   },
   0xe705: {
     name: 'Linea Sepolia Testnet',

--- a/packages/site/.env.example
+++ b/packages/site/.env.example
@@ -2,4 +2,5 @@
 VITE_KERNEL_SNAP_ORIGIN=local:http://localhost:8081
 VITE_GATOR_SNAP_ORIGIN=local:http://localhost:8082
 VITE_BUNDLER_RPC_URL=https://<bundler-url>
-VITE_SUPPORTED_CHAINS=11155111
+# Comma-separated chain IDs. Includes Robinhood Chain (4663) and Robinhood Chain Testnet (46630).
+VITE_SUPPORTED_CHAINS=11155111,4663,46630

--- a/packages/site/src/config/chains.ts
+++ b/packages/site/src/config/chains.ts
@@ -1,8 +1,62 @@
-import { extractChain } from 'viem';
+import { defineChain, extractChain } from 'viem';
 import type { Chain } from 'viem';
 import * as chains from 'viem/chains';
 
-const ALL_CHAINS = [...Object.values(chains)];
+/**
+ * Robinhood Chain is not yet included in viem/chains.
+ * Network details: https://docs.robinhood.com/chain/add-network-to-wallet/
+ */
+export const robinhoodChain = defineChain({
+  id: 4663,
+  name: 'Robinhood Chain',
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.mainnet.chain.robinhood.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Robinhood Chain Explorer',
+      url: 'https://robinhoodchain.blockscout.com',
+    },
+  },
+});
+
+/**
+ * Robinhood Chain Testnet is not yet included in viem/chains.
+ * Network details: https://docs.robinhood.com/chain/add-network-to-wallet/
+ */
+export const robinhoodChainTestnet = defineChain({
+  id: 46630,
+  name: 'Robinhood Chain Testnet',
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.testnet.chain.robinhood.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Robinhood Chain Testnet Explorer',
+      url: 'https://explorer.testnet.chain.robinhood.com',
+    },
+  },
+});
+
+const ALL_CHAINS = [
+  ...Object.values(chains),
+  robinhoodChain,
+  robinhoodChainTestnet,
+];
 
 const DEFAULT_CHAINS = [chains.sepolia];
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds chain configuration for Robinhood chain and Robinhood chain testnet. In order to support the chains, it is only necessary for Launch Darkly to be configured to support EIP-7702 on those chains.

This PR adds chain name and explorer URL, so that the permission picker UI can show the network name and link to the chain explorer.

Here is the WETH chain explorer link generated for an ERC-20 permission request on Robinhood mainnet: https://robinhoodchain.blockscout.com/address/0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="521" height="631" alt="image" src="https://github.com/user-attachments/assets/bb72af76-52de-402a-9e07-036dfb521097" />

Testnet is not yet supported in infura

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive chain metadata and dev-site configuration only; no changes to permission enforcement or auth logic.
> 
> **Overview**
> Adds **Robinhood Chain** (4663) and **Robinhood Chain Testnet** (46630) so the permission picker can show network names and block explorer links.
> 
> In `gator-permissions-snap`, `nameAndExplorerUrlByChainId` gains entries for both chains (Blockscout mainnet, Robinhood testnet explorer). The demo **site** defines the networks with `viem`’s `defineChain` (RPC + explorers) because they are not in `viem/chains` yet, and merges them into the chain list used by `VITE_SUPPORTED_CHAINS`. `.env.example` documents including `4663` and `46630` alongside Sepolia for local dev.
> 
> Full EIP-7702 support on these chains still depends on LaunchDarkly configuration, as noted in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c8b9a01483d42839bc6deee4c01cb28b5015151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->