### PR TITLE
chore: bump @metamask/7715-permission-types to v1.0.0 and update smart-accounts-kit to v1.7.0

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -28,9 +28,9 @@
     ]
   },
   "dependencies": {
-    "@metamask/7715-permission-types": "0.7.1",
+    "@metamask/7715-permission-types": "1.0.0",
     "@metamask/providers": "22.1.1",
-    "@metamask/smart-accounts-kit": "^1.6.0",
+    "@metamask/smart-accounts-kit": "^1.7.0",
     "@metamask/utils": "11.11.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,10 +2823,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/7715-permission-types@npm:0.7.1, @metamask/7715-permission-types@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@metamask/7715-permission-types@npm:0.7.1"
-  checksum: 10/2cbe7b8d09ae9b11171d2f9c36bf94f1acea17f9541b399bf99caa14e500c0e91d79e69a4846db2c80b18aa0df0215b36be1ea661cc99f4d6b5bc8d9eea5a4dd
+"@metamask/7715-permission-types@npm:1.0.0, @metamask/7715-permission-types@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/7715-permission-types@npm:1.0.0"
+  dependencies:
+    "@metamask/delegation-core": "npm:^2.2.1"
+    "@metamask/utils": "npm:^11.4.0"
+  checksum: 10/df565c43c05daa4ef35b2e57bfdf9062e3e928d8fa43194c27c7149f4e2fdb7bda05b2397267b2f9fed3e42a8c26e956483262b2e8d39e63c2045c069cb53e66
   languageName: node
   linkType: hard
 
@@ -3563,11 +3566,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-accounts-kit@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@metamask/smart-accounts-kit@npm:1.6.0"
+"@metamask/smart-accounts-kit@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@metamask/smart-accounts-kit@npm:1.7.0"
   dependencies:
-    "@metamask/7715-permission-types": "npm:^0.7.1"
+    "@metamask/7715-permission-types": "npm:^1.0.0"
     "@metamask/delegation-abis": "npm:^1.1.0"
     "@metamask/delegation-core": "npm:^2.2.1"
     "@metamask/delegation-deployments": "npm:^1.4.0"
@@ -3576,7 +3579,7 @@ __metadata:
     ox: "npm:0.8.1"
   peerDependencies:
     viem: ^2.31.4
-  checksum: 10/807713727f6c65a2a4b94c226b4db20128e0dcdf48bc8ec3f1022ac081a058e90a5c2a69c9e99729eb600f955ac52c91dea949fee1e9a9a82585788081924b9a
+  checksum: 10/4258c02743d57f13b0962e4a07acd7ae6d73fd68b1694dc80becdc4f9d73557ed725754dbbfba4b75aeb394fccf97fd1f528a457e8713abea3161e2b93689e49
   languageName: node
   linkType: hard
 
@@ -13648,13 +13651,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "site@workspace:packages/site"
   dependencies:
-    "@metamask/7715-permission-types": "npm:0.7.1"
+    "@metamask/7715-permission-types": "npm:1.0.0"
     "@metamask/eslint-config": "npm:15.0.0"
     "@metamask/eslint-config-jest": "npm:15.0.0"
     "@metamask/eslint-config-nodejs": "npm:15.0.0"
     "@metamask/eslint-config-typescript": "npm:15.0.0"
     "@metamask/providers": "npm:22.1.1"
-    "@metamask/smart-accounts-kit": "npm:^1.6.0"
+    "@metamask/smart-accounts-kit": "npm:^1.7.0"
     "@metamask/utils": "npm:11.11.0"
     "@types/jest": "npm:27.5.2"
     "@types/react": "npm:19.2.3"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major-version permission-types and smart-accounts-kit upgrades can change runtime types/behavior for permission and delegation flows in the site demo, though the diff is dependency-only.
> 
> **Overview**
> Updates **`packages/site`** dependency versions only: **`@metamask/7715-permission-types`** from **0.7.1** to **1.0.0** and **`@metamask/smart-accounts-kit`** from **^1.6.0** to **^1.7.0**, with matching **`yarn.lock`** resolution entries (including **`smart-accounts-kit`** now pulling **`^1.0.0`** permission types).
> 
> There are **no application source changes** in this diff; the demo site continues to consume the same smart-accounts-kit APIs for bundler actions, delegation, and ERC-7715 provider flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820f146d99a86f019bf21e92bde1b855d033e0c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->