### PR TITLE
Decouple existing permissions navigation from context

### DIFF
--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
@@ -54,6 +54,15 @@ type ConfirmationSessionStateUpdate<TContext extends BaseContext> = Partial<
 >;
 
 /**
+ * Update request for {@link ConfirmationSession}'s serialized render pipeline.
+ * `showExistingPermissions` is resolved against the chained state, not outer `state`.
+ */
+type ConfirmationSessionUpdateRequest<TContext extends BaseContext> =
+  ConfirmationSessionStateUpdate<TContext> & {
+    showExistingPermissions?: boolean;
+  };
+
+/**
  * Lifecycle callbacks used by {@link ConfirmationSession.#renderConfirmation}.
  */
 type ConfirmationRenderLifecycleHandlers<
@@ -164,6 +173,36 @@ export class ConfirmationSession {
         isGrantDisabled: update.isGrantDisabled,
       }),
       ...(update.view !== undefined && { view: update.view }),
+    };
+  }
+
+  /**
+   * Resolves navigation intent and explicit field updates against chained state.
+   * @param currentState - Latest serialized session state for the request.
+   * @param update - Partial update and optional existing-permissions navigation.
+   * @returns Fields to merge before rendering.
+   */
+  #resolveStateUpdate<TContext extends BaseContext>(
+    currentState: ConfirmationSessionState<TContext>,
+    update: ConfirmationSessionUpdateRequest<TContext>,
+  ): ConfirmationSessionStateUpdate<TContext> {
+    const { showExistingPermissions, ...stateUpdate } = update;
+
+    if (showExistingPermissions === undefined) {
+      return stateUpdate;
+    }
+
+    let view: ConfirmationView = 'main';
+    if (showExistingPermissions) {
+      view =
+        currentState.view === 'main'
+          ? 'enteringExistingPermissions'
+          : 'existingPermissions';
+    }
+
+    return {
+      ...stateUpdate,
+      view,
     };
   }
 
@@ -362,11 +401,16 @@ export class ConfirmationSession {
       Promise.resolve(state);
 
     const updateConfirmation = async (
-      update: ConfirmationSessionStateUpdate<TContext> = {},
+      update: ConfirmationSessionUpdateRequest<TContext> = {},
     ): Promise<void> => {
       const runUpdate = async (): Promise<void> => {
         renderChain = renderChain.then(async (currentState) => {
-          const updatedState = this.#applyStateUpdate(currentState, update);
+          const resolvedUpdate = this.#resolveStateUpdate(currentState, update);
+          const updatedState = this.#applyStateUpdate(
+            currentState,
+            resolvedUpdate,
+          );
+          state = updatedState;
 
           const view = await this.#renderConfirmation({
             state: updatedState,
@@ -380,11 +424,11 @@ export class ConfirmationSession {
             hasValidationErrors,
           });
 
-          // the view may have changed during render, so we need to update the state
-          return this.#applyStateUpdate(updatedState, { view });
+          state = this.#applyStateUpdate(updatedState, { view });
+          return state;
         });
 
-        state = await renderChain;
+        await renderChain;
       };
 
       lastRenderPromise = lastRenderPromise.finally(runUpdate);
@@ -438,15 +482,7 @@ export class ConfirmationSession {
         show: boolean,
       ): Promise<void> => {
         try {
-          let view: ConfirmationView = 'main';
-          if (show) {
-            view =
-              state.view === 'main'
-                ? 'enteringExistingPermissions'
-                : 'existingPermissions';
-          }
-
-          await updateConfirmation({ view });
+          await updateConfirmation({ showExistingPermissions: show });
         } catch (error) {
           await confirmationDialog.closeWithError(error as Error);
           throw error;

--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
@@ -55,7 +55,8 @@ type ConfirmationSessionStateUpdate<TContext extends BaseContext> = Partial<
 
 /**
  * Update request for {@link ConfirmationSession}'s serialized render pipeline.
- * `showExistingPermissions` is resolved against the chained state, not outer `state`.
+ * `showExistingPermissions` is resolved against the latest session state when the
+ * update runs, not when the caller enqueues it.
  */
 type ConfirmationSessionUpdateRequest<TContext extends BaseContext> =
   ConfirmationSessionStateUpdate<TContext> & {
@@ -177,8 +178,8 @@ export class ConfirmationSession {
   }
 
   /**
-   * Resolves navigation intent and explicit field updates against chained state.
-   * @param currentState - Latest serialized session state for the request.
+   * Resolves navigation intent and explicit field updates against session state.
+   * @param currentState - Session state at the start of this serialized update.
    * @param update - Partial update and optional existing-permissions navigation.
    * @returns Fields to merge before rendering.
    */
@@ -396,61 +397,57 @@ export class ConfirmationSession {
       confirmationDialog.displayConfirmationDialogAndAwaitUserDecision();
 
     let lastRenderPromise: Promise<void> = Promise.resolve();
-    let renderChain: Promise<ConfirmationSessionState<TContext>> =
-      Promise.resolve(state);
 
     const updateConfirmation = async (
       update: ConfirmationSessionUpdateRequest<TContext> = {},
     ): Promise<void> => {
       const runUpdate = async (): Promise<void> => {
-        let stepFailed = false;
-        let stepError: unknown;
+        const previousState = state;
+        let nextState = previousState;
+        try {
+          const resolvedUpdate = this.#resolveStateUpdate(
+            previousState,
+            update,
+          );
+          const updatedState = this.#applyStateUpdate(
+            previousState,
+            resolvedUpdate,
+          );
 
-        renderChain = renderChain.then(async (currentState) => {
-          try {
-            const resolvedUpdate = this.#resolveStateUpdate(
-              currentState,
-              update,
-            );
-            const updatedState = this.#applyStateUpdate(
-              currentState,
-              resolvedUpdate,
-            );
-            state = updatedState;
+          const view = await this.#renderConfirmation({
+            state: updatedState,
+            lifecycleHandlers,
+            existingPermissionsCoordinator,
+            trustSignalsCoordinator,
+            dialogInterface,
+            confirmationDialog,
+            origin,
+            chainId,
+            hasValidationErrors,
+          });
 
-            const view = await this.#renderConfirmation({
-              state: updatedState,
-              lifecycleHandlers,
-              existingPermissionsCoordinator,
-              trustSignalsCoordinator,
-              dialogInterface,
-              confirmationDialog,
-              origin,
-              chainId,
-              hasValidationErrors,
-            });
-
-            state = this.#applyStateUpdate(updatedState, { view });
-            return state;
-          } catch (error) {
-            state = currentState;
-            stepFailed = true;
-            stepError = error;
-            logger.debug('ConfirmationSession: render update failed', {
-              origin,
-              error: error instanceof Error ? error.message : error,
-            });
-            return currentState;
-          }
-        });
-
-        await renderChain;
-
-        if (stepFailed) {
-          throw stepError;
+          nextState = this.#applyStateUpdate(updatedState, { view });
+        } catch (error) {
+          nextState = previousState;
+          logger.debug('ConfirmationSession: render update failed', {
+            origin,
+            error: error instanceof Error ? error.message : error,
+          });
+          throw error;
+        } finally {
+          // Updates are serialized via lastRenderPromise; previousState is the authoritative pre-await snapshot.
+          // eslint-disable-next-line require-atomic-updates -- see lastRenderPromise comment below
+          state = nextState;
         }
       };
 
+      // Serialize confirmation renders so concurrent updates (trust signals, context
+      // edits, subview navigation) never interleave. Each runUpdate snapshots `state`
+      // as previousState at entry; that is only safe because lastRenderPromise
+      // guarantees the prior update finished and assigned `state`. On failure, roll
+      // back to previousState so UI and session state stay aligned, then rethrow.
+      // The leading .catch() keeps the queue alive after a rejected step so later
+      // updates still run (trust-signal callers swallow errors locally).
       lastRenderPromise = lastRenderPromise
         .catch(() => undefined)
         .then(runUpdate);
@@ -458,12 +455,8 @@ export class ConfirmationSession {
       await lastRenderPromise;
     };
 
-    // no need to execute the update handler if the results have already settled, as we immediately
-    // call updateConfirmation below.
     trustSignalsCoordinator.onUpdate(() => {
-      updateConfirmation({
-        isGrantDisabled: false,
-      }).catch(() => undefined);
+      updateConfirmation().catch(() => undefined);
     });
 
     try {

--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
@@ -3,21 +3,93 @@ import type {
   PermissionRequest,
 } from '@metamask/7715-permissions-shared/types';
 import { logger } from '@metamask/7715-permissions-shared/utils';
+import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 import { numberToHex, parseCaipAccountId } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import type { TrustSignalsClient } from '../../clients/trustSignalsClient';
+import type {
+  FetchAddressScanResult,
+  ScanDappUrlResult,
+  TrustSignalsClient,
+} from '../../clients/trustSignalsClient';
 import type { SnapsMetricsService } from '../../services/snapsMetricsService';
 import type { AccountController } from '../accountController';
+import { ConfirmationDialog } from '../confirmation';
 import type { ConfirmationDialogFactory } from '../confirmationFactory';
 import { ExistingPermissionsCoordinator } from '../coordinators/ExistingPermissionsCoordinator';
 import { TrustSignalsCoordinator } from '../coordinators/TrustSignalsCoordinator';
 import type { DialogInterface } from '../dialogInterface';
 import type { DialogInterfaceFactory } from '../dialogInterfaceFactory';
 import type { ExistingPermissionsService } from '../existingpermissions';
+import type { ExistingPermissionsState } from '../existingpermissions/existingPermissionsState';
 import type { PermissionRequestLifecycleHandlers } from '../permission/PermissionRequestLifecycleHandlers';
 import type { PermissionIntroductionService } from '../permissionIntroduction';
 import type { BaseContext, BaseMetadata, DeepRequired } from '../types';
+
+/**
+ * Which confirmation surface is active for the session.
+ */
+type ConfirmationView =
+  | 'main'
+  | 'enteringExistingPermissions'
+  | 'existingPermissions';
+
+/**
+ * UI and permission state for a single confirmation session.
+ */
+type ConfirmationSessionState<TContext extends BaseContext> = {
+  context: TContext;
+  isGrantDisabled: boolean;
+  view: ConfirmationView;
+};
+
+/**
+ * Partial updates applied before re-rendering the confirmation dialog.
+ */
+type ConfirmationSessionStateUpdate<TContext extends BaseContext> = Partial<
+  Pick<
+    ConfirmationSessionState<TContext>,
+    'context' | 'isGrantDisabled' | 'view'
+  >
+>;
+
+/**
+ * Lifecycle callbacks used by {@link ConfirmationSession.#renderConfirmation}.
+ */
+type ConfirmationRenderLifecycleHandlers<
+  TContext extends BaseContext,
+  TMetadata extends BaseMetadata,
+> = {
+  deriveMetadata: (args: { context: TContext }) => Promise<TMetadata>;
+  createConfirmationContent: (args: {
+    context: TContext;
+    metadata: TMetadata;
+    origin: string;
+    chainId: number;
+    scanDappUrlResult: ScanDappUrlResult | null;
+    scanAddressResult: FetchAddressScanResult | null;
+    existingPermissionsStatus: ExistingPermissionsState;
+    isGrantDisabled: boolean;
+  }) => Promise<SnapElement>;
+};
+
+/**
+ * Per-request dependencies passed into {@link ConfirmationSession.#renderConfirmation}.
+ */
+type ConfirmationRenderContext<
+  TContext extends BaseContext,
+  TMetadata extends BaseMetadata,
+> = {
+  state: ConfirmationSessionState<TContext>;
+  lifecycleHandlers: ConfirmationRenderLifecycleHandlers<TContext, TMetadata>;
+  existingPermissionsCoordinator: ExistingPermissionsCoordinator;
+  trustSignalsCoordinator: TrustSignalsCoordinator;
+  dialogInterface: DialogInterface;
+  confirmationDialog: ConfirmationDialog;
+  origin: string;
+  chainId: number;
+  hasValidationErrors: (metadata: TMetadata) => boolean;
+};
 
 /**
  * Result of running a confirmation session through intro and grant UI.
@@ -73,6 +145,90 @@ export class ConfirmationSession {
     this.#trustSignalsClient = trustSignalsClient;
     this.#accountController = accountController;
     this.#snapsMetricsService = snapsMetricsService;
+  }
+
+  /**
+   * Returns session state with a partial update applied.
+   * @param state - Current session state for the request.
+   * @param update - Fields to merge into the returned state.
+   * @returns Updated session state.
+   */
+  #applyStateUpdate<TContext extends BaseContext>(
+    state: ConfirmationSessionState<TContext>,
+    update: ConfirmationSessionStateUpdate<TContext>,
+  ): ConfirmationSessionState<TContext> {
+    return {
+      ...state,
+      ...(update.context !== undefined && { context: update.context }),
+      ...(update.isGrantDisabled !== undefined && {
+        isGrantDisabled: update.isGrantDisabled,
+      }),
+      ...(update.view !== undefined && { view: update.view }),
+    };
+  }
+
+  /**
+   * Re-renders the confirmation dialog from the current session state.
+   * @param context - Per-request render dependencies and state.
+   * @returns The view state after rendering.
+   */
+  async #renderConfirmation<
+    TContext extends BaseContext,
+    TMetadata extends BaseMetadata,
+  >(
+    context: ConfirmationRenderContext<TContext, TMetadata>,
+  ): Promise<ConfirmationView> {
+    const {
+      state,
+      lifecycleHandlers,
+      existingPermissionsCoordinator,
+      trustSignalsCoordinator,
+      dialogInterface,
+      confirmationDialog,
+      origin,
+      chainId,
+      hasValidationErrors,
+    } = context;
+
+    const metadata = await lifecycleHandlers.deriveMetadata({
+      context: state.context,
+    });
+
+    const existingPermissionsStatus =
+      await existingPermissionsCoordinator.getStatus();
+
+    const grantDisabled =
+      state.isGrantDisabled || hasValidationErrors(metadata);
+
+    const { scanDappUrlResult, scanAddressResult } =
+      trustSignalsCoordinator.getResults();
+
+    if (state.view === 'enteringExistingPermissions') {
+      await existingPermissionsCoordinator.showSubview({
+        dialogInterface,
+        enteringSubview: true,
+      });
+
+      // within this function, the view only changes when transitioning from 'enteringExistingPermissions' to 'existingPermissions'
+      return 'existingPermissions';
+    }
+
+    if (state.view === 'main') {
+      const ui = await lifecycleHandlers.createConfirmationContent({
+        context: state.context,
+        metadata,
+        origin,
+        chainId,
+        scanDappUrlResult,
+        scanAddressResult,
+        existingPermissionsStatus,
+        isGrantDisabled: grantDisabled,
+      });
+
+      await confirmationDialog.updateContent({ ui });
+    }
+
+    return state.view;
   }
 
   /**
@@ -152,13 +308,13 @@ export class ConfirmationSession {
     // permissions are requested before the confirmation dialog is shown.
     await this.#accountController.getAccountAddresses();
 
-    let context: TContext;
-
     const hasValidationErrors = (metadata: TMetadata): boolean => {
       return Object.values(metadata?.validationErrors ?? {}).some(
         (message) => typeof message === 'string',
       );
     };
+
+    let state: ConfirmationSessionState<TContext>;
 
     // Validation callback that runs when grant button is clicked.
     // Race condition scenario this prevents:
@@ -169,12 +325,15 @@ export class ConfirmationSession {
     //   5. Button handler already invoked (button was enabled at click time)
     //   6. This callback catches it → returns false → dialog stays open
     const onBeforeGrant = async (): Promise<boolean> => {
-      const metadata = await lifecycleHandlers.deriveMetadata({ context });
+      const metadata = await lifecycleHandlers.deriveMetadata({
+        context: state.context,
+      });
       return !hasValidationErrors(metadata);
     };
 
     const skeletonUi =
       await lifecycleHandlers.createSkeletonConfirmationContent();
+
     const confirmationDialog =
       this.#confirmationDialogFactory.createConfirmation({
         dialogInterface,
@@ -185,7 +344,11 @@ export class ConfirmationSession {
     const interfaceId = await confirmationDialog.initialize();
 
     try {
-      context = await lifecycleHandlers.buildContext(normalizedRequest);
+      state = {
+        context: await lifecycleHandlers.buildContext(normalizedRequest),
+        isGrantDisabled: false,
+        view: 'main',
+      };
     } catch (error) {
       await confirmationDialog.closeWithError(error as Error);
       throw error;
@@ -194,69 +357,39 @@ export class ConfirmationSession {
     const decisionPromise =
       confirmationDialog.displayConfirmationDialogAndAwaitUserDecision();
 
-    let lastUpdateConfirmationPromise: Promise<void> = Promise.resolve();
+    let lastRenderPromise: Promise<void> = Promise.resolve();
+    let renderChain: Promise<ConfirmationSessionState<TContext>> =
+      Promise.resolve(state);
 
-    let existingPermissionsSubviewActive = false;
-
-    const updateConfirmation = async ({
-      newContext,
-      isGrantDisabled,
-    }: {
-      newContext?: TContext;
-      isGrantDisabled: boolean;
-    }): Promise<void> => {
+    const updateConfirmation = async (
+      update: ConfirmationSessionStateUpdate<TContext> = {},
+    ): Promise<void> => {
       const runUpdate = async (): Promise<void> => {
-        if (newContext) {
-          context = newContext;
-        }
+        renderChain = renderChain.then(async (currentState) => {
+          const updatedState = this.#applyStateUpdate(currentState, update);
 
-        const metadata = await lifecycleHandlers.deriveMetadata({ context });
-
-        const existingPermissionsStatus =
-          await existingPermissionsCoordinator.getStatus();
-
-        const grantDisabled = isGrantDisabled || hasValidationErrors(metadata);
-
-        const { scanDappUrlResult, scanAddressResult } =
-          trustSignalsCoordinator.getResults();
-
-        if (context.showExistingPermissions) {
-          const enteringSubview = !existingPermissionsSubviewActive;
-          if (enteringSubview) {
-            // Set synchronously before awaits so eslint require-atomic-updates is satisfied;
-            // runUpdate calls are serialized via lastUpdateConfirmationPromise.
-            existingPermissionsSubviewActive = true;
-          }
-
-          await existingPermissionsCoordinator.maybeShowSubview({
+          const view = await this.#renderConfirmation({
+            state: updatedState,
+            lifecycleHandlers,
+            existingPermissionsCoordinator,
+            trustSignalsCoordinator,
             dialogInterface,
-            context,
-            enteringSubview,
+            confirmationDialog,
+            origin,
+            chainId,
+            hasValidationErrors,
           });
 
-          return;
-        }
-
-        existingPermissionsSubviewActive = false;
-
-        const ui = await lifecycleHandlers.createConfirmationContent({
-          context,
-          metadata,
-          origin,
-          chainId,
-          scanDappUrlResult,
-          scanAddressResult,
-          existingPermissionsStatus,
-          isGrantDisabled: grantDisabled,
+          // the view may have changed during render, so we need to update the state
+          return this.#applyStateUpdate(updatedState, { view });
         });
 
-        await confirmationDialog.updateContent({ ui });
+        state = await renderChain;
       };
 
-      lastUpdateConfirmationPromise =
-        lastUpdateConfirmationPromise.finally(runUpdate);
+      lastRenderPromise = lastRenderPromise.finally(runUpdate);
 
-      await lastUpdateConfirmationPromise;
+      await lastRenderPromise;
     };
 
     // no need to execute the update handler if the results have already settled, as we immediately
@@ -273,16 +406,14 @@ export class ConfirmationSession {
     });
 
     try {
-      await updateConfirmation({
-        isGrantDisabled: false,
-      });
+      await updateConfirmation();
 
       await this.#snapsMetricsService.trackPermissionDialogShown({
         origin,
         permissionType,
         chainId: normalizedRequest.chainId,
         permissionData: normalizedRequest.permission.data,
-        justification: context.justification,
+        justification: state.context.justification,
       });
     } catch (error) {
       await confirmationDialog.closeWithError(error as Error);
@@ -296,10 +427,26 @@ export class ConfirmationSession {
         updatedContext: TContext;
       }): Promise<void> => {
         try {
-          await updateConfirmation({
-            newContext: updatedContext,
-            isGrantDisabled: false,
-          });
+          await updateConfirmation({ context: updatedContext });
+        } catch (error) {
+          await confirmationDialog.closeWithError(error as Error);
+          throw error;
+        }
+      };
+
+      const onExistingPermissionsViewChange = async (
+        show: boolean,
+      ): Promise<void> => {
+        try {
+          let view: ConfirmationView = 'main';
+          if (show) {
+            view =
+              state.view === 'main'
+                ? 'enteringExistingPermissions'
+                : 'existingPermissions';
+          }
+
+          await updateConfirmation({ view });
         } catch (error) {
           await confirmationDialog.closeWithError(error as Error);
           throw error;
@@ -309,7 +456,8 @@ export class ConfirmationSession {
       lifecycleHandlers.onConfirmationCreated({
         interfaceId,
         updateContext,
-        initialContext: context,
+        onExistingPermissionsViewChange,
+        initialContext: state.context,
       });
     }
 
@@ -318,7 +466,9 @@ export class ConfirmationSession {
 
       if (isApproved) {
         try {
-          const { address } = parseCaipAccountId(context.accountAddressCaip10);
+          const { address } = parseCaipAccountId(
+            state.context.accountAddressCaip10,
+          );
           const upgradeStatus =
             await this.#accountController.getAccountUpgradeStatus({
               account: address,
@@ -349,7 +499,7 @@ export class ConfirmationSession {
 
         return {
           isApproved: true,
-          context,
+          context: state.context,
         };
       }
 
@@ -358,7 +508,7 @@ export class ConfirmationSession {
         permissionType,
         chainId: normalizedRequest.chainId,
         permissionData: normalizedRequest.permission.data,
-        justification: context.justification,
+        justification: state.context.justification,
       });
 
       return {

--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
@@ -245,7 +245,6 @@ export class ConfirmationSession {
     if (state.view === 'enteringExistingPermissions') {
       await existingPermissionsCoordinator.showSubview({
         dialogInterface,
-        enteringSubview: true,
       });
 
       // within this function, the view only changes when transitioning from 'enteringExistingPermissions' to 'existingPermissions'

--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
@@ -404,34 +404,57 @@ export class ConfirmationSession {
       update: ConfirmationSessionUpdateRequest<TContext> = {},
     ): Promise<void> => {
       const runUpdate = async (): Promise<void> => {
+        let stepFailed = false;
+        let stepError: unknown;
+
         renderChain = renderChain.then(async (currentState) => {
-          const resolvedUpdate = this.#resolveStateUpdate(currentState, update);
-          const updatedState = this.#applyStateUpdate(
-            currentState,
-            resolvedUpdate,
-          );
-          state = updatedState;
+          try {
+            const resolvedUpdate = this.#resolveStateUpdate(
+              currentState,
+              update,
+            );
+            const updatedState = this.#applyStateUpdate(
+              currentState,
+              resolvedUpdate,
+            );
+            state = updatedState;
 
-          const view = await this.#renderConfirmation({
-            state: updatedState,
-            lifecycleHandlers,
-            existingPermissionsCoordinator,
-            trustSignalsCoordinator,
-            dialogInterface,
-            confirmationDialog,
-            origin,
-            chainId,
-            hasValidationErrors,
-          });
+            const view = await this.#renderConfirmation({
+              state: updatedState,
+              lifecycleHandlers,
+              existingPermissionsCoordinator,
+              trustSignalsCoordinator,
+              dialogInterface,
+              confirmationDialog,
+              origin,
+              chainId,
+              hasValidationErrors,
+            });
 
-          state = this.#applyStateUpdate(updatedState, { view });
-          return state;
+            state = this.#applyStateUpdate(updatedState, { view });
+            return state;
+          } catch (error) {
+            state = currentState;
+            stepFailed = true;
+            stepError = error;
+            logger.debug('ConfirmationSession: render update failed', {
+              origin,
+              error: error instanceof Error ? error.message : error,
+            });
+            return currentState;
+          }
         });
 
         await renderChain;
+
+        if (stepFailed) {
+          throw stepError;
+        }
       };
 
-      lastRenderPromise = lastRenderPromise.finally(runUpdate);
+      lastRenderPromise = lastRenderPromise
+        .catch(() => undefined)
+        .then(runUpdate);
 
       await lastRenderPromise;
     };
@@ -441,12 +464,7 @@ export class ConfirmationSession {
     trustSignalsCoordinator.onUpdate(() => {
       updateConfirmation({
         isGrantDisabled: false,
-      }).catch((error: unknown) => {
-        logger.debug('ConfirmationSession: trust signal UI update failed', {
-          origin,
-          error: error instanceof Error ? error.message : error,
-        });
-      });
+      }).catch(() => undefined);
     });
 
     try {

--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationShell.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationShell.ts
@@ -66,6 +66,7 @@ export type ConfirmationShellBindSessionArgs<
   initialContext: TContext;
   rules: RuleDefinition<TContext, TMetadata>[];
   updateContext: (args: { updatedContext: TContext }) => Promise<void>;
+  onExistingPermissionsViewChange: (show: boolean) => Promise<void>;
 };
 
 export type ConfirmationShellParams<
@@ -236,7 +237,13 @@ export class ConfirmationShell<
   ): () => void {
     this.#callOnceGuard();
 
-    const { interfaceId, initialContext, rules, updateContext } = args;
+    const {
+      interfaceId,
+      initialContext,
+      rules,
+      updateContext,
+      onExistingPermissionsViewChange,
+    } = args;
 
     let currentContext = initialContext;
     const rerender = async (): Promise<void> => {
@@ -382,11 +389,7 @@ export class ConfirmationShell<
         eventType: UserInputEventType.ButtonClickEvent,
         interfaceId,
         handler: async () => {
-          currentContext = {
-            ...currentContext,
-            showExistingPermissions: true,
-          };
-          await rerender();
+          await onExistingPermissionsViewChange(true);
         },
       });
 
@@ -396,11 +399,7 @@ export class ConfirmationShell<
         eventType: UserInputEventType.ButtonClickEvent,
         interfaceId,
         handler: async () => {
-          currentContext = {
-            ...currentContext,
-            showExistingPermissions: false,
-          };
-          await rerender();
+          await onExistingPermissionsViewChange(false);
         },
       });
 

--- a/packages/gator-permissions-snap/src/core/coordinators/ExistingPermissionsCoordinator.ts
+++ b/packages/gator-permissions-snap/src/core/coordinators/ExistingPermissionsCoordinator.ts
@@ -7,7 +7,6 @@ import { createCallOnceGuard } from '../callOnceGuard';
 import type { DialogInterface } from '../dialogInterface';
 import type { ExistingPermissionsService } from '../existingpermissions';
 import { ExistingPermissionsState } from '../existingpermissions/existingPermissionsState';
-import type { BaseContext } from '../types';
 
 /**
  * Prefetches existing-permissions snapshot data and manages the existing-permissions subview.
@@ -83,40 +82,33 @@ export class ExistingPermissionsCoordinator {
   }
 
   /**
-   * Shows the existing-permissions subview when requested by context.
+   * Shows the existing-permissions subview when the session enters it for the first time.
    *
    * @param args - Subview display parameters.
    * @param args.dialogInterface - Shared dialog interface for the request.
-   * @param args.context - Current confirmation context.
    * @param args.enteringSubview - Whether the subview is being entered for the first time.
-   * @returns `handled: true` when the caller should skip the normal confirmation content update.
    * @throws If {@link prefetch} has not been called.
    */
-  async maybeShowSubview(args: {
+  async showSubview(args: {
     dialogInterface: DialogInterface;
-    context: BaseContext;
     enteringSubview: boolean;
-  }): Promise<{ handled: boolean }> {
+  }): Promise<void> {
     if (!this.#snapshotPromise) {
       throw new InternalError(
-        'ExistingPermissionsCoordinator.maybeShowSubview() called before prefetch()',
+        'ExistingPermissionsCoordinator.showSubview() called before prefetch()',
       );
     }
 
-    const { dialogInterface, context, enteringSubview } = args;
+    const { dialogInterface, enteringSubview } = args;
 
-    if (context.showExistingPermissions) {
-      if (enteringSubview) {
-        const snapshot = await this.#snapshotPromise;
-        await this.#existingPermissionsService.showExistingPermissions(
-          dialogInterface,
-          snapshot,
-        );
-      }
-
-      return { handled: true };
+    if (!enteringSubview) {
+      return;
     }
 
-    return { handled: false };
+    const snapshot = await this.#snapshotPromise;
+    await this.#existingPermissionsService.showExistingPermissions(
+      dialogInterface,
+      snapshot,
+    );
   }
 }

--- a/packages/gator-permissions-snap/src/core/coordinators/ExistingPermissionsCoordinator.ts
+++ b/packages/gator-permissions-snap/src/core/coordinators/ExistingPermissionsCoordinator.ts
@@ -82,28 +82,20 @@ export class ExistingPermissionsCoordinator {
   }
 
   /**
-   * Shows the existing-permissions subview when the session enters it for the first time.
+   * Shows the existing-permissions subview.
    *
    * @param args - Subview display parameters.
    * @param args.dialogInterface - Shared dialog interface for the request.
-   * @param args.enteringSubview - Whether the subview is being entered for the first time.
    * @throws If {@link prefetch} has not been called.
    */
-  async showSubview(args: {
-    dialogInterface: DialogInterface;
-    enteringSubview: boolean;
-  }): Promise<void> {
+  async showSubview(args: { dialogInterface: DialogInterface }): Promise<void> {
     if (!this.#snapshotPromise) {
       throw new InternalError(
         'ExistingPermissionsCoordinator.showSubview() called before prefetch()',
       );
     }
 
-    const { dialogInterface, enteringSubview } = args;
-
-    if (!enteringSubview) {
-      return;
-    }
+    const { dialogInterface } = args;
 
     const snapshot = await this.#snapshotPromise;
     await this.#existingPermissionsService.showExistingPermissions(

--- a/packages/gator-permissions-snap/src/core/permission/PermissionModule.ts
+++ b/packages/gator-permissions-snap/src/core/permission/PermissionModule.ts
@@ -116,6 +116,8 @@ export function buildRequestLifecycleHandlers<
         initialContext: sessionArgs.initialContext,
         rules: module.rules,
         updateContext: sessionArgs.updateContext,
+        onExistingPermissionsViewChange:
+          sessionArgs.onExistingPermissionsViewChange,
       });
     },
     onConfirmationResolved: (): void => {

--- a/packages/gator-permissions-snap/src/core/permission/PermissionRequestLifecycleHandlers.ts
+++ b/packages/gator-permissions-snap/src/core/permission/PermissionRequestLifecycleHandlers.ts
@@ -52,6 +52,7 @@ export type PermissionRequestLifecycleHandlers<
     updateContext: (updateContextArgs: {
       updatedContext: TContext;
     }) => Promise<void>;
+    onExistingPermissionsViewChange: (show: boolean) => Promise<void>;
   }) => void;
   onConfirmationResolved?: () => void;
 };

--- a/packages/gator-permissions-snap/src/core/types.ts
+++ b/packages/gator-permissions-snap/src/core/types.ts
@@ -49,11 +49,6 @@ export type BaseContext = {
     iconDataBase64: string | null;
   };
   /**
-   * When true, the confirmation UI shows stored permissions for this site instead of the grant form.
-   * Omitted or falsey means the normal confirmation content. Set by the permission handler when the user opens the existing-permissions view.
-   */
-  showExistingPermissions?: boolean | null;
-  /**
    * Allowed redeemer addresses from the dapp-provided redeemer rule (read-only in the UI).
    */
   redeemerAddresses?: string[] | undefined;

--- a/packages/gator-permissions-snap/test/core/confirmation/ConfirmationSession.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation/ConfirmationSession.test.ts
@@ -430,26 +430,10 @@ describe('ConfirmationSession', () => {
     await sessionPromise;
   });
 
-  it('shows the existing permissions subview when updateContext sets showExistingPermissions', async () => {
-    const subviewContext: BaseContext = {
-      ...mockContext,
-      showExistingPermissions: true,
-      justification: '',
-      expiry: { timestamp: 1733088000 },
-      accountAddressCaip10: fixedCaip10Address,
-      tokenAddressCaip19: 'eip155:1:0x1234/erc20:0x1234',
-      tokenMetadata: {
-        decimals: 18,
-        symbol: 'TEST',
-        iconDataBase64: null,
-      },
-    };
-
+  it('shows the existing permissions subview when onExistingPermissionsViewChange is called', async () => {
     let capturedParams:
       | {
-          updateContext: (args: {
-            updatedContext: BaseContext;
-          }) => Promise<void>;
+          onExistingPermissionsViewChange: (show: boolean) => Promise<void>;
         }
       | undefined;
 
@@ -480,7 +464,7 @@ describe('ConfirmationSession', () => {
     const createContentCallsBefore =
       lifecycleHandlerMocks.createConfirmationContent.mock.calls.length;
 
-    await capturedParams?.updateContext({ updatedContext: subviewContext });
+    await capturedParams?.onExistingPermissionsViewChange(true);
 
     expect(
       mockExistingPermissionsService.showExistingPermissions,
@@ -508,25 +492,9 @@ describe('ConfirmationSession', () => {
       async () => new Promise<FetchAddressScanResult>(() => {}),
     );
 
-    const subviewContext: BaseContext = {
-      ...mockContext,
-      showExistingPermissions: true,
-      justification: '',
-      expiry: { timestamp: 1733088000 },
-      accountAddressCaip10: fixedCaip10Address,
-      tokenAddressCaip19: 'eip155:1:0x1234/erc20:0x1234',
-      tokenMetadata: {
-        decimals: 18,
-        symbol: 'TEST',
-        iconDataBase64: null,
-      },
-    };
-
     let capturedParams:
       | {
-          updateContext: (args: {
-            updatedContext: BaseContext;
-          }) => Promise<void>;
+          onExistingPermissionsViewChange: (show: boolean) => Promise<void>;
         }
       | undefined;
 
@@ -552,7 +520,7 @@ describe('ConfirmationSession', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    await capturedParams?.updateContext({ updatedContext: subviewContext });
+    await capturedParams?.onExistingPermissionsViewChange(true);
 
     const createContentCallsAfterSubview =
       lifecycleHandlerMocks.createConfirmationContent.mock.calls.length;

--- a/packages/gator-permissions-snap/test/core/confirmation/ConfirmationSession.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation/ConfirmationSession.test.ts
@@ -477,6 +477,70 @@ describe('ConfirmationSession', () => {
     await sessionPromise;
   });
 
+  it('does not call showExistingPermissions twice when existing permissions is opened twice before the first subview render completes', async () => {
+    let resolveShowExistingPermissions: () => void = () => {
+      throw new Error('resolveShowExistingPermissions not set');
+    };
+
+    mockExistingPermissionsService.showExistingPermissions.mockImplementation(
+      async () =>
+        new Promise<void>((resolve) => {
+          resolveShowExistingPermissions = resolve;
+        }),
+    );
+
+    let capturedParams:
+      | {
+          onExistingPermissionsViewChange: (show: boolean) => Promise<void>;
+        }
+      | undefined;
+
+    lifecycleHandlerMocks.onConfirmationCreated?.mockImplementation(
+      (params) => {
+        capturedParams = params;
+      },
+    );
+
+    let resolveUserDecision: (decision: boolean) => void = (_) => {
+      throw new Error('resolveUserDecision not set');
+    };
+    mockConfirmationDialog.displayConfirmationDialogAndAwaitUserDecision.mockImplementation(
+      async () => {
+        const isApproved = await new Promise<boolean>((resolve) => {
+          resolveUserDecision = resolve;
+        });
+        return { isApproved };
+      },
+    );
+
+    const sessionPromise = runSession();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(capturedParams).toBeDefined();
+
+    const firstOpen = capturedParams?.onExistingPermissionsViewChange(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(
+      mockExistingPermissionsService.showExistingPermissions,
+    ).toHaveBeenCalledTimes(1);
+
+    const secondOpen = capturedParams?.onExistingPermissionsViewChange(true);
+
+    resolveShowExistingPermissions();
+    await firstOpen;
+    await secondOpen;
+
+    expect(
+      mockExistingPermissionsService.showExistingPermissions,
+    ).toHaveBeenCalledTimes(1);
+
+    resolveUserDecision(true);
+    await sessionPromise;
+  });
+
   it('does not re-render confirmation content when trust signals resolve while the existing permissions subview is open', async () => {
     let resolveDappScan: (result: ScanDappUrlResult) => void = (_) => {
       throw new Error('resolveDappScan not set');

--- a/packages/gator-permissions-snap/test/core/confirmation/ConfirmationSession.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation/ConfirmationSession.test.ts
@@ -541,6 +541,94 @@ describe('ConfirmationSession', () => {
     await sessionPromise;
   });
 
+  it('continues processing confirmation updates after a failed trust signal render', async () => {
+    let createContentCallCount = 0;
+
+    lifecycleHandlerMocks.createConfirmationContent.mockImplementation(
+      async () => {
+        createContentCallCount += 1;
+        if (createContentCallCount === 2) {
+          throw new Error('trust signal render failed');
+        }
+        return mockUiContent;
+      },
+    );
+
+    let resolveDappScan: (result: ScanDappUrlResult) => void = (_) => {
+      throw new Error('resolveDappScan not set');
+    };
+
+    mockTrustSignalsClient.scanDappUrl.mockImplementation(
+      async () =>
+        new Promise<ScanDappUrlResult>((resolve) => {
+          resolveDappScan = resolve;
+        }),
+    );
+    mockTrustSignalsClient.fetchAddressScan.mockImplementation(
+      async () => new Promise<FetchAddressScanResult>(() => {}),
+    );
+
+    let capturedParams:
+      | {
+          updateContext: (args: {
+            updatedContext: BaseContext;
+          }) => Promise<void>;
+        }
+      | undefined;
+
+    lifecycleHandlerMocks.onConfirmationCreated?.mockImplementation(
+      (params) => {
+        capturedParams = params;
+      },
+    );
+
+    let resolveUserDecision: (decision: boolean) => void = (_) => {
+      throw new Error('resolveUserDecision not set');
+    };
+    mockConfirmationDialog.displayConfirmationDialogAndAwaitUserDecision.mockImplementation(
+      async () => {
+        const isApproved = await new Promise<boolean>((resolve) => {
+          resolveUserDecision = resolve;
+        });
+        return { isApproved };
+      },
+    );
+
+    const sessionPromise = runSession();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createContentCallCount).toBe(1);
+
+    resolveDappScan({
+      isComplete: true,
+      recommendedAction: RecommendedAction.WARN,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(createContentCallCount).toBe(2);
+
+    const modifiedContext = {
+      ...mockContext,
+      justification: 'after failed trust signal render',
+    };
+
+    await capturedParams?.updateContext({ updatedContext: modifiedContext });
+
+    expect(createContentCallCount).toBe(3);
+    expect(mockConfirmationDialog.updateContent).toHaveBeenCalled();
+
+    resolveUserDecision(true);
+
+    const result = await sessionPromise;
+
+    expect(result).toStrictEqual({
+      isApproved: true,
+      context: modifiedContext,
+    });
+  });
+
   it('does not re-render confirmation content when trust signals resolve while the existing permissions subview is open', async () => {
     let resolveDappScan: (result: ScanDappUrlResult) => void = (_) => {
       throw new Error('resolveDappScan not set');

--- a/packages/gator-permissions-snap/test/core/confirmation/ConfirmationShell.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation/ConfirmationShell.test.ts
@@ -175,10 +175,15 @@ const setupTest = (options?: { rules?: RuleDefinition<any, any>[] }) => {
   const updateContext =
     jest.fn<(args: { updatedContext: TestContextType }) => Promise<void>>();
 
+  const onExistingPermissionsViewChange = jest.fn(async () =>
+    Promise.resolve(),
+  );
+
   return {
     confirmationShell,
     renderBody,
     updateContext,
+    onExistingPermissionsViewChange,
     rules,
     getBoundEvent,
     getUnboundEvent,
@@ -324,13 +329,19 @@ describe('ConfirmationShell', () => {
         }),
         updateContext: (context) => context,
       };
-      const { confirmationShell, rules, getBoundEvent, updateContext } =
-        setupTest({ rules: [rule] });
+      const {
+        confirmationShell,
+        rules,
+        getBoundEvent,
+        updateContext,
+        onExistingPermissionsViewChange,
+      } = setupTest({ rules: [rule] });
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       const accountSelectorBoundEvent = getBoundEvent({
@@ -350,13 +361,19 @@ describe('ConfirmationShell', () => {
     });
 
     it('throws if bindSessionEvents is called more than once', () => {
-      const { confirmationShell, rules, updateContext } = setupTest();
+      const {
+        confirmationShell,
+        rules,
+        updateContext,
+        onExistingPermissionsViewChange,
+      } = setupTest();
 
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       expect(() =>
@@ -365,6 +382,7 @@ describe('ConfirmationShell', () => {
           initialContext: mockContext,
           rules,
           updateContext,
+          onExistingPermissionsViewChange,
         }),
       ).toThrow(InternalError);
       expect(() =>
@@ -373,18 +391,25 @@ describe('ConfirmationShell', () => {
           initialContext: mockContext,
           rules,
           updateContext,
+          onExistingPermissionsViewChange,
         }),
       ).toThrow('ConfirmationShell.bindSessionEvents() called more than once');
     });
 
     it('loads the balance for the selected account', async () => {
-      const { confirmationShell, rules, tokenMetadataService, updateContext } =
-        setupTest();
+      const {
+        confirmationShell,
+        rules,
+        tokenMetadataService,
+        updateContext,
+        onExistingPermissionsViewChange,
+      } = setupTest();
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       expect(
@@ -397,13 +422,19 @@ describe('ConfirmationShell', () => {
     });
 
     it('updates the context when the account is changed', async () => {
-      const { confirmationShell, rules, getBoundEvent, updateContext } =
-        setupTest();
+      const {
+        confirmationShell,
+        rules,
+        getBoundEvent,
+        updateContext,
+        onExistingPermissionsViewChange,
+      } = setupTest();
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       const accountSelectorChangeHandler = getBoundEvent({
@@ -442,12 +473,14 @@ describe('ConfirmationShell', () => {
         getBoundEvent,
         tokenMetadataService,
         updateContext,
+        onExistingPermissionsViewChange,
       } = setupTest();
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       const accountSelectorChangeHandler = getBoundEvent({
@@ -483,12 +516,18 @@ describe('ConfirmationShell', () => {
     });
 
     it('renders the balance in the confirmation content', async () => {
-      const { confirmationShell, rules, updateContext } = setupTest();
+      const {
+        confirmationShell,
+        rules,
+        updateContext,
+        onExistingPermissionsViewChange,
+      } = setupTest();
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       const confirmationContent =
@@ -1100,12 +1139,14 @@ describe('ConfirmationShell', () => {
         getBoundEvent,
         tokenPricesService,
         updateContext,
+        onExistingPermissionsViewChange,
       } = setupTest();
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       const accountSelectorChangeHandler = getBoundEvent({
@@ -1746,6 +1787,7 @@ describe('ConfirmationShell', () => {
         tokenMetadataService,
         tokenPricesService,
         updateContext,
+        onExistingPermissionsViewChange,
       } = setupTest();
 
       let resolveTokenBalancePromise: () => void = (): void => {
@@ -1776,6 +1818,7 @@ describe('ConfirmationShell', () => {
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       const accountSelectorChangeHandler = getBoundEvent({
@@ -3651,6 +3694,7 @@ describe('ConfirmationShell', () => {
         getBoundEvent,
         tokenMetadataService,
         updateContext,
+        onExistingPermissionsViewChange,
       } = setupTest();
 
       let resolveTokenBalancePromise: () => void = (): void => {
@@ -3671,6 +3715,7 @@ describe('ConfirmationShell', () => {
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       const accountSelectorChangeHandler = getBoundEvent({
@@ -3713,12 +3758,14 @@ describe('ConfirmationShell', () => {
         getUnboundEvent,
         getBoundEvent,
         updateContext,
+        onExistingPermissionsViewChange,
       } = setupTest();
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       const accountSelectorBoundEvent = getBoundEvent({
@@ -3765,13 +3812,19 @@ describe('ConfirmationShell', () => {
         }),
         updateContext: (context) => context,
       };
-      const { confirmationShell, rules, getBoundEvent, updateContext } =
-        setupTest({ rules: [rule] });
+      const {
+        confirmationShell,
+        rules,
+        getBoundEvent,
+        updateContext,
+        onExistingPermissionsViewChange,
+      } = setupTest({ rules: [rule] });
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
         initialContext: mockContext,
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       // Try to get a rule input handler - it should still be bound
@@ -3794,8 +3847,13 @@ describe('ConfirmationShell', () => {
     });
 
     it('skips balance fetch when context has no asset address', () => {
-      const { confirmationShell, updateContext, tokenMetadataService, rules } =
-        setupTest();
+      const {
+        confirmationShell,
+        updateContext,
+        tokenMetadataService,
+        rules,
+        onExistingPermissionsViewChange,
+      } = setupTest();
 
       confirmationShell.bindSessionEvents({
         interfaceId: mockInterfaceId,
@@ -3805,6 +3863,7 @@ describe('ConfirmationShell', () => {
         },
         rules,
         updateContext,
+        onExistingPermissionsViewChange,
       });
 
       expect(

--- a/packages/gator-permissions-snap/test/core/coordinators/ExistingPermissionsCoordinator.test.ts
+++ b/packages/gator-permissions-snap/test/core/coordinators/ExistingPermissionsCoordinator.test.ts
@@ -7,7 +7,6 @@ import {
   ExistingPermissionsService,
   ExistingPermissionsState,
 } from '../../../src/core/existingpermissions/existingPermissionsService';
-import type { BaseContext } from '../../../src/core/types';
 import type { StoredGrantedPermission } from '../../../src/profileSync/profileSync';
 
 const mockPermission: Permission = {
@@ -17,19 +16,6 @@ const mockPermission: Permission = {
 };
 
 const mockSnapshot: StoredGrantedPermission[] = [];
-
-const mockContext: BaseContext = {
-  tokenAddressCaip19: 'eip155:1:0x1234/erc20:0x1234',
-  expiry: { timestamp: 1717987200 },
-  isAdjustmentAllowed: true,
-  accountAddressCaip10: 'eip155:1:0x1234',
-  justification: 'Justification',
-  tokenMetadata: {
-    decimals: 18,
-    symbol: 'TKN',
-    iconDataBase64: null,
-  },
-};
 
 describe('ExistingPermissionsCoordinator', () => {
   let mockExistingPermissionsService: jest.Mocked<
@@ -118,7 +104,7 @@ describe('ExistingPermissionsCoordinator', () => {
     });
   });
 
-  describe('maybeShowSubview()', () => {
+  describe('showSubview()', () => {
     const dialogInterface = {} as DialogInterface;
 
     beforeEach(() => {
@@ -132,63 +118,32 @@ describe('ExistingPermissionsCoordinator', () => {
       });
 
       await expect(
-        freshCoordinator.maybeShowSubview({
+        freshCoordinator.showSubview({
           dialogInterface,
-          context: { ...mockContext, showExistingPermissions: true },
           enteringSubview: true,
         }),
       ).rejects.toThrow(
-        'ExistingPermissionsCoordinator.maybeShowSubview() called before prefetch()',
+        'ExistingPermissionsCoordinator.showSubview() called before prefetch()',
       );
     });
 
     it('shows the subview when entering for the first time', async () => {
-      const result = await coordinator.maybeShowSubview({
+      await coordinator.showSubview({
         dialogInterface,
-        context: { ...mockContext, showExistingPermissions: true },
         enteringSubview: true,
       });
 
-      expect(result).toStrictEqual({ handled: true });
       expect(
         mockExistingPermissionsService.showExistingPermissions,
       ).toHaveBeenCalledWith(dialogInterface, mockSnapshot);
     });
 
     it('does not re-show the subview when already entered', async () => {
-      const result = await coordinator.maybeShowSubview({
+      await coordinator.showSubview({
         dialogInterface,
-        context: { ...mockContext, showExistingPermissions: true },
         enteringSubview: false,
       });
 
-      expect(result).toStrictEqual({ handled: true });
-      expect(
-        mockExistingPermissionsService.showExistingPermissions,
-      ).not.toHaveBeenCalled();
-    });
-
-    it('returns handled false when the subview is not requested', async () => {
-      const result = await coordinator.maybeShowSubview({
-        dialogInterface,
-        context: { ...mockContext, showExistingPermissions: false },
-        enteringSubview: false,
-      });
-
-      expect(result).toStrictEqual({ handled: false });
-      expect(
-        mockExistingPermissionsService.showExistingPermissions,
-      ).not.toHaveBeenCalled();
-    });
-
-    it('returns handled false when showExistingPermissions is null', async () => {
-      const result = await coordinator.maybeShowSubview({
-        dialogInterface,
-        context: { ...mockContext, showExistingPermissions: null },
-        enteringSubview: false,
-      });
-
-      expect(result).toStrictEqual({ handled: false });
       expect(
         mockExistingPermissionsService.showExistingPermissions,
       ).not.toHaveBeenCalled();

--- a/packages/gator-permissions-snap/test/core/coordinators/ExistingPermissionsCoordinator.test.ts
+++ b/packages/gator-permissions-snap/test/core/coordinators/ExistingPermissionsCoordinator.test.ts
@@ -120,33 +120,20 @@ describe('ExistingPermissionsCoordinator', () => {
       await expect(
         freshCoordinator.showSubview({
           dialogInterface,
-          enteringSubview: true,
         }),
       ).rejects.toThrow(
         'ExistingPermissionsCoordinator.showSubview() called before prefetch()',
       );
     });
 
-    it('shows the subview when entering for the first time', async () => {
+    it('shows the subview', async () => {
       await coordinator.showSubview({
         dialogInterface,
-        enteringSubview: true,
       });
 
       expect(
         mockExistingPermissionsService.showExistingPermissions,
       ).toHaveBeenCalledWith(dialogInterface, mockSnapshot);
-    });
-
-    it('does not re-show the subview when already entered', async () => {
-      await coordinator.showSubview({
-        dialogInterface,
-        enteringSubview: false,
-      });
-
-      expect(
-        mockExistingPermissionsService.showExistingPermissions,
-      ).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## **Description**

The permission is represented in a number different ways through it's request lifecycle:
- `PermissionRequest` object - the data provided by the caller (it is also parsed, and populated with defaults)
- `Context` object - the data rendered in the confirmation, and modified by the user
- `Metadata` object - data derived from the `Context` each render (validation messages, calculated fields, and other non-persistent data)

The `Context` object also has a couple fields that don't strictly belong here:
- `tokenMetadata`
- `showExistingPermissions`

The `tokenMetadata` will likely need to move into a coordinator or otherwise, if we decouple the token from the permission (support multiple tokens per permission).

This PR addresses the `showExistingPermissions` property - a boolean used to indicate whether the existing permissions view should be shown to the user.

Much like the `isJustificationCollapsed` property, this is a variable that belongs to the confirmation, not the permission itself.

This PR slightly refactors the `PermissionSession` class with the following changes:
 - creates a single `ConfirmationSession` state variable to represent the current state of the confirmation session
 - removes `showExistingPermissions` from `BaseContext` moved into `ConfirmationSession` state
 - refactor `ConfirmationSession` state update and confirmation rendering functions
 - simplify `ExistingPermissionsCoordinator` function `showSubview`
 - condense `ConfirmationSession.state` properties `isExistingPermissionsShown` and `hasExistingPermissionsSubviewBeenShown` into single `view`

The `ConfirmationSession` class is _not_ single use, which means that the state is stored within the closure of the `run()` function, and not as instance variables. I considered changing that within this PR but it seemed unnecessary, and likely to provide minimal value.

## **Manual testing steps**

No functional changes - ensure that existing permissions functionality continues to work as expected.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask 7715 Permissions Snaps Contributor Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches permission confirmation rendering and subview navigation; behavior is intended to be unchanged but concurrent-update and error-recovery paths were reworked in a user-facing flow.
> 
> **Overview**
> Moves **existing-permissions subview navigation** out of permission `BaseContext` into **`ConfirmationSession`** session state (`view`: `main` | `enteringExistingPermissions` | `existingPermissions`), so UI navigation is no longer carried on the grant form context.
> 
> `ConfirmationSession` now drives updates through a **serialized render pipeline** (`#resolveStateUpdate`, `#renderConfirmation`, rollback on failed renders, queue kept alive after trust-signal update failures). **`ConfirmationShell`** opens/closes the subview via a new **`onExistingPermissionsViewChange`** hook instead of toggling `showExistingPermissions` on context. **`ExistingPermissionsCoordinator`** is simplified from `maybeShowSubview` to **`showSubview`** (no context / `handled` branching).
> 
> Tests are updated for the new callback and add coverage for **double-open while subview is loading** and **continuing updates after a failed trust-signal render**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922c1df5581dec046b7696b5c516d0da8ec29953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->