### PR TITLE
feat: restrict permission grant to accounts not supporting EIP-7702

### DIFF
--- a/packages/gator-permissions-snap/locales/en.json
+++ b/packages/gator-permissions-snap/locales/en.json
@@ -172,6 +172,9 @@
     "accountUpgradeWarning": {
       "message": "This account will be upgraded to a smart account to complete this permission."
     },
+    "accountNotSupportingEip7702": {
+      "message": "This account does not support EIP-7702 and cannot grant permissions."
+    },
     "removeFieldAlt": {
       "message": "Remove $1"
     },

--- a/packages/gator-permissions-snap/src/core/accountController.ts
+++ b/packages/gator-permissions-snap/src/core/accountController.ts
@@ -13,6 +13,7 @@ import type { SignDelegationOptions } from './types';
 import { ensureChain } from '../utils/blockchain';
 
 export type AccountUpgradeStatus = {
+  isSupported: boolean;
   isUpgraded: boolean;
 };
 
@@ -187,7 +188,11 @@ export class AccountController {
       const result = (await this.#ethereumProvider.request({
         method: 'wallet_getAccountUpgradeStatus',
         params,
-      })) as { isUpgraded: boolean; upgradedAddress: Hex | null };
+      })) as {
+        isSupported?: boolean;
+        isUpgraded: boolean;
+        upgradedAddress: Hex | null;
+      };
 
       logger.debug('Account upgrade status result', result);
 
@@ -196,6 +201,9 @@ export class AccountController {
       } = getChainMetadata({ chainId: hexToNumber(params.chainId) });
 
       return {
+        // Only an explicit `false` means unsupported; wallets that omit the
+        // field are treated as supported so the request is not blocked.
+        isSupported: result.isSupported !== false,
         isUpgraded:
           result.isUpgraded &&
           result.upgradedAddress?.toLowerCase() ===

--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationSession.ts
@@ -3,6 +3,7 @@ import type {
   PermissionRequest,
 } from '@metamask/7715-permissions-shared/types';
 import { logger } from '@metamask/7715-permissions-shared/utils';
+import { InvalidRequestError } from '@metamask/snaps-sdk';
 import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 import { numberToHex, parseCaipAccountId } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
@@ -13,7 +14,11 @@ import type {
   TrustSignalsClient,
 } from '../../clients/trustSignalsClient';
 import type { SnapsMetricsService } from '../../services/snapsMetricsService';
-import type { AccountController } from '../accountController';
+import { t } from '../../utils/i18n';
+import type {
+  AccountController,
+  AccountUpgradeStatus,
+} from '../accountController';
 import { ConfirmationDialog } from '../confirmation';
 import type { ConfirmationDialogFactory } from '../confirmationFactory';
 import { ExistingPermissionsCoordinator } from '../coordinators/ExistingPermissionsCoordinator';
@@ -511,17 +516,30 @@ export class ConfirmationSession {
       const { isApproved } = await decisionPromise;
 
       if (isApproved) {
+        const { address } = parseCaipAccountId(
+          state.context.accountAddressCaip10,
+        );
+
+        // A failed lookup means "unknown", not "unsupported": it must never
+        // block the request. Only an explicit negative verdict does.
+        let accountStatus: AccountUpgradeStatus | null = null;
         try {
-          const { address } = parseCaipAccountId(
-            state.context.accountAddressCaip10,
-          );
-          const upgradeStatus =
-            await this.#accountController.getAccountUpgradeStatus({
+          accountStatus = await this.#accountController.getAccountUpgradeStatus(
+            {
               account: address,
               chainId: numberToHex(chainId),
-            });
+            },
+          );
+        } catch (error) {
+          logger.error('Failed to check account upgrade status', error);
+        }
 
-          if (!upgradeStatus.isUpgraded) {
+        if (accountStatus && !accountStatus.isSupported) {
+          throw new InvalidRequestError(t('accountNotSupportingEip7702'));
+        }
+
+        try {
+          if (accountStatus && !accountStatus.isUpgraded) {
             let upgradeSuccess = false;
             try {
               await this.#accountController.upgradeAccount({
@@ -540,7 +558,6 @@ export class ConfirmationSession {
           }
         } catch {
           // Silently ignore errors here, we don't want to block the permission request if the account upgrade fails
-          // TODO: When we know extension has support for account upgrade, we can show an error to the user
         }
 
         return {

--- a/packages/gator-permissions-snap/src/core/confirmation/ConfirmationShell.ts
+++ b/packages/gator-permissions-snap/src/core/confirmation/ConfirmationShell.ts
@@ -124,7 +124,10 @@ export class ConfirmationShell<
 
   #tokenBalanceFiat: string | null = null;
 
-  #accountUpgradeStatus: AccountUpgradeStatus = { isUpgraded: true };
+  #accountUpgradeStatus: AccountUpgradeStatus = {
+    isSupported: true,
+    isUpgraded: true,
+  };
 
   readonly #callOnceGuard = createCallOnceGuard(
     'ConfirmationShell.bindSessionEvents()',
@@ -220,8 +223,10 @@ export class ConfirmationShell<
       chainId,
       explorerUrl,
       isAccountUpgraded: this.#accountUpgradeStatus.isUpgraded,
+      isAccountSupported: this.#accountUpgradeStatus.isSupported,
       existingPermissionsStatus,
-      isGrantDisabled,
+      isGrantDisabled:
+        isGrantDisabled || !this.#accountUpgradeStatus.isSupported,
       showTokenBalance: this.#showTokenBalance,
     });
   }
@@ -360,7 +365,7 @@ export class ConfirmationShell<
 
         this.#tokenBalance = null;
         this.#tokenBalanceFiat = null;
-        this.#accountUpgradeStatus = { isUpgraded: true }; // Reset to default while fetching
+        this.#accountUpgradeStatus = { isSupported: true, isUpgraded: true }; // Reset to default while fetching
 
         // we explicitly don't await this as it's a background process that will re-render the UI once it is complete
         const shouldFetchTokenBalanceForAccount =

--- a/packages/gator-permissions-snap/src/core/confirmation/confirmationShellContent.tsx
+++ b/packages/gator-permissions-snap/src/core/confirmation/confirmationShellContent.tsx
@@ -66,6 +66,7 @@ export type ConfirmationShellContentProps = {
   chainId: number;
   explorerUrl: string | undefined;
   isAccountUpgraded: boolean;
+  isAccountSupported: boolean;
   existingPermissionsStatus: ExistingPermissionsState;
   /** When true, the primary grant button is not clickable. */
   isGrantDisabled: boolean;
@@ -94,6 +95,7 @@ export type ConfirmationShellContentProps = {
  * @param options.chainId - The chain ID of the network.
  * @param options.explorerUrl - The URL of the block explorer for the token.
  * @param options.isAccountUpgraded - Whether the account is upgraded to a smart account.
+ * @param options.isAccountSupported - Whether the account supports EIP-7702.
  * @param options.existingPermissionsStatus - Status of existing permissions for banner UI.
  * @param options.isGrantDisabled - Whether the grant button should render disabled.
  * @param options.showTokenBalance - Whether to show token balance in the account section.
@@ -118,6 +120,7 @@ export const ConfirmationShellContent = ({
   chainId,
   explorerUrl,
   isAccountUpgraded,
+  isAccountSupported,
   existingPermissionsStatus,
   isGrantDisabled,
   showTokenBalance,
@@ -243,9 +246,15 @@ export const ConfirmationShellContent = ({
                 switchGlobalAccount={false}
                 value={context.accountAddressCaip10}
               />
-              {!isAccountUpgraded && (
-                <Text size="sm" color="warning">
-                  {t('accountUpgradeWarning')}
+              {isAccountSupported ? (
+                !isAccountUpgraded && (
+                  <Text size="sm" color="warning">
+                    {t('accountUpgradeWarning')}
+                  </Text>
+                )
+              ) : (
+                <Text size="sm" color="error">
+                  {t('accountNotSupportingEip7702')}
                 </Text>
               )}
               {showTokenBalance && hasAsset && (

--- a/packages/gator-permissions-snap/test/core/PermissionRequestPipeline.test.ts
+++ b/packages/gator-permissions-snap/test/core/PermissionRequestPipeline.test.ts
@@ -110,7 +110,10 @@ const mockPopulatedPermission = {
 const mockAccountController = {
   signDelegation: jest.fn(),
   getAccountAddresses: jest.fn(),
-  getAccountUpgradeStatus: jest.fn(async () => ({ isUpgraded: false })),
+  getAccountUpgradeStatus: jest.fn(async () => ({
+    isSupported: true,
+    isUpgraded: false,
+  })),
   upgradeAccount: jest.fn().mockResolvedValue(undefined),
 } as unknown as jest.Mocked<AccountController>;
 
@@ -257,7 +260,7 @@ describe('PermissionRequestPipeline', () => {
     );
 
     mockAccountController.getAccountUpgradeStatus.mockImplementation(
-      async () => ({ isUpgraded: false }),
+      async () => ({ isSupported: true, isUpgraded: false }),
     );
 
     mockAccountController.getAccountAddresses.mockResolvedValue([

--- a/packages/gator-permissions-snap/test/core/accountController.test.ts
+++ b/packages/gator-permissions-snap/test/core/accountController.test.ts
@@ -42,6 +42,7 @@ describe('AccountController', () => {
           return expectedBalance;
         case 'wallet_getAccountUpgradeStatus':
           return {
+            isSupported: true,
             isUpgraded: false,
             upgradedAddress: null,
           };
@@ -104,6 +105,7 @@ describe('AccountController', () => {
   describe('getAccountUpgradeStatus()', () => {
     it('should return upgrade status', async () => {
       mockEthereumProvider.request.mockResolvedValueOnce({
+        isSupported: true,
         isUpgraded: true,
         upgradedAddress: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B', // eip7702StatelessDeleGatorImpl address
       });
@@ -113,7 +115,55 @@ describe('AccountController', () => {
         chainId: mockChainId,
       });
 
-      expect(result).toStrictEqual({ isUpgraded: true });
+      expect(result).toStrictEqual({ isSupported: true, isUpgraded: true });
+      expect(mockEthereumProvider.request).toHaveBeenCalledWith({
+        method: 'wallet_getAccountUpgradeStatus',
+        params: { account: mockAddress, chainId: mockChainId },
+      });
+    });
+
+    it('should return isSupported false when the account does not support EIP-7702', async () => {
+      mockEthereumProvider.request.mockResolvedValueOnce({
+        isSupported: false,
+        isUpgraded: false,
+        upgradedAddress: null,
+      });
+
+      const result = await accountController.getAccountUpgradeStatus({
+        account: mockAddress,
+        chainId: mockChainId,
+      });
+
+      expect(result).toStrictEqual({ isSupported: false, isUpgraded: false });
+    });
+
+    it('should return isUpgraded false when the account is supported but not upgraded', async () => {
+      mockEthereumProvider.request.mockResolvedValueOnce({
+        isSupported: true,
+        isUpgraded: false,
+        upgradedAddress: null,
+      });
+
+      const result = await accountController.getAccountUpgradeStatus({
+        account: mockAddress,
+        chainId: mockChainId,
+      });
+
+      expect(result).toStrictEqual({ isSupported: true, isUpgraded: false });
+    });
+
+    it('should treat a missing isSupported field as supported', async () => {
+      mockEthereumProvider.request.mockResolvedValueOnce({
+        isUpgraded: false,
+        upgradedAddress: null,
+      });
+
+      const result = await accountController.getAccountUpgradeStatus({
+        account: mockAddress,
+        chainId: mockChainId,
+      });
+
+      expect(result).toStrictEqual({ isSupported: true, isUpgraded: false });
     });
   });
 
@@ -132,6 +182,10 @@ describe('AccountController', () => {
 
       expect(result).toStrictEqual({
         transactionHash: mockTransactionHash,
+      });
+      expect(mockEthereumProvider.request).toHaveBeenCalledWith({
+        method: 'wallet_upgradeAccount',
+        params: { account: mockAddress, chainId: mockChainId },
       });
     });
   });

--- a/packages/gator-permissions-snap/test/core/confirmation/ConfirmationSession.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation/ConfirmationSession.test.ts
@@ -78,8 +78,12 @@ const mockPermissionRequest: PermissionRequest = {
 
 const mockAccountController = {
   getAccountAddresses: jest.fn(),
-  getAccountUpgradeStatus: jest.fn(async () => ({ isUpgraded: false })),
+  getAccountUpgradeStatus: jest.fn(async () => ({
+    isSupported: true,
+    isUpgraded: false,
+  })),
   upgradeAccount: jest.fn().mockResolvedValue(undefined),
+  signDelegation: jest.fn().mockResolvedValue(undefined),
 } as unknown as jest.Mocked<AccountController>;
 
 const mockDialogInterfaceFactory = {
@@ -197,7 +201,7 @@ describe('ConfirmationSession', () => {
     };
 
     mockAccountController.getAccountUpgradeStatus.mockImplementation(
-      async () => ({ isUpgraded: false }),
+      async () => ({ isSupported: true, isUpgraded: false }),
     );
 
     mockConfirmationDialogFactory.createConfirmation.mockReturnValue(
@@ -368,6 +372,7 @@ describe('ConfirmationSession', () => {
 
   it('checks account upgrade status and triggers upgrade when needed', async () => {
     mockAccountController.getAccountUpgradeStatus.mockResolvedValueOnce({
+      isSupported: true,
       isUpgraded: false,
     });
 
@@ -386,6 +391,7 @@ describe('ConfirmationSession', () => {
 
   it('does not trigger upgrade when account is already upgraded', async () => {
     mockAccountController.getAccountUpgradeStatus.mockResolvedValueOnce({
+      isSupported: true,
       isUpgraded: true,
     });
 
@@ -395,6 +401,50 @@ describe('ConfirmationSession', () => {
     expect(
       mockSnapsMetricsService.trackSmartAccountUpgraded,
     ).not.toHaveBeenCalled();
+  });
+
+  it('rejects the grant when the account does not support EIP-7702', async () => {
+    mockAccountController.getAccountUpgradeStatus.mockResolvedValueOnce({
+      isSupported: false,
+      isUpgraded: false,
+    });
+
+    await expect(runSession()).rejects.toThrow(
+      'This account does not support EIP-7702 and cannot grant permissions.',
+    );
+
+    expect(mockAccountController.upgradeAccount).not.toHaveBeenCalled();
+    expect(mockAccountController.signDelegation).not.toHaveBeenCalled();
+    expect(mockConfirmationDialog.closeWithError).toHaveBeenCalled();
+  });
+
+  it('approves without upgrading when the account is supported and upgraded', async () => {
+    mockAccountController.getAccountUpgradeStatus.mockResolvedValueOnce({
+      isSupported: true,
+      isUpgraded: true,
+    });
+
+    const result = await runSession();
+
+    expect(result).toStrictEqual({
+      isApproved: true,
+      context: expect.any(Object),
+    });
+    expect(mockAccountController.upgradeAccount).not.toHaveBeenCalled();
+  });
+
+  it('approves the grant when the account upgrade status lookup fails', async () => {
+    mockAccountController.getAccountUpgradeStatus.mockRejectedValueOnce(
+      new Error('Failed to check account upgrade status'),
+    );
+
+    const result = await runSession();
+
+    expect(result).toStrictEqual({
+      isApproved: true,
+      context: expect.any(Object),
+    });
+    expect(mockConfirmationDialog.closeWithError).not.toHaveBeenCalled();
   });
 
   it('prevents race condition when grant is clicked before debounced validation completes', async () => {
@@ -752,6 +802,7 @@ describe('ConfirmationSession', () => {
 
   it('tracks smart account upgrade success when upgrade is successful', async () => {
     mockAccountController.getAccountUpgradeStatus.mockResolvedValueOnce({
+      isSupported: true,
       isUpgraded: false,
     });
     mockAccountController.upgradeAccount.mockResolvedValueOnce({
@@ -777,6 +828,7 @@ describe('ConfirmationSession', () => {
 
   it('tracks smart account upgrade failure when upgrade fails', async () => {
     mockAccountController.getAccountUpgradeStatus.mockResolvedValueOnce({
+      isSupported: true,
       isUpgraded: false,
     });
     mockAccountController.upgradeAccount.mockRejectedValueOnce(

--- a/packages/gator-permissions-snap/test/core/confirmation/ConfirmationShell.test.ts
+++ b/packages/gator-permissions-snap/test/core/confirmation/ConfirmationShell.test.ts
@@ -8,6 +8,7 @@ import type { SnapElement } from '@metamask/snaps-sdk/jsx';
 import { AddressScanResultType } from '../../../src/clients/trustSignalsClient';
 import type { TokenBalanceAndMetadata } from '../../../src/clients/types';
 import type { AccountController } from '../../../src/core/accountController';
+import { ConfirmationDialog } from '../../../src/core/confirmation';
 import { ConfirmationShell } from '../../../src/core/confirmation/ConfirmationShell';
 import { ExistingPermissionsState } from '../../../src/core/existingpermissions/existingPermissionsState';
 import { METAMASK_FACILITATOR_ADDRESSES } from '../../../src/core/facilitatorAddresses';
@@ -135,6 +136,7 @@ const setupTest = (options?: { rules?: RuleDefinition<any, any>[] }) => {
   } as unknown as jest.Mocked<AccountController>;
 
   accountController.getAccountUpgradeStatus.mockResolvedValue({
+    isSupported: true,
     isUpgraded: false,
   });
 
@@ -314,6 +316,78 @@ describe('ConfirmationShell', () => {
       expect(serialized).toContain('Redeemers');
       expect(serialized).not.toContain('Facilitators');
     });
+  });
+
+  it('renders an error and disables grant for an account that does not support EIP-7702', async () => {
+    const {
+      confirmationShell,
+      rules,
+      updateContext,
+      onExistingPermissionsViewChange,
+      accountController,
+    } = setupTest();
+    accountController.getAccountUpgradeStatus.mockResolvedValue({
+      isSupported: false,
+      isUpgraded: false,
+    });
+
+    confirmationShell.bindSessionEvents({
+      interfaceId: mockInterfaceId,
+      initialContext: mockContext,
+      rules,
+      updateContext,
+      onExistingPermissionsViewChange,
+    });
+
+    const result = await confirmationShell.createConfirmationContent({
+      context: mockContext,
+      metadata: mockMetadata,
+      origin: mockOrigin,
+      chainId: 1,
+      scanDappUrlResult: null,
+      scanAddressResult: null,
+      existingPermissionsStatus: ExistingPermissionsState.None,
+      isGrantDisabled: false,
+    });
+
+    const flatten = (element: SnapElement): SnapElement[] => {
+      const { props } = element;
+      const children = Array.isArray(props.children)
+        ? props.children
+        : [props.children];
+      return [
+        element,
+        ...children.flatMap((child) =>
+          child && typeof child === 'object' && 'type' in child
+            ? flatten(child as SnapElement)
+            : [],
+        ),
+      ];
+    };
+
+    const flattened = flatten(result);
+
+    const errorText = flattened.find(
+      (element) =>
+        element.type === 'Text' &&
+        element.props.children ===
+          'This account does not support EIP-7702 and cannot grant permissions.',
+    );
+    expect(errorText).toBeDefined();
+    expect(errorText?.props).toMatchObject({ color: 'error', size: 'sm' });
+
+    const grantButton = flattened.find(
+      (element) =>
+        element.type === 'Button' &&
+        element.props.name === ConfirmationDialog.grantButton,
+    );
+    expect(grantButton).toBeDefined();
+    expect(grantButton?.props.disabled).toBe(true);
+
+    const accountSelector = flattened.find(
+      (element) => element.type === 'AccountSelector',
+    );
+    expect(accountSelector).toBeDefined();
   });
 
   describe('bindSessionEvents', () => {


### PR DESCRIPTION
## **Description**

**Problem**

ERC-7715 permission grants create a delegation from the user's account, which requires that account to be (or become) an EIP-7702 smart account.
The snap previously had no notion of whether the selected account was even *capable* of that: it read `wallet_getAccountUpgradeStatus` only for
`isUpgraded`, and silently attempted an upgrade for any non-upgraded account. For accounts whose keyring cannot sign an EIP-7702 authorization
(hardware and Snap keyrings), that upgrade attempt is guaranteed to fail, so the user could complete an entire permission-grant flow that produced
a delegation their account can never redeem.

**Solution**

Surface EIP-7702 account eligibility as a first-class signal and gate the grant on it:

- `AccountUpgradeStatus` gains **`isSupported`**, mapped from the `isSupported` field of `wallet_getAccountUpgradeStatus`. Only an explicit
`isSupported: false` is treated as unsupported — a wallet that omits the field is still treated as supported, so older wallet versions are
unaffected.
- The confirmation UI renders the **`accountNotSupportingEip7702`** message and **disables the Grant button** when the selected account is
unsupported. The existing "account will be upgraded" notice is now shown only for accounts that are supported but not yet upgraded. Switching
accounts re-fetches the status in the background and resets to the permissive default while in flight.
- After the user approves, `ConfirmationSession` re-checks support and rejects with `InvalidRequestError` when it is explicitly false, so the
grant cannot slip through a stale UI state.
- **Lookup failures remain fail-open.** If `wallet_getAccountUpgradeStatus` throws, the status is treated as unknown (not unsupported) and the
grant proceeds — an unavailable wallet RPC must not block a legitimate request.

**Dependency on the wallet-side fix**

The `isSupported` flag is only meaningful once the wallet reports it correctly for hardware accounts. MetaMask's `isEip7702Supported` previously
derived eligibility from atomic-batch/chain support alone and ignored the account's keyring, so hardware accounts were reported as `isSupported:
true`. That is fixed in **[MetaMask/metamask-extension#45846](https://github.com/MetaMask/metamask-extension/pull/45846)**, which gates
eligibility on `KEYRING_TYPES_SUPPORTING_7702` before the chain checks. Until that ships, hardware accounts will continue to report as supported
and this PR's guard will not trigger for them; the two changes are intended to land together.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and run the snaps and test site (`yarn build && yarn start`), and load a MetaMask Flask build that includes
[extension#45846](https://github.com/MetaMask/metamask-extension/pull/45846).
2. From the test site at `http://localhost:8000/`, issue a `wallet_requestExecutionPermissions` request.
3. With an **HD or imported account** selected, confirm the flow is unchanged: the upgrade notice appears for non-upgraded accounts and Grant is
enabled.
4. Switch the account selector to a **hardware (Ledger/Trezor) or Snap account**: the error text "This account does not support EIP-7702 and
cannot grant permissions." is shown and the Grant button is disabled.
5. Switch back to a supported account and confirm the error clears and Grant is re-enabled.
6. Simulate a failing status lookup (e.g. stop the wallet RPC from resolving) and confirm the grant is **not** blocked — unknown is not treated as
unsupported.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="524" height="1151" alt="image" src="https://github.com/user-attachments/assets/d6aff7a5-10c7-41b3-8345-c2f25e826f31" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask 7715 Permissions Snaps Contributor
Docs](https://github.com/MetaMask/snap-7715-permissions/blob/main/CONTRIBUTING.md) and [MetaMask 7715 Permissions Snaps Coding
Standards](https://github.com/MetaMask/snap-7715-permissions/blob/main/docs/styleGuide.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.